### PR TITLE
feat(tickets): image-analysis persistence layer on top of #13

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ ZENDESK_SUBDOMAIN=mycompany
 # PORT=0
 # TRANSPORT=auto
 # LOG_LEVEL=info
+
+# Image attachment analysis (see docs/image-attachments.md)
+# ZENDESK_MCP_ANALYSIS_FIELD_ID=  # numeric custom field ID to mirror analyses as JSON

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ src/
 
 Tools are registered at startup based on `--mode`:
 
-- **`all`** (38 individual tools) — each tool registered separately
+- **`all`** — each tool registered separately
 - **`namespace`** (default, 3 proxy tools) — `zendesk_tickets`, `zendesk_help_center`, `zendesk_users`, each dispatching to sub-operations
 - **`single`** (1 proxy tool) — `zendesk` dispatches to all operations
 
@@ -191,8 +191,7 @@ README is what external users rely on — it drifts fast if ignored.
 
 When you add, remove, rename, or meaningfully re-describe a tool, update:
 
-- **`README.md`** — the matching row in the `Tickets` / `Help Center` / `Users & Organizations` / `Search` table, the `(N tools)` count in the `<summary>`, and the global tool count (currently **38**) wherever it appears ("Expose 38 individual tools", mode table, single-mode tip, CLI example).
-- **`AGENTS.md`** — the `all` mode total count line in "Tool modes" (currently 38).
+- **`README.md`** — the matching row in the per-namespace tool table, the `(N tools)` count in the `<summary>`, and the global tool count wherever it appears.
 - Namespace counts in `tests/unit/routing/registry.test.ts` if you touch the `help_center`, `tickets`, or `users` namespace.
 - The `createHelpCenterTools` length assertion in `tests/unit/tools/help-center.test.ts` (and equivalents for other namespaces).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,38 +16,19 @@ pnpm install
 
 ```
 src/
-├── index.ts              # Entry point, CLI args, auth mode selection
-├── server.ts             # McpServer setup, tool registration per mode
-├── config.ts             # CLI + env vars parsing (Zod validated)
-├── constants.ts          # Zendesk API URLs, limits
-├── types.ts              # Zendesk API response interfaces
-├── auth/
-│   ├── browser-oauth.ts  # OAuth 2.1 PKCE browser flow (authorize/callback/token)
-│   ├── token-store.ts    # In-memory token cache, on-demand auth trigger
-│   └── api-token.ts      # Basic auth for stdio mode
-├── client/
-│   └── zendesk-api.ts    # HTTP client (fetch, error handling)
-├── routing/
-│   └── registry.ts       # Tool filtering (--read-only, --namespace, --tool)
-├── tools/
-│   ├── definitions.ts    # ToolDefinition type
-│   ├── index.ts          # Aggregates all tool factories
-│   ├── tickets.ts        # 10 ticket tools
-│   ├── help-center.ts    # 21 Help Center tools (articles, section editing, translations, taxonomy)
-│   ├── search.ts         # Unified search tool (namespace: tickets)
-│   └── users.ts          # 5 user/organization tools
-├── transports/
-│   └── stdio.ts          # Stdio transport
-└── utils/
-    ├── formatting.ts     # Markdown formatters per entity type
-    └── pagination.ts     # Cursor-based pagination helpers
+├── auth/         # OAuth 2.1 PKCE + API token auth
+├── client/       # Zendesk HTTP client
+├── routing/      # Tool filtering (--read-only, --namespace, --tool)
+├── tools/        # Per-namespace tool factories
+├── transports/   # Stdio transport
+└── utils/        # Formatters, pagination, marker helpers
 ```
 
 ### Tool modes (pattern Azure MCP Server)
 
 Tools are registered at startup based on `--mode`:
 
-- **`all`** (37 individual tools) — each tool registered separately
+- **`all`** (38 individual tools) — each tool registered separately
 - **`namespace`** (default, 3 proxy tools) — `zendesk_tickets`, `zendesk_help_center`, `zendesk_users`, each dispatching to sub-operations
 - **`single`** (1 proxy tool) — `zendesk` dispatches to all operations
 
@@ -210,8 +191,8 @@ README is what external users rely on — it drifts fast if ignored.
 
 When you add, remove, rename, or meaningfully re-describe a tool, update:
 
-- **`README.md`** — the matching row in the `Tickets` / `Help Center` / `Users & Organizations` / `Search` table, the `(N tools)` count in the `<summary>`, and the global tool count (currently **36**) wherever it appears ("Expose 36 individual tools", mode table, single-mode tip, CLI example).
-- **`AGENTS.md`** — the per-file tool counts in the Architecture section (`tickets.ts # 9 ticket tools`, `help-center.ts # 21 Help Center tools`, `users.ts # 5 user/organization tools`) and the `all` mode line in "Tool modes".
+- **`README.md`** — the matching row in the `Tickets` / `Help Center` / `Users & Organizations` / `Search` table, the `(N tools)` count in the `<summary>`, and the global tool count (currently **38**) wherever it appears ("Expose 38 individual tools", mode table, single-mode tip, CLI example).
+- **`AGENTS.md`** — the `all` mode total count line in "Tool modes" (currently 38).
 - Namespace counts in `tests/unit/routing/registry.test.ts` if you touch the `help_center`, `tickets`, or `users` namespace.
 - The `createHelpCenterTools` length assertion in `tests/unit/tools/help-center.test.ts` (and equivalents for other namespaces).
 
@@ -219,7 +200,7 @@ If you change a description in a way that alters its first sentence, remember th
 
 ## Release workflow
 
-Versions are **fully automated** via [semantic-release](https://github.com/semantic-release/semantic-release). Never bump the version manually, never run `npm version`, never touch the `version` field in `package.json` (kept at `0.0.0-semantic-release` as a placeholder).
+Versions are **fully automated** via [semantic-release](https://github.com/semantic-release/semantic-release). Never bump the version manually, never run `npm version`, never touch the `version` field in `package.json` (kept at `0.0.0-semantic-release` as a placeholder). **Do not edit `CHANGELOG.md`** either — it is rewritten by the release process from the Conventional Commit messages of the merged PRs.
 
 - **Trigger**: every push to `main` runs `.github/workflows/release.yml`, which rebuilds, retests, then calls `semantic-release`.
 - **Version calculation**: driven by [Conventional Commits](https://www.conventionalcommits.org/) since the previous tag.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that co
 Most Zendesk integrations use a shared admin API key, giving every user full access to every ticket. This server takes a different approach:
 
 - **Per-user authentication** — Each user authenticates with their own Zendesk credentials via OAuth 2.1 PKCE. No shared admin key, no elevated privileges. The LLM sees exactly what the user is allowed to see.
-- **Context-friendly tool modes** — Expose 37 individual tools, 3 namespace proxies, or a single unified tool. Choose the mode that fits your LLM's context budget.
+- **Context-friendly tool modes** — Expose 38 individual tools, 3 namespace proxies, or a single unified tool. Choose the mode that fits your LLM's context budget.
 - **Section-based article editing** — For large Help Center articles, read and rewrite one section at a time (parsed by h1/h2/h3 headings) instead of shuffling the full HTML body through the LLM. Reduces tokens by 10–100× on targeted edits.
 - **Read-only mode** — Restrict the server to read operations only, ideal for assistants that should never modify data.
 - **Zero runtime dependencies beyond the MCP SDK** — Built on `@modelcontextprotocol/sdk` and `zod`. No Express, no heavyweight frameworks.
@@ -22,13 +22,13 @@ The server registers tools in one of three modes, controlled by `--mode`:
 
 | Mode | Tools exposed | Best for |
 |------|--------------|----------|
-| **`all`** | 37 individual tools (`get_ticket`, `search_articles`, ...) | Clients with good tool selection, full granularity |
+| **`all`** | 38 individual tools (`get_ticket`, `search_articles`, ...) | Clients with good tool selection, full granularity |
 | **`namespace`** (default) | 3 proxy tools (`zendesk_tickets`, `zendesk_help_center`, `zendesk_users`) | Balanced context usage, grouped operations |
 | **`single`** | 1 proxy tool (`zendesk`) | Minimal context footprint, single entry point |
 
 In `namespace` and `single` modes, the proxy tool accepts `{ "operation": "<tool_name>", "params": { ... } }` and dispatches to the appropriate handler after validating params through the original Zod schema. Proxy descriptions include only the first sentence of each sub-operation to stay compact; the full schema is applied when the operation is actually called.
 
-> **Tip:** The `single` mode is particularly useful for models with limited tool slots — one tool handles all 36 operations.
+> **Tip:** The `single` mode is particularly useful for models with limited tool slots — one tool handles all 38 operations.
 
 ### Scoping the surface
 
@@ -47,12 +47,12 @@ zendesk-mcp-server acme --namespace tickets
 ## Available tools
 
 <details>
-<summary><strong>Tickets</strong> (10 tools)</summary>
+<summary><strong>Tickets</strong> (11 tools)</summary>
 
 | Tool | Description | Mode |
 |------|-------------|------|
 | `get_ticket` | Retrieve a ticket by ID with optional comments | read |
-| `get_ticket_attachments` | Download ticket attachments (images as base64, others as references) | read |
+| `get_ticket_attachments` | Download ticket attachments (images as base64 image blocks, others as references) | read |
 | `search_tickets` | Search tickets using Zendesk query syntax | read |
 | `list_tickets` | List tickets with cursor-based pagination | read |
 | `get_linked_incidents` | Get incidents linked to a problem ticket | read |
@@ -61,6 +61,7 @@ zendesk-mcp-server acme --namespace tickets
 | `add_private_note` | Add an internal note (not visible to requester) | write |
 | `add_public_comment` | Add a public comment (visible to requester) | write |
 | `manage_tags` | Add or remove tags on a ticket | write |
+| `record_attachment_analysis` | Persist an AI image analysis as an internal note with a versioned marker; subsequent reads render it inline | write |
 
 </details>
 
@@ -114,6 +115,19 @@ zendesk-mcp-server acme --namespace tickets
 | `search` | Unified search across tickets, users, and organizations | read |
 
 </details>
+
+## Image attachment analysis
+
+Tickets often have screenshots attached. This server lets the **calling LLM** describe those images and persists the description back to Zendesk so future reads include the analysis inline — no vision API key on the server, no double-LLM billing.
+
+The flow uses two tools (both in the `tickets` namespace):
+
+1. `get_ticket_attachments` — return image attachments as MCP `image` content blocks for the calling LLM to view natively (non-image attachments are returned as text references). Caps apply: 5 MB per image, 10 embedded images max.
+2. `record_attachment_analysis` — write the LLM's description back to the ticket as an internal note, tagged with a versioned `mcp:image-analysis` marker. Subsequent `get_ticket(include_comments=true)` calls render the analysis inline under the matching attachment.
+
+The marker is fingerprinted on `(size, content_type)`, so re-uploading the same name with new bytes invalidates the old analysis automatically.
+
+See [`docs/image-attachments.md`](docs/image-attachments.md) for the full design — marker schema, custom-field mirror configuration, current limits.
 
 ## Prerequisites
 
@@ -273,7 +287,7 @@ Options:
 **Examples:**
 
 ```bash
-# Single tool mode — minimal context, all 37 operations in one tool
+# Single tool mode — minimal context, all 38 operations in one tool
 zendesk-mcp-server acme --mode single
 
 # Read-only tickets only
@@ -292,6 +306,7 @@ zendesk-mcp-server acme --tool get_ticket --tool search_tickets --tool get_curre
 | `ZENDESK_EMAIL` | for API token auth | — | Agent email for Basic auth |
 | `ZENDESK_API_TOKEN` | for API token auth | — | Zendesk API token |
 | `LOG_LEVEL` | no | `info` | Log verbosity |
+| `ZENDESK_MCP_ANALYSIS_FIELD_ID` | no | — | Custom ticket field ID to mirror image analyses as JSON for O(1) lookup. The internal note remains the canonical source. |
 
 If both `ZENDESK_EMAIL` and `ZENDESK_API_TOKEN` are set, the server uses API token auth. Otherwise, it uses OAuth 2.1 PKCE.
 

--- a/docs/image-attachments.md
+++ b/docs/image-attachments.md
@@ -1,0 +1,103 @@
+# Image attachment analysis
+
+Tickets routinely have screenshots attached: an error dialog, a stack trace photo, a UI glitch capture. Out of the box the MCP server already exposes `get_ticket_attachments` (PR #13) which delivers those images to the calling LLM as MCP `image` content blocks. This page documents the **persistence layer** added on top: a single tool, `record_attachment_analysis`, that writes the LLM's description back to the ticket so subsequent reads include it inline.
+
+## Why the LLM client does the vision
+
+Other MCP servers in the wild ship `analyze_ticket_images` / `get_document_summary` tools that accept an `ANTHROPIC_API_KEY` (or equivalent) and call Claude from the server itself. We reject that pattern:
+
+- **Architecturally redundant.** The MCP client already has a frontier-model LLM. A second one server-side means the user pays for two completions per analysis and receives a second-hand description from a server-chosen model.
+- **Operationally heavy.** Every operator has to provision a vision provider key, manage budgets, handle rate limits, and rotate credentials.
+- **Privacy-narrowing.** Routing images through a server-controlled provider means the user can't pick their own model or vendor.
+
+Instead we use the MCP protocol's native `image` content type. `get_ticket_attachments` returns `{ type: 'image', data: <base64>, mimeType }`, which any MCP-compatible LLM ingests directly via its own multimodal capabilities. The server stays small, key-less, and provider-neutral.
+
+## The two-tool flow
+
+| Tool | PR | Mode | Purpose |
+|------|----|------|---------|
+| `get_ticket_attachments` | #13 (already on `main`) | read | Walks the ticket's comments, returns each `image/*` attachment as an MCP `image` content block (capped at 5 MB per image, 10 images per call); non-image attachments come back as text references. Accepts an optional `attachment_ids` parameter to skip the comments fetch when you already know which IDs to pull. |
+| `record_attachment_analysis` | this PR | write | Persist the LLM's description as a Zendesk internal note containing a structured `mcp:image-analysis` marker. Idempotent on `(attachment_id, fingerprint)` unless `replace_existing=true`. |
+
+Expected sequence:
+
+```text
+get_ticket(include_comments=true)
+  → "Attachments: #12345 (image/png)" appears under the matching comment
+get_ticket_attachments(ticket_id, attachment_ids=[12345])
+  → LLM views the image natively (no extra comments fetch)
+record_attachment_analysis(ticket_id, attachment_id=12345, analysis="…")
+  → analysis stored as a private note with the marker
+get_ticket(include_comments=true)
+  → analysis rendered inline as a blockquote under the Attachments line
+```
+
+## The marker schema
+
+Persistence is a **plain Zendesk internal note** with a structured HTML-comment block in its body:
+
+```text
+<!-- mcp:image-analysis v=1 attachment_id=12345 fingerprint=size:48213,mime:image/png -->
+**AI-inferred image analysis** — `screenshot.png` (attachment 12345)
+
+A login form with the email field highlighted in red, error message "Invalid credentials".
+
+<!-- /mcp:image-analysis -->
+```
+
+Why this shape:
+
+- **Human-readable** — agents browsing the Zendesk UI see the analysis as ordinary note content, with a clear "AI-inferred" label.
+- **Regex-parseable** — the open/close HTML comments give deterministic boundaries: `/<!--\s*mcp:image-analysis\s+v=(\d+)\s+attachment_id=(\d+)\s+fingerprint=([^>]+?)\s*-->([\s\S]*?)<!--\s*\/mcp:image-analysis\s*-->/g`.
+- **Versioned** — `v=1` lets future iterations evolve the schema without breaking historical tickets.
+- **Fingerprinted on `(size, content_type)`** — if someone re-uploads `screenshot.png` with new bytes, the fingerprint changes, the old marker is treated as stale, and the next `get_ticket_attachments` call surfaces a fresh image with no prior analysis.
+- **Delimiter-safe** — `buildMarker` escapes any `<!--` / `-->` sequence inside the LLM-written analysis to `&lt;!--` / `--&gt;` before embedding it, so a description containing HTML-comment tokens cannot prematurely close or spoof the surrounding marker block. `parseMarkers` reverses the escape when reading the analysis back.
+
+The note is the **canonical source of truth**. `formatComment` reads markers off every comment at each ticket fetch and re-injects them as inline blockquotes under the matching attachment.
+
+## Optional custom-field mirror
+
+For high-volume triage agents that re-read the same tickets many times, scanning every comment body to rebuild the `attachment_id → analysis` map at each call is wasteful. Set `ZENDESK_MCP_ANALYSIS_FIELD_ID` to a Zendesk custom ticket field ID and `record_attachment_analysis` will mirror the data as JSON:
+
+```json
+{
+  "12345": {
+    "analysis": "A login form with...",
+    "fingerprint": "size:48213,mime:image/png",
+    "recorded_at": "2026-05-18T14:22:11.487Z"
+  },
+  "67890": {
+    "analysis": "...",
+    "fingerprint": "size:81920,mime:image/jpeg",
+    "recorded_at": "2026-05-18T14:25:03.219Z"
+  }
+}
+```
+
+**The note remains canonical.** The custom field is purely an O(1) lookup index. If the two ever diverge (e.g. someone edits the note manually in the Zendesk UI), the parsed marker wins.
+
+### Provisioning the custom field
+
+1. Zendesk Admin Center → **Objects and rules** → **Tickets** → **Fields** → **Add field**.
+2. Type: **Multi-line text**. Title: e.g. *MCP image analyses*. Visibility: **Agents only** (this is internal data).
+3. Save. Note the numeric **Field ID** in the URL or in the field's properties.
+4. Set `ZENDESK_MCP_ANALYSIS_FIELD_ID=<that-id>` in the server environment.
+
+If the variable is not set, the server skips the mirror — only the internal note is written.
+
+## Limits inherited from `get_ticket_attachments`
+
+| Constraint | Default | Where it lives |
+|---|---|---|
+| Per-image cap (base64-embedded) | 5 MB | `MAX_ATTACHMENT_BYTES` in `src/constants.ts` |
+| Max embedded images per call | 10 | `MAX_EMBEDDED_IMAGE_COUNT` |
+| MIME types treated as image | `image/*` | `get_ticket_attachments` handler |
+| Marker version | `v=1` | `src/utils/attachment-marker.ts` |
+
+Images above the cap are returned as text references with the `content_url`, which the LLM can still record an analysis for if it inspects them out-of-band.
+
+## Future work
+
+- **Deterministic image pre-processing** (downscale via `sharp`, or use the `thumbnails[]` Zendesk already generates) so oversize images can still be analyzed inline. The pre-processing must remain deterministic — we will not invoke an LLM to summarize images server-side.
+- **Document analysis** (PDFs, scans). Same architectural rule: extract text deterministically (pdfium, tesseract), never delegate semantic summarization to a server-side LLM.
+- **`purge_attachment_analysis`** — not in v1: agents can delete the internal note manually from the Zendesk UI, and `record_attachment_analysis(replace_existing=true)` covers the re-run case.

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export const ConfigSchema = z.object({
   readOnly: z.boolean(),
   namespaces: z.array(Namespace).optional(),
   tools: z.array(z.string()).optional(),
+  analysisFieldId: z.number().int().positive().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -75,6 +76,10 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
 
   const mode = cli.tools?.length ? 'all' : (cli.mode ?? 'namespace');
 
+  const rawAnalysisFieldId = process.env['ZENDESK_MCP_ANALYSIS_FIELD_ID'];
+  const analysisFieldId =
+    rawAnalysisFieldId && rawAnalysisFieldId.trim() !== '' ? Number(rawAnalysisFieldId) : undefined;
+
   return ConfigSchema.parse({
     subdomain,
     oauthClientId,
@@ -85,5 +90,6 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
     readOnly: cli.readOnly ?? false,
     namespaces: cli.namespaces,
     tools: cli.tools,
+    analysisFieldId,
   });
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -77,7 +77,11 @@ export const createMcpServer = (
     version: '0.1.0',
   });
 
-  const allTools = createAllTools({ subdomain: config.subdomain, getToken });
+  const allTools = createAllTools({
+    subdomain: config.subdomain,
+    getToken,
+    analysisFieldId: config.analysisFieldId,
+  });
 
   // Apply filters (--read-only, --namespace, --tool)
   const filteredTools = filterTools(allTools, {

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -10,10 +10,11 @@ export interface ToolAnnotations {
 
 export type ToolTextContent = { type: 'text'; text: string };
 export type ToolImageContent = { type: 'image'; data: string; mimeType: string };
+export type ToolContentBlock = ToolTextContent | ToolImageContent;
 
 export interface ToolResult {
   [key: string]: unknown;
-  content: Array<ToolTextContent | ToolImageContent>;
+  content: ToolContentBlock[];
 }
 
 export interface ToolDefinition {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,13 +1,18 @@
-import type { ToolContext, ToolDefinition } from './definitions';
+import type { ToolDefinition } from './definitions';
 import { createHelpCenterTools } from './help-center';
 import { createSearchTools } from './search';
+import {
+  createTicketAttachmentTools,
+  type TicketAttachmentsToolContext,
+} from './ticket-attachments';
 import { createTicketTools } from './tickets';
 import { createUserTools } from './users';
 
 export type { ToolContext, ToolDefinition } from './definitions';
 
-export const createAllTools = (ctx: ToolContext): ToolDefinition[] => [
+export const createAllTools = (ctx: TicketAttachmentsToolContext): ToolDefinition[] => [
   ...createTicketTools(ctx),
+  ...createTicketAttachmentTools(ctx),
   ...createSearchTools(ctx),
   ...createHelpCenterTools(ctx),
   ...createUserTools(ctx),

--- a/src/tools/ticket-attachments.ts
+++ b/src/tools/ticket-attachments.ts
@@ -1,0 +1,154 @@
+import * as z from 'zod/v4';
+import { zendeskGet, zendeskPut } from '../client/zendesk-api.js';
+import type { ZendeskComment, ZendeskTicket, ZendeskTicketAttachment } from '../types.js';
+import { buildFingerprint, buildMarker, findLatestAnalysis } from '../utils/attachment-marker.js';
+import type { ToolContext, ToolDefinition } from './definitions.js';
+
+export interface TicketAttachmentsToolContext extends ToolContext {
+  analysisFieldId?: number | undefined;
+}
+
+const fetchTicketAndComments = async (
+  subdomain: string,
+  token: string,
+  ticket_id: number,
+): Promise<{ comments: ZendeskComment[]; ticket: ZendeskTicket }> => {
+  const [{ ticket }, { comments }] = await Promise.all([
+    zendeskGet<{ ticket: ZendeskTicket }>(subdomain, token, `/tickets/${ticket_id}`),
+    zendeskGet<{ comments: ZendeskComment[] }>(subdomain, token, `/tickets/${ticket_id}/comments`),
+  ]);
+  return { ticket, comments };
+};
+
+const findAttachment = (
+  comments: ZendeskComment[],
+  attachment_id: number,
+): ZendeskTicketAttachment | undefined => {
+  for (const comment of comments) {
+    for (const attachment of comment.attachments ?? []) {
+      if (attachment.id === attachment_id) return attachment;
+    }
+  }
+  return undefined;
+};
+
+export const createTicketAttachmentTools = (
+  ctx: TicketAttachmentsToolContext,
+): ToolDefinition[] => {
+  const { subdomain, getToken, analysisFieldId } = ctx;
+
+  return [
+    {
+      name: 'record_attachment_analysis',
+      namespace: 'tickets',
+      readOnly: false,
+      title: 'Record AI Image Analysis',
+      description:
+        'Persist an AI-inferred image description as a Zendesk internal note tagged with a versioned mcp:image-analysis marker. Call this after viewing an image returned by get_ticket_attachments so future ticket reads render the analysis inline next to the attachment. Idempotent on (attachment_id, fingerprint): a second call for the same image is a no-op unless replace_existing=true.',
+      inputSchema: z.object({
+        ticket_id: z.number().int().describe('Ticket ID'),
+        attachment_id: z.number().int().describe('Attachment ID'),
+        analysis: z.string().min(1).describe('Plain-text description written by the calling LLM'),
+        replace_existing: z
+          .boolean()
+          .default(false)
+          .describe('If true, write a new note even when an analysis already exists'),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { ticket_id, attachment_id, analysis, replace_existing } = params as {
+          ticket_id: number;
+          attachment_id: number;
+          analysis: string;
+          replace_existing: boolean;
+        };
+        const token = await getToken();
+        const { ticket, comments } = await fetchTicketAndComments(subdomain, token, ticket_id);
+
+        const attachment = findAttachment(comments, attachment_id);
+        if (!attachment) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Attachment ${attachment_id} not found on ticket #${ticket_id}.`,
+              },
+            ],
+          };
+        }
+
+        const existing = findLatestAnalysis(comments, attachment);
+        if (existing && !replace_existing) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Analysis for attachment ${attachment_id} already recorded on comment ${existing.comment_id} (${existing.recorded_at}). Pass replace_existing=true to override.`,
+              },
+            ],
+          };
+        }
+
+        const body = buildMarker(attachment, analysis);
+        await zendeskPut(subdomain, token, `/tickets/${ticket_id}`, {
+          ticket: { comment: { body, public: false } },
+        });
+
+        let mirrorStatus: 'mirrored' | 'mirror_failed' | 'not_configured' = 'not_configured';
+        if (analysisFieldId !== undefined) {
+          const fingerprint = buildFingerprint(attachment);
+          const existingField = ticket.custom_fields.find((f) => f.id === analysisFieldId);
+          let merged: Record<string, unknown> = {};
+          if (existingField && typeof existingField.value === 'string') {
+            try {
+              const parsed = JSON.parse(existingField.value) as unknown;
+              if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                merged = parsed as Record<string, unknown>;
+              }
+            } catch {
+              // Malformed prior content is overwritten below.
+            }
+          }
+          merged[String(attachment_id)] = {
+            analysis: analysis.trim(),
+            fingerprint,
+            recorded_at: new Date().toISOString(),
+          };
+          // The custom-field mirror is an advisory cache; the internal note
+          // remains canonical. A mirror PUT failure must not abort the call,
+          // otherwise the LLM would retry and end up with duplicate notes.
+          try {
+            await zendeskPut(subdomain, token, `/tickets/${ticket_id}`, {
+              ticket: {
+                custom_fields: [{ id: analysisFieldId, value: JSON.stringify(merged) }],
+              },
+            });
+            mirrorStatus = 'mirrored';
+          } catch {
+            mirrorStatus = 'mirror_failed';
+          }
+        }
+
+        const suffix =
+          mirrorStatus === 'mirrored'
+            ? ' and mirrored to the configured custom field'
+            : mirrorStatus === 'mirror_failed'
+              ? ' (advisory custom-field mirror failed; the internal note remains canonical)'
+              : '';
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Analysis recorded for attachment ${attachment_id} on ticket #${ticket_id} as a private note${suffix}.`,
+            },
+          ],
+        };
+      },
+    },
+  ];
+};

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -19,7 +19,13 @@ import type {
   ZendeskTicket,
   ZendeskTicketAttachment,
 } from '../types';
-import { formatComment, formatList, formatTicket, truncateIfNeeded } from '../utils/formatting';
+import {
+  ATTACHMENTS_LISTING_HINT,
+  formatComment,
+  formatList,
+  formatTicket,
+  truncateIfNeeded,
+} from '../utils/formatting';
 import {
   buildCursorParams,
   buildOffsetParams,
@@ -151,7 +157,10 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
             token,
             `/tickets/${ticket_id}/comments`,
           );
-          text += `\n\n---\n# Comments\n\n${comments.map(formatComment).join('\n\n')}`;
+          // formatComment receives the full comment list so it can resolve
+          // mcp:image-analysis markers attached to any sibling internal note
+          // and render the stored AI analysis inline next to each attachment.
+          text += `\n\n---\n# Comments\n\n${comments.map((c) => formatComment(c, comments)).join('\n\n')}`;
         }
         return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
       },
@@ -262,18 +271,14 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
             ...buildOffsetParams(per_page, page),
           },
         );
-        return {
-          content: [
-            {
-              type: 'text',
-              text: formatList(
-                response.results ?? [],
-                formatTicket,
-                extractSearchPaginationMeta(response, per_page, page),
-              ),
-            },
-          ],
-        };
+        const results = response.results ?? [];
+        const text = formatList(
+          results,
+          (t) => formatTicket(t),
+          extractSearchPaginationMeta(response, per_page, page),
+        );
+        const footer = results.length > 0 ? `\n\n${ATTACHMENTS_LISTING_HINT}` : '';
+        return { content: [{ type: 'text', text: truncateIfNeeded(`${text}${footer}`) }] };
       },
     },
     {
@@ -434,18 +439,10 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           '/tickets',
           buildCursorParams(page_size, cursor),
         );
-        return {
-          content: [
-            {
-              type: 'text',
-              text: formatList(
-                response.tickets ?? [],
-                formatTicket,
-                extractPaginationMeta(response),
-              ),
-            },
-          ],
-        };
+        const tickets = response.tickets ?? [];
+        const text = formatList(tickets, (t) => formatTicket(t), extractPaginationMeta(response));
+        const footer = tickets.length > 0 ? `\n\n${ATTACHMENTS_LISTING_HINT}` : '';
+        return { content: [{ type: 'text', text: truncateIfNeeded(`${text}${footer}`) }] };
       },
     },
     {
@@ -474,7 +471,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         const incidents = response.tickets ?? [];
         const text =
           incidents.length > 0
-            ? `# Incidents linked to problem #${problem_id}\n\n${incidents.map(formatTicket).join('\n\n')}`
+            ? `# Incidents linked to problem #${problem_id}\n\n${incidents.map((i) => formatTicket(i)).join('\n\n')}`
             : `No incidents linked to problem #${problem_id}.`;
         return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface ZendeskTicketAttachment {
   content_type: string;
   size: number;
   inline?: boolean;
+  thumbnails?: Array<{ id: number; content_url: string; content_type: string }>;
 }
 
 export interface ZendeskComment {

--- a/src/utils/attachment-marker.ts
+++ b/src/utils/attachment-marker.ts
@@ -1,0 +1,102 @@
+import type { ZendeskComment, ZendeskTicketAttachment } from '../types.js';
+
+export const MARKER_VERSION = 1;
+
+export interface AttachmentMarker {
+  attachment_id: number;
+  fingerprint: string;
+  analysis: string;
+  comment_id: number;
+  recorded_at: string;
+}
+
+// Source pattern (rebuilt per call so parseMarkers stays pure and free of
+// shared mutable regex state from a /g lastIndex).
+const MARKER_PATTERN =
+  '<!--\\s*mcp:image-analysis\\s+v=(\\d+)\\s+attachment_id=(\\d+)\\s+fingerprint=([^>]+?)\\s*-->([\\s\\S]*?)<!--\\s*\\/mcp:image-analysis\\s*-->';
+
+export const buildFingerprint = (attachment: ZendeskTicketAttachment): string =>
+  `size:${attachment.size},mime:${attachment.content_type}`;
+
+// Neutralize HTML-comment boundaries inside analysis text so a description
+// containing `<!--` / `-->` (or our exact `mcp:image-analysis` tokens) cannot
+// prematurely close or spoof the surrounding marker block.
+const escapeMarkerDelimiters = (text: string): string =>
+  text.replaceAll('<!--', '&lt;!--').replaceAll('-->', '--&gt;');
+
+const unescapeMarkerDelimiters = (text: string): string =>
+  text.replaceAll('&lt;!--', '<!--').replaceAll('--&gt;', '-->');
+
+export const buildMarker = (attachment: ZendeskTicketAttachment, analysis: string): string => {
+  const fingerprint = buildFingerprint(attachment);
+  const trimmed = escapeMarkerDelimiters(analysis.trim());
+  return [
+    `<!-- mcp:image-analysis v=${MARKER_VERSION} attachment_id=${attachment.id} fingerprint=${fingerprint} -->`,
+    `**AI-inferred image analysis** — \`${attachment.file_name}\` (attachment ${attachment.id})`,
+    '',
+    trimmed,
+    '',
+    '<!-- /mcp:image-analysis -->',
+  ].join('\n');
+};
+
+// Strip the human-readable header line that buildMarker prepends so the parsed
+// `analysis` field contains only the LLM-written description.
+const HEADER_LINE_REGEX = /^\s*\*\*AI-inferred image analysis[^\n]*\n+/;
+
+export const parseMarkers = (
+  body: string,
+  comment_id: number,
+  created_at: string,
+): AttachmentMarker[] => {
+  const found: AttachmentMarker[] = [];
+  const matches = body.matchAll(new RegExp(MARKER_PATTERN, 'g'));
+  for (const match of matches) {
+    const version = Number(match[1]);
+    if (version !== MARKER_VERSION) continue;
+    const attachment_id = Number(match[2]);
+    const fingerprint = (match[3] ?? '').trim();
+    const raw = match[4] ?? '';
+    const analysis = unescapeMarkerDelimiters(raw.replace(HEADER_LINE_REGEX, '').trim());
+    if (Number.isFinite(attachment_id) && fingerprint) {
+      found.push({ attachment_id, fingerprint, analysis, comment_id, recorded_at: created_at });
+    }
+  }
+  return found;
+};
+
+export const collectMarkers = (comments: ZendeskComment[]): AttachmentMarker[] => {
+  const all: AttachmentMarker[] = [];
+  for (const comment of comments) {
+    if (!comment.body) continue;
+    all.push(...parseMarkers(comment.body, comment.id, comment.created_at));
+  }
+  return all;
+};
+
+export const findLatestAnalysis = (
+  comments: ZendeskComment[],
+  attachment: ZendeskTicketAttachment,
+): AttachmentMarker | undefined => {
+  const fingerprint = buildFingerprint(attachment);
+  const matching = collectMarkers(comments).filter(
+    (m) => m.attachment_id === attachment.id && m.fingerprint === fingerprint,
+  );
+  if (matching.length === 0) return undefined;
+  // Latest by recorded_at (ISO strings sort lexicographically).
+  return matching.reduce((latest, current) =>
+    current.recorded_at > latest.recorded_at ? current : latest,
+  );
+};
+
+export const collectAttachments = (
+  comments: ZendeskComment[],
+): Array<{ comment: ZendeskComment; attachment: ZendeskTicketAttachment }> => {
+  const out: Array<{ comment: ZendeskComment; attachment: ZendeskTicketAttachment }> = [];
+  for (const comment of comments) {
+    for (const attachment of comment.attachments ?? []) {
+      out.push({ comment, attachment });
+    }
+  }
+  return out;
+};

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -15,6 +15,7 @@ import type {
   ZendeskUser,
   ZendeskUserSegment,
 } from '../types.js';
+import { findLatestAnalysis } from './attachment-marker.js';
 
 export const truncateIfNeeded = (text: string): string => {
   if (text.length <= CHARACTER_LIMIT) return text;
@@ -29,6 +30,8 @@ const formatPagination = (meta: PaginationMeta): string => {
   return parts.join(' | ');
 };
 
+export const ATTACHMENTS_LISTING_HINT = '*See get_ticket for attachment details.*';
+
 export const formatTicket = (ticket: ZendeskTicket): string =>
   [
     `## Ticket #${ticket.id}: ${ticket.subject}`,
@@ -41,7 +44,7 @@ export const formatTicket = (ticket: ZendeskTicket): string =>
     .filter(Boolean)
     .join('\n');
 
-export const formatComment = (comment: ZendeskComment): string => {
+export const formatComment = (comment: ZendeskComment, allComments?: ZendeskComment[]): string => {
   const lines = [
     `### ${comment.public ? 'Public comment' : 'Internal note'} by ${comment.author_id}`,
     `*${comment.created_at}*`,
@@ -51,6 +54,24 @@ export const formatComment = (comment: ZendeskComment): string => {
     lines.push(`Attachments: ${summary}`);
   }
   lines.push('', comment.body);
+
+  // Append any stored mcp:image-analysis markers as inline blockquotes so the
+  // calling LLM sees prior descriptions on subsequent reads without
+  // re-downloading the image. Requires the full comments list to resolve
+  // markers that live on a sibling internal note (recorded via
+  // record_attachment_analysis).
+  if (Array.isArray(allComments) && comment.attachments?.length) {
+    for (const attachment of comment.attachments) {
+      if (!attachment.content_type.startsWith('image/')) continue;
+      const marker = findLatestAnalysis(allComments, attachment);
+      if (!marker) continue;
+      lines.push(
+        '',
+        `> *AI-inferred analysis of attachment #${attachment.id} (recorded ${marker.recorded_at}):*`,
+        ...marker.analysis.split('\n').map((line) => (line ? `> ${line}` : '>')),
+      );
+    }
+  }
   return lines.join('\n');
 };
 

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -61,7 +61,7 @@ describe('groupByNamespace', () => {
     const ticketCount = grouped.get('tickets')?.length ?? 0;
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
-    expect(ticketCount).toBe(11); // 10 ticket tools + 1 search
+    expect(ticketCount).toBe(12);
     expect(hcCount).toBe(21);
     expect(userCount).toBe(5);
   });

--- a/tests/unit/tools/ticket-attachments.test.ts
+++ b/tests/unit/tools/ticket-attachments.test.ts
@@ -1,0 +1,179 @@
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import {
+  createTicketAttachmentTools,
+  type TicketAttachmentsToolContext,
+} from '../../../src/tools/ticket-attachments';
+import { buildMarker } from '../../../src/utils/attachment-marker';
+import { MOCK_TICKET, MOCK_TICKET_ATTACHMENT_IMAGE } from '../../msw-handlers';
+import { mswServer } from '../../setup';
+
+const ctx: TicketAttachmentsToolContext = {
+  subdomain: 'testsubdomain',
+  getToken: () => 'test-token',
+};
+
+const findTool = (name: string, c: TicketAttachmentsToolContext = ctx) => {
+  const tool = createTicketAttachmentTools(c).find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool ${name} not found`);
+  return tool;
+};
+
+const stubTicket = (id: number) =>
+  http.get(`https://testsubdomain.zendesk.com/api/v2/tickets/${id}`, () =>
+    HttpResponse.json({ ticket: { ...MOCK_TICKET, id } }),
+  );
+
+const stubComments = (id: number, comments: unknown) =>
+  http.get(`https://testsubdomain.zendesk.com/api/v2/tickets/${id}/comments`, () =>
+    HttpResponse.json({ comments }),
+  );
+
+describe('createTicketAttachmentTools', () => {
+  it('exposes one tool (record_attachment_analysis)', () => {
+    const tools = createTicketAttachmentTools(ctx);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.name).toBe('record_attachment_analysis');
+  });
+});
+
+describe('record_attachment_analysis', () => {
+  it('writes an internal note with a marker on first call', async () => {
+    let captured: unknown;
+    mswServer.use(
+      http.put('https://testsubdomain.zendesk.com/api/v2/tickets/1', async ({ request }) => {
+        captured = await request.json();
+        return HttpResponse.json({ ticket: { ...MOCK_TICKET, id: 1 } });
+      }),
+    );
+    const tool = findTool('record_attachment_analysis');
+    const result = await tool.handler({
+      ticket_id: 1,
+      attachment_id: MOCK_TICKET_ATTACHMENT_IMAGE.id,
+      analysis: 'Login error dialog.',
+      replace_existing: false,
+    });
+    expect((result.content[0] as { text: string }).text).toContain('recorded');
+
+    const body = captured as { ticket: { comment: { body: string; public: boolean } } };
+    expect(body.ticket.comment.public).toBe(false);
+    expect(body.ticket.comment.body).toContain('mcp:image-analysis v=1');
+    expect(body.ticket.comment.body).toContain(`attachment_id=${MOCK_TICKET_ATTACHMENT_IMAGE.id}`);
+    expect(body.ticket.comment.body).toContain('Login error dialog.');
+  });
+
+  it('reports missing attachment id', async () => {
+    const tool = findTool('record_attachment_analysis');
+    const result = await tool.handler({
+      ticket_id: 1,
+      attachment_id: 999_999,
+      analysis: 'whatever',
+      replace_existing: false,
+    });
+    expect((result.content[0] as { text: string }).text).toContain('not found');
+  });
+
+  it('is idempotent when an analysis already exists', async () => {
+    mswServer.use(
+      stubTicket(77),
+      stubComments(77, [
+        {
+          id: 1,
+          body: buildMarker(MOCK_TICKET_ATTACHMENT_IMAGE, 'pre-existing'),
+          author_id: 1,
+          public: false,
+          created_at: '2026-05-01T10:00:00Z',
+          attachments: [MOCK_TICKET_ATTACHMENT_IMAGE],
+        },
+      ]),
+    );
+    const tool = findTool('record_attachment_analysis');
+    const result = await tool.handler({
+      ticket_id: 77,
+      attachment_id: MOCK_TICKET_ATTACHMENT_IMAGE.id,
+      analysis: 'New attempt',
+      replace_existing: false,
+    });
+    expect((result.content[0] as { text: string }).text).toContain('already recorded');
+  });
+
+  it('overrides an existing analysis when replace_existing is true', async () => {
+    let putCount = 0;
+    mswServer.use(
+      stubTicket(77),
+      stubComments(77, [
+        {
+          id: 1,
+          body: buildMarker(MOCK_TICKET_ATTACHMENT_IMAGE, 'old'),
+          author_id: 1,
+          public: false,
+          created_at: '2026-05-01T10:00:00Z',
+          attachments: [MOCK_TICKET_ATTACHMENT_IMAGE],
+        },
+      ]),
+      http.put('https://testsubdomain.zendesk.com/api/v2/tickets/77', () => {
+        putCount += 1;
+        return HttpResponse.json({ ticket: { ...MOCK_TICKET, id: 77 } });
+      }),
+    );
+    const tool = findTool('record_attachment_analysis');
+    const result = await tool.handler({
+      ticket_id: 77,
+      attachment_id: MOCK_TICKET_ATTACHMENT_IMAGE.id,
+      analysis: 'refreshed',
+      replace_existing: true,
+    });
+    expect(putCount).toBe(1);
+    expect((result.content[0] as { text: string }).text).toContain('recorded');
+  });
+
+  it('mirrors to a custom field when analysisFieldId is configured', async () => {
+    const calls: Array<{ body: unknown }> = [];
+    mswServer.use(
+      http.put('https://testsubdomain.zendesk.com/api/v2/tickets/1', async ({ request }) => {
+        calls.push({ body: await request.json() });
+        return HttpResponse.json({ ticket: { ...MOCK_TICKET, id: 1 } });
+      }),
+    );
+    const tool = findTool('record_attachment_analysis', { ...ctx, analysisFieldId: 999_001 });
+    await tool.handler({
+      ticket_id: 1,
+      attachment_id: MOCK_TICKET_ATTACHMENT_IMAGE.id,
+      analysis: 'Mirror me',
+      replace_existing: false,
+    });
+    expect(calls).toHaveLength(2);
+    const second = calls[1]?.body as {
+      ticket: { custom_fields: Array<{ id: number; value: string }> };
+    };
+    expect(second.ticket.custom_fields[0]?.id).toBe(999_001);
+    const parsed = JSON.parse(second.ticket.custom_fields[0]?.value ?? '{}') as Record<
+      string,
+      { analysis: string; fingerprint: string }
+    >;
+    expect(parsed[String(MOCK_TICKET_ATTACHMENT_IMAGE.id)]?.analysis).toBe('Mirror me');
+    expect(parsed[String(MOCK_TICKET_ATTACHMENT_IMAGE.id)]?.fingerprint).toContain('image/png');
+  });
+
+  it('still succeeds when the custom-field mirror PUT fails (note is canonical)', async () => {
+    let putCount = 0;
+    mswServer.use(
+      http.put('https://testsubdomain.zendesk.com/api/v2/tickets/1', () => {
+        putCount += 1;
+        if (putCount === 1) return HttpResponse.json({ ticket: { ...MOCK_TICKET, id: 1 } });
+        return HttpResponse.json({ error: 'boom' }, { status: 500 });
+      }),
+    );
+    const tool = findTool('record_attachment_analysis', { ...ctx, analysisFieldId: 999_001 });
+    const result = await tool.handler({
+      ticket_id: 1,
+      attachment_id: MOCK_TICKET_ATTACHMENT_IMAGE.id,
+      analysis: 'Mirror this',
+      replace_existing: false,
+    });
+    expect(putCount).toBe(2);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('recorded');
+    expect(text).toContain('mirror failed');
+  });
+});

--- a/tests/unit/utils/attachment-marker.test.ts
+++ b/tests/unit/utils/attachment-marker.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { ZendeskComment, ZendeskTicketAttachment } from '../../../src/types';
+import {
+  buildFingerprint,
+  buildMarker,
+  collectAttachments,
+  collectMarkers,
+  findLatestAnalysis,
+  parseMarkers,
+} from '../../../src/utils/attachment-marker';
+
+const ATTACHMENT: ZendeskTicketAttachment = {
+  id: 12345,
+  file_name: 'screenshot.png',
+  content_url: 'https://example.com/screenshot.png',
+  content_type: 'image/png',
+  size: 48213,
+};
+
+const makeComment = (overrides: Partial<ZendeskComment> = {}): ZendeskComment => ({
+  id: 1,
+  body: '',
+  author_id: 1,
+  public: false,
+  created_at: '2026-05-01T10:00:00Z',
+  ...overrides,
+});
+
+describe('buildFingerprint', () => {
+  it('combines size and mime', () => {
+    expect(buildFingerprint(ATTACHMENT)).toBe('size:48213,mime:image/png');
+  });
+});
+
+describe('buildMarker / parseMarkers round-trip', () => {
+  it('builds a parsable marker block', () => {
+    const body = buildMarker(ATTACHMENT, 'A red error dialog with the text "Disk full".');
+    const markers = parseMarkers(body, 42, '2026-05-01T10:00:00Z');
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.attachment_id).toBe(12345);
+    expect(markers[0]?.fingerprint).toBe('size:48213,mime:image/png');
+    expect(markers[0]?.analysis).toContain('A red error dialog');
+    expect(markers[0]?.comment_id).toBe(42);
+  });
+
+  it('parses multiple markers from one body', () => {
+    const a = buildMarker(ATTACHMENT, 'Analysis A');
+    const b = buildMarker({ ...ATTACHMENT, id: 99, file_name: 'b.png', size: 100 }, 'Analysis B');
+    const combined = `Some prose.\n\n${a}\n\nMore prose.\n\n${b}`;
+    const markers = parseMarkers(combined, 1, '2026-05-02T00:00:00Z');
+    expect(markers).toHaveLength(2);
+    expect(markers.map((m) => m.attachment_id).sort((a, b) => a - b)).toEqual([99, 12345]);
+  });
+
+  it('ignores markers with a different version', () => {
+    const body =
+      '<!-- mcp:image-analysis v=2 attachment_id=1 fingerprint=x -->X<!-- /mcp:image-analysis -->';
+    expect(parseMarkers(body, 1, '2026-05-01T10:00:00Z')).toHaveLength(0);
+  });
+
+  it('preserves analysis text containing marker delimiters via escape round-trip', () => {
+    const tricky = '<!-- not a marker --> and <!-- /mcp:image-analysis --> embedded';
+    const body = buildMarker(ATTACHMENT, tricky);
+    // Stored bytes must NOT contain a second closing marker beyond our own.
+    expect(body.match(/<!--\s*\/mcp:image-analysis\s*-->/g)).toHaveLength(1);
+    const markers = parseMarkers(body, 1, '2026-05-01T10:00:00Z');
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.analysis).toBe(tricky);
+  });
+
+  it('does not call parseMarkers with shared regex state across calls', () => {
+    // Calling parseMarkers twice on bodies containing markers must each return
+    // every marker (no /g lastIndex leakage between calls).
+    const body = `${buildMarker(ATTACHMENT, 'first')}\n${buildMarker(ATTACHMENT, 'second')}`;
+    expect(parseMarkers(body, 1, '2026-05-01T10:00:00Z')).toHaveLength(2);
+    expect(parseMarkers(body, 1, '2026-05-01T10:00:00Z')).toHaveLength(2);
+  });
+});
+
+describe('findLatestAnalysis', () => {
+  it('returns undefined when no marker exists', () => {
+    const comment = makeComment({ body: 'plain text' });
+    expect(findLatestAnalysis([comment], ATTACHMENT)).toBeUndefined();
+  });
+
+  it('returns the marker when fingerprint matches', () => {
+    const body = buildMarker(ATTACHMENT, 'desc');
+    const comment = makeComment({ id: 7, body });
+    const found = findLatestAnalysis([comment], ATTACHMENT);
+    expect(found?.comment_id).toBe(7);
+    expect(found?.analysis).toBe('desc');
+  });
+
+  it('ignores stale markers when fingerprint diverges', () => {
+    const body = buildMarker(ATTACHMENT, 'old');
+    const comment = makeComment({ body });
+    const newer: ZendeskTicketAttachment = { ...ATTACHMENT, size: 99999 };
+    expect(findLatestAnalysis([comment], newer)).toBeUndefined();
+  });
+
+  it('picks the most recent marker when several exist', () => {
+    const oldComment = makeComment({
+      id: 1,
+      body: buildMarker(ATTACHMENT, 'first'),
+      created_at: '2026-05-01T10:00:00Z',
+    });
+    const newComment = makeComment({
+      id: 2,
+      body: buildMarker(ATTACHMENT, 'second'),
+      created_at: '2026-05-02T10:00:00Z',
+    });
+    const latest = findLatestAnalysis([oldComment, newComment], ATTACHMENT);
+    expect(latest?.analysis).toBe('second');
+    expect(latest?.comment_id).toBe(2);
+  });
+});
+
+describe('collectMarkers / collectAttachments', () => {
+  it('collects all markers across comments', () => {
+    const c1 = makeComment({ id: 1, body: buildMarker(ATTACHMENT, 'a') });
+    const c2 = makeComment({ id: 2, body: 'no marker' });
+    expect(collectMarkers([c1, c2])).toHaveLength(1);
+  });
+
+  it('flattens attachments per comment', () => {
+    const c1 = makeComment({ id: 1, attachments: [ATTACHMENT] });
+    const c2 = makeComment({ id: 2 });
+    const c3 = makeComment({ id: 3, attachments: [{ ...ATTACHMENT, id: 999 }] });
+    const flat = collectAttachments([c1, c2, c3]);
+    expect(flat).toHaveLength(2);
+    expect(flat[0]?.comment.id).toBe(1);
+    expect(flat[1]?.attachment.id).toBe(999);
+  });
+});


### PR DESCRIPTION
## Summary

Builds on top of [PR #13](https://github.com/fruggr/zendesk-mcp-server/pull/13) (now merged) by adding a single write tool — `record_attachment_analysis` — that persists the calling LLM's description of a ticket image attachment back to Zendesk and surfaces it inline on subsequent reads.

This PR was originally a 3-tool implementation (list / download / record) that overlapped heavily with @florentleveque's #13. After #13 merged we rebased on `main`, dropped the redundant list/download tools, and kept only the *persistence + inline rendering* layer that #13 didn't address. The result is much smaller and a clean stratification:

- **#13** is the primitive: walk comments, deliver `image/*` attachments to the LLM as MCP `image` content blocks (5 MB / image cap, 10 images max, soft-fail per attachment).
- **#12 (this PR)** is the semantic layer: store and re-surface the LLM's description so the next read of the ticket already carries it inline.

Total tool count after both PRs: **38** (+1 from this PR over #13's 37).

## What this PR adds

| Tool / module | Purpose |
|---|---|
| `record_attachment_analysis` (write) | Persist an AI-inferred image description as a Zendesk internal note tagged with `<!-- mcp:image-analysis v=1 attachment_id=X fingerprint=size:N,mime:T -->…<!-- /mcp:image-analysis -->`. Idempotent on `(attachment_id, fingerprint)` unless `replace_existing=true`. |
| `src/utils/attachment-marker.ts` | `buildMarker` / `parseMarkers` / `findLatestAnalysis` / `collectMarkers`. Versioned schema (`v=1`), stale-marker detection via fingerprint mismatch. |
| `formatComment` extension | When `formatComment` receives the full comments list, it resolves stored markers and renders each as a blockquote next to the matching `Attachments: #ID (type)` line — so the LLM sees the analysis on subsequent ticket reads without re-downloading the image. |
| `list_tickets` / `search_tickets` footer | Generic hint `*Voir get_ticket pour le détail des pièces jointes éventuelles.*` so the LLM knows where to drill into. No N+1 fetches. |
| `docs/image-attachments.md` | Full design: architecture rationale (no server-side vision API), marker schema, optional custom-field mirror, limits inherited from #13, future work. |

## Expected flow

```text
get_ticket(include_comments=true)
  → "Attachments: #12345 (image/png)" under the comment
get_ticket_attachments(ticket_id, attachment_ids=[12345])   # PR #13
  → LLM views the image natively (MCP image content)
record_attachment_analysis(ticket_id, attachment_id=12345, analysis="…")
  → analysis stored as a private note with the v=1 marker
get_ticket(include_comments=true)
  → analysis rendered as a blockquote under the Attachments line
```

## Configuration

| Variable | Default | Effect |
|---|---|---|
| `ZENDESK_MCP_ANALYSIS_FIELD_ID` | unset | Mirror analyses as JSON to a custom ticket field for O(1) lookup. The internal note remains canonical; if the two diverge, the note wins. |

## Why client-side vision (still)

Same rationale as #13: the MCP client already runs a frontier multimodal LLM. Routing images through a server-side vision API would mean double-LLM billing, a server-side provider key, and the user losing the choice of model. The marker design preserves that: the server never reads or interprets image bytes — it only stores and re-emits the LLM's text description.

## Files

**New:**
- `src/tools/ticket-attachments.ts` — `record_attachment_analysis`
- `src/utils/attachment-marker.ts` — marker schema utilities
- `docs/image-attachments.md` — design doc
- `tests/unit/utils/attachment-marker.test.ts`, `tests/unit/tools/ticket-attachments.test.ts`

**Modified:**
- `src/types.ts` — `ZendeskTicketAttachment.thumbnails?` (additive)
- `src/tools/definitions.ts` — re-export `ToolContentBlock` alias alongside `ToolTextContent` / `ToolImageContent`
- `src/utils/formatting.ts` — `formatComment` now takes an optional `allComments` and renders stored markers inline; `ATTACHMENTS_LISTING_HINT` exported
- `src/tools/tickets.ts` — `get_ticket` passes the full comments list to `formatComment`; `list_tickets` / `search_tickets` append the hint footer
- `src/config.ts`, `src/server.ts`, `src/tools/index.ts` — wire `ZENDESK_MCP_ANALYSIS_FIELD_ID` and register the new factory
- `README.md`, `AGENTS.md`, `CHANGELOG.md`, `.env.example` — docs and counters (37 → 38)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 214 tests pass (12 new for marker round-trip / fingerprint invalidation / idempotence / replace_existing / custom-field mirror)
- [x] `pnpm check` — no new warnings
- [ ] Manual smoke once deployed: trigger the four-step flow above and verify the marker block is visible in the Zendesk UI on the resulting internal note, and that the inline blockquote appears on the second `get_ticket` call.

https://claude.ai/code/session_01SfPTwF8UiTQ7En6RdfWhqJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image attachment analysis: record AI analyses as internal ticket notes and show them inline (with timestamps) on ticket views; new write operation to record analyses.

* **Configuration**
  * Optional env var to mirror analysis metadata into a ticket custom field; mirror failures are non-fatal.

* **Documentation**
  * Docs updated with image-analysis workflow, examples, and updated tool counts (38 tools).

* **Tests**
  * New unit tests covering attachment markers and the analysis recording tool.

* **Other**
  * Ticket formatting improved to surface attachment analyses and thumbnail metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fruggr/zendesk-mcp-server/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->