### PR TITLE
chore(ci): switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,11 @@ jobs:
           # supported runtime.
           node-version: 22
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+          # No `registry-url`: with NPM Trusted Publishing, the OIDC exchange
+          # happens inside @semantic-release/npm. Letting setup-node write
+          # an ~/.npmrc with an `_authToken=${NODE_AUTH_TOKEN}` placeholder
+          # would either require us to re-introduce NPM_TOKEN or break the
+          # pre-publish `npm whoami` check.
 
       - run: pnpm install --frozen-lockfile
 
@@ -49,16 +53,6 @@ jobs:
       - run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Bootstrap only: required for the very first publish, since
-          # NPM Trusted Publisher cannot be configured before the package
-          # exists. After configuring Trusted Publisher on npmjs.com, remove
-          # these two lines and the NPM_TOKEN secret. OIDC takes over via
-          # `id-token: write`.
-          #
-          # NODE_AUTH_TOKEN is consumed by the .npmrc that actions/setup-node
-          # wrote at the job level (`_authToken=${NODE_AUTH_TOKEN}`); without
-          # it the registry receives the literal placeholder and rejects the
-          # publish with EINVALIDNPMTOKEN. NPM_TOKEN is what @semantic-release/npm
-          # itself reads.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Auth to npm is via NPM Trusted Publishing (OIDC), configured on
+          # npmjs.com against this workflow file. The `id-token: write`
+          # permission above is all that's needed — no NPM_TOKEN secret.


### PR DESCRIPTION
## Summary

Now that `@fruggr/zendesk-mcp-server@1.0.0` is on npm, we can migrate from the bootstrap `NPM_TOKEN` secret to [NPM Trusted Publishing via OIDC](https://docs.npmjs.com/trusted-publishers).

Changes:
- Drop `NPM_TOKEN` and `NODE_AUTH_TOKEN` from the release step.
- Drop `registry-url` from `actions/setup-node` — it was only there to help the token-based auth flow; with OIDC it would get in the way (setup-node writes a broken `.npmrc` placeholder).
- Keep `id-token: write` permission at the job level — that's all OIDC needs.

## Do this BEFORE merging

On npmjs.com, for the package `@fruggr/zendesk-mcp-server`:

1. Settings → **Trusted Publisher** → GitHub Actions
2. Organization: `fruggr`
3. Repository: `zendesk-mcp-server`
4. Workflow filename: `release.yml` (exact match, case-sensitive)
5. Environment: (empty)

If you merge before saving this config, the next release will fail because there's no more NPM_TOKEN to fall back on.

## Do AFTER this PR lands successfully

- Delete the `NPM_TOKEN` secret from the GitHub repo settings.
- Revoke the token on npmjs.com (belt-and-suspenders).

## Test plan

- [ ] CI green on this PR.
- [ ] Trusted Publisher configured on npmjs.com (manual step above).
- [ ] After merge, `release.yml` runs and semantic-release reports "no new version to release" (since this PR only ships a `chore:` commit) — proving the OIDC flow at least authenticates.
- [ ] Next non-chore merge publishes a new version via OIDC only; npm page shows a "Provenance" badge.