### PR TITLE
fix(ci): wire NODE_AUTH_TOKEN so .npmrc resolves to the real token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,13 @@ jobs:
           # Bootstrap only: required for the very first publish, since
           # NPM Trusted Publisher cannot be configured before the package
           # exists. After configuring Trusted Publisher on npmjs.com, remove
-          # this line and the NPM_TOKEN secret. OIDC takes over via
+          # these two lines and the NPM_TOKEN secret. OIDC takes over via
           # `id-token: write`.
+          #
+          # NODE_AUTH_TOKEN is consumed by the .npmrc that actions/setup-node
+          # wrote at the job level (`_authToken=${NODE_AUTH_TOKEN}`); without
+          # it the registry receives the literal placeholder and rejects the
+          # publish with EINVALIDNPMTOKEN. NPM_TOKEN is what @semantic-release/npm
+          # itself reads.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The v1.0.0 release attempt failed with `EINVALIDNPMTOKEN` even though the NPM token stored in `secrets.NPM_TOKEN` is valid.

Root cause: `actions/setup-node@v4`, when given `registry-url`, writes `~/.npmrc` with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. The placeholder is only substituted at runtime by bash, so the step that actually calls npm must expose `NODE_AUTH_TOKEN` in its `env:`. Without it, npm reads the literal placeholder string and the registry rejects auth.

`@semantic-release/npm` reads `NPM_TOKEN` directly but its pre-flight verification (`npm whoami --userconfig=<existing .npmrc>`) hits the broken `.npmrc` first.

This PR exposes `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on the semantic-release step so the `.npmrc` resolves correctly.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, `release.yml` publishes `@fruggr/zendesk-mcp-server@1.0.0` to npm.
- [ ] GitHub Release `v1.0.0` is created.