### PR TITLE
docs: contribution policy and AI review setup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,40 @@
+# CodeRabbit configuration.
+# Schema reference: https://docs.coderabbit.ai/reference/configuration
+# Only keys documented in the official schema are set here. New options
+# should be added with a comment linking to the doc that introduced them.
+
+language: en-US
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  path_filters:
+    - '!dist/**'
+    - '!node_modules/**'
+    - '!coverage/**'
+    - '!pnpm-lock.yaml'
+    - '!CHANGELOG.md'
+  path_instructions:
+    - path: 'src/tools/**'
+      instructions: |
+        These files define MCP tools exposed to the LLM. Check that:
+        - The Zod schema validates all inputs and matches the handler's usage.
+        - The first sentence of the tool description reads as a self-contained
+          summary (proxy modes only surface that first sentence).
+        - Any new, renamed, or removed tool is reflected in README.md and
+          AGENTS.md (tool tables and per-namespace counts).
+    - path: 'tests/**'
+      instructions: |
+        Zendesk API calls in tests must go through MSW handlers in
+        tests/msw-handlers.ts. Flag any test that hits the real network.
+
+knowledge_base:
+  learnings:
+    scope: local

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+<!-- In 1-3 sentences, what does this PR change and why? -->
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (no external behavior change)
+- [ ] Documentation
+- [ ] Tooling / CI
+
+## Author checklist
+- [ ] `pnpm test` passes locally
+- [ ] `pnpm check` is clean (lint + format)
+- [ ] `pnpm typecheck` passes
+- [ ] I have read the diff myself, line by line
+- [ ] I ran a Claude Code review on the diff and addressed its findings
+- [ ] Documentation is updated where needed
+- [ ] If this PR adds an MCP tool: it is documented in `README.md`
+
+## Notes for the reviewer (human or AI)
+<!-- Points worth attention, design choices to validate, alternatives ruled out -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,42 @@ Tests use vitest + MSW for mocking the Zendesk API.
 - Functional style: pure functions, no classes (except `ZendeskApiError`), immutable data
 - Tool handlers are standalone functions in `ToolDefinition[]` arrays, not tied to `registerTool`
 
+## Submission quality bar
+
+This is the bar to clear before opening a PR or asking the maintainer to
+review. It applies the same way whether the code was written by a human or
+by an AI assistant — the goal is that the patch survives external scrutiny
+and that the human author can defend every line.
+
+Before you submit:
+
+1. **Re-read your own diff in full.** No skimming. If a hunk no longer makes
+   sense out of the context where you wrote it, rewrite it.
+2. **Justify each change.** For every non-trivial hunk, you should be able
+   to answer: why is this change here, what would break without it, and is
+   it the smallest version of the fix.
+3. **Look for what you didn't write.** Missing zod validation on an input,
+   missing test for an edge case, missing README/AGENTS update on a renamed
+   tool, missing error path. Reviewers find these — find them first.
+4. **Self-review prompt.** Run a Claude Code pass on the diff against
+   `main` using the prompt in the
+   [`CONTRIBUTING.md`](CONTRIBUTING.md#author-side-ai-review) "Author-side
+   AI review" section. Address findings or document why you're skipping
+   them in the PR description.
+5. **Run the full local gate**: `pnpm check`, `pnpm typecheck`, `pnpm test`,
+   `pnpm build`. A green CI on a non-green local run means a flaky check,
+   not a free pass.
+6. **Scope discipline.** Don't bundle unrelated cleanups into a feature PR.
+   If you spot something worth fixing along the way, note it and open a
+   separate PR.
+7. **No invented behavior.** If a Zendesk API field, an SDK option, or a
+   library API isn't confirmed by the docs, an existing test, or a typed
+   response, mark it `// TODO:` and surface the question in the PR
+   description rather than guessing.
+
+The maintainer's review starts from the assumption that everything above
+has already been done.
+
 ## Documentation maintenance
 
 Any change to the tool surface requires a README sync in the same PR. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing
+
+Thanks for considering a contribution to `@fruggr/zendesk-mcp-server`. See the
+[README](README.md) for what the project does and how to run it.
+
+## Review philosophy
+
+This server is maintained primarily by a single developer who works with AI
+assistance (Claude Code) to write code. **AI-assisted contributions are
+welcome and explicitly accepted**, on one condition: every submitted change
+has been read line by line and is owned by a human author who can defend it.
+
+Every PR goes through at least two automated review passes:
+
+1. **Author-side review**, run locally before push. The author runs Claude
+   Code on the diff and addresses anything found.
+2. **CodeRabbit** in CI, which posts a high-level summary and inline review
+   comments on the PR.
+
+Final responsibility for merging belongs to the human author. Tooling catches
+the mechanical issues; understanding the change is non-negotiable.
+
+External contributions follow the same standard.
+
+## Opening a pull request
+
+1. Fork the repository.
+2. Create a feature branch from `main`.
+3. Write code in small, reviewable commits.
+4. Use [Conventional Commits](https://www.conventionalcommits.org/) — they
+   directly drive the next version bump via semantic-release. See the
+   [release table in the README](README.md#releases--versioning) for which
+   prefixes trigger which bump.
+5. Make the author checklist below pass locally.
+6. Push your branch and open a PR against `main`.
+
+## Author checklist
+
+The same checklist appears on the
+[PR template](.github/pull_request_template.md):
+
+- [ ] `pnpm test` passes locally.
+- [ ] `pnpm check` is clean (Biome lint + format).
+- [ ] `pnpm typecheck` passes.
+- [ ] `pnpm build` produces a clean bundle.
+- [ ] You have read the diff yourself, line by line.
+- [ ] You ran a Claude Code review on the diff (see below).
+- [ ] Documentation is updated if behavior or the tool surface changed
+      (see [Documentation maintenance](AGENTS.md#documentation-maintenance)
+      in `AGENTS.md`).
+- [ ] If a new MCP tool was added, it is documented in `README.md`.
+
+## Code standards
+
+- TypeScript with `@tsconfig/strictest` — no `any` escapes without a comment
+  explaining why.
+- Biome must be clean: `pnpm check` (and `pnpm check:fix` to auto-format).
+- All `vitest` tests must pass: `pnpm test`.
+- Test-Driven Development is the default workflow:
+  - **New features**: write a failing test first, then implement.
+  - **Bug fixes**: write or adapt a test that reproduces the bug first, then
+    fix the code.
+  - **Existing tests are sacred**: a failing existing test is a potential
+    regression. Investigate why before changing it. Never modify an existing
+    test just to make it pass without understanding the root cause.
+  - The Zendesk API is mocked with MSW handlers in `tests/msw-handlers.ts`.
+    Never call the real API in tests.
+- Functional style: pure functions, immutable data, no classes (except
+  `ZendeskApiError`). See `AGENTS.md` for the full architecture and
+  conventions.
+
+## Author-side AI review
+
+Before pushing, run a Claude Code pass on the diff. Suggested prompt — copy
+this into your `claude` CLI from the branch:
+
+> Read the diff between this branch and `main`. Look for: potential bugs,
+> uncovered edge cases, inconsistencies with the project architecture,
+> undocumented dependencies, security issues (secrets in cleartext,
+> injections, missing zod validations), missing tests. Be strict.
+
+Address everything Claude flags, or document in the PR description why
+you're not addressing it.
+
+## What happens after you open the PR
+
+1. CI runs lint, typecheck, tests, build, and a smoke test (single
+   `build-and-test` job in `.github/workflows/ci.yml`).
+2. CodeRabbit posts a high-level summary and review comments on the diff.
+3. The maintainer reviews everything.
+4. You address review findings.
+5. Merge.
+
+## Merge policy
+
+- **Squash merge** is the default. The squashed commit message must follow
+  Conventional Commits — that's what semantic-release reads to compute the
+  next version.
+- No force-push to `main`.
+- The maintainer can self-merge, given that two automated review passes
+  (author-side Claude + CodeRabbit) and the CI gate have run cleanly. This
+  policy will tighten (require a human reviewer on PRs to `main`) once the
+  project has its first regular contributor or first production user.
+
+## Releases
+
+Versions are calculated and published automatically from Conventional Commit
+messages. See the [release section in the
+README](README.md#releases--versioning) and the [Release
+workflow](AGENTS.md#release-workflow) section in `AGENTS.md`.

--- a/README.md
+++ b/README.md
@@ -324,17 +324,18 @@ Versions follow [SemVer](https://semver.org/) and are calculated **automatically
 
 ## Contributing
 
-Pull requests are welcome! Whether you write code by hand or with the help of AI, contributions are appreciated.
+Pull requests are welcome — including AI-assisted ones, as long as the human author has read and validated every line.
 
-If you'd like to contribute:
+The full guide is in [`CONTRIBUTING.md`](CONTRIBUTING.md). The short version:
 
-1. Fork the repository
-2. Create a feature branch
-3. Write tests (we practice TDD)
-4. Use [Conventional Commits](https://www.conventionalcommits.org/) in your commit messages — they directly drive the next version bump
-5. Submit a pull request
+1. Fork and create a feature branch from `main`.
+2. Practice TDD: write the failing test first, then implement.
+3. Use [Conventional Commits](https://www.conventionalcommits.org/) — they drive the next version bump via semantic-release.
+4. Make `pnpm check`, `pnpm typecheck`, and `pnpm test` pass locally.
+5. Run a Claude Code review on your diff before pushing.
+6. Open a PR.
 
-Please ensure `pnpm check` and `pnpm test` pass before submitting.
+Every PR is reviewed automatically by [CodeRabbit](https://www.coderabbit.ai) in CI, on top of the author-side AI review. The project is maintained in part with [Claude Code](https://www.anthropic.com/claude-code) assistance; that workflow is documented in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

Sets up a formal contribution policy that explicitly accepts AI-assisted code, on the condition that the human author has read and validated every line. Wires two automated review passes on every PR: author-side Claude Code (locally, before push) and CodeRabbit (in CI). The CI gate (`pnpm check` / `typecheck` / `test` / `build` / smoke test) is already in place via the existing `build-and-test` job in `.github/workflows/ci.yml` and is left untouched.

## What's in this PR (one commit per deliverable)

- **`CONTRIBUTING.md`** — review philosophy, opening a PR, author checklist, code standards (TDD, Biome, vitest + MSW), Claude Code review prompt, post-PR flow, squash-merge policy.
- **`.github/pull_request_template.md`** — short template mirroring the author checklist.
- **`.coderabbit.yaml`** — auto-review on PRs to `main`, `chill` profile, high-level summary, English (`en-US`), path filters for generated paths, path-scoped instructions for `src/tools/**` and `tests/**`, learnings scoped `local`. Only keys present in the official CodeRabbit schema are used.
- **`README.md`** — Contributing section now points to `CONTRIBUTING.md` and surfaces CodeRabbit + Claude Code at the top level.
- **`AGENTS.md`** — new "Submission quality bar" section codifying the self-review checklist an AI assistant (or human) is expected to clear before submitting.

## Decisions taken vs. the original spec

- **No new CI workflow.** `.github/workflows/ci.yml` already runs lint / typecheck / test / build / smoke on every PR; `release.yml` re-runs the same checks on push to `main` before semantic-release. Per spec §4.5 (conditional creation), nothing was created. The status check exposed to GitHub is a single one named `build-and-test` — see the manual checklist below for ruleset wiring.
- **No `CODEOWNERS`** in this PR (deliverable §4.6 is optional and you opted out for now).
- **No `docs/contributing-policy-rationale.md`** (deliverable §4.7 is optional and you opted out).
- **Language: English** for all new docs, matching the existing repo (README, AGENTS.md, code, workflows).
- **Squash merge** is documented as the default policy.
- Branch name is `claude/contribution-policy-setup-WYjCr` (kept per your instruction) instead of the `chore/contribution-policy` from the spec text.

## À faire manuellement après merge

1. **Install CodeRabbit.** Go to https://www.coderabbit.ai, sign in via GitHub, install the app on `fruggr/zendesk-mcp-server`. The Pro plan is free for public repositories.
2. **Configure the GitHub ruleset.** Settings → Rules → Rulesets → New branch ruleset, target `main`, enable:
   - Restrict deletions
   - Block force pushes
   - Require a pull request before merging — **Required approvals: 0**
   - Require status checks to pass: add **`build-and-test`** (single job exposed by `.github/workflows/ci.yml`). If you later split the workflow into separate `lint` / `test` / `build` jobs, swap this for the three new check names.
   - Require branches to be up to date before merging
3. **Verify repo permissions.** Settings → General → Pull Requests → "Allow squash merging" enabled (other merge methods to taste).
4. **Verify CodeRabbit.** Confirm CodeRabbit posts a review on this PR (or on the next one after install).

## Questions au mainteneur

None blocking. Two things to be aware of:

- The CI status check name to wire into the ruleset is `build-and-test` (current single-job workflow), not `lint` / `test` / `build` as the spec originally suggested. If you want three separate checks for clearer visibility in the GitHub UI, the workflow would need to be split into three jobs — say the word and I'll do it as a follow-up PR.
- A `CODEOWNERS` file can be added later in a one-line PR once you decide which handle should own the codebase (your personal handle vs. an org/team).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SU3uKTfxkYWHC3BgATVVWX)_