### PR TITLE
fix(ci): bump release workflow to node 22 for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # semantic-release v25+ requires Node >= 22.14. Keep ci.yml on
+          # Node 20 (matching `engines.node`) to test against the minimum
+          # supported runtime.
+          node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
## Summary

The initial `Release` workflow run (after the first merge) failed immediately with:

> `[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.`

semantic-release v25 dropped Node 20 support. This PR bumps the **release workflow only** to Node 22, leaving `ci.yml` on Node 20 so the minimum supported runtime (matching `engines.node: ">=20"`) stays covered by the test suite.

Once merged, `release.yml` will re-run on `main` and should publish `@fruggr/zendesk-mcp-server@1.0.0` on npm.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, `release.yml` publishes v1.0.0 to npm.
- [ ] GitHub Release `v1.0.0` is created with generated notes.