### PR TITLE
fix(ci): upgrade npm for OIDC Trusted Publishing + recover v1.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,13 @@ jobs:
           # would either require us to re-introduce NPM_TOKEN or break the
           # pre-publish `npm whoami` check.
 
+      - name: Upgrade npm to a version that supports OIDC Trusted Publishing
+        # Node 22 ships npm 10.9.x. Full Trusted Publishing OIDC (publish
+        # without NPM_TOKEN, using only id-token: write) needs npm >= 11.5.1.
+        # @semantic-release/npm shells out to the npm CLI, so it is the
+        # global npm version that matters here.
+        run: npm install -g npm@^11.5.1
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm check
@@ -56,3 +63,8 @@ jobs:
           # Auth to npm is via NPM Trusted Publishing (OIDC), configured on
           # npmjs.com against this workflow file. The `id-token: write`
           # permission above is all that's needed — no NPM_TOKEN secret.
+          # Verbose logging so the next failure is debuggable from the run
+          # log alone (the OIDC publish step previously exit-1'd without
+          # surfacing the actual npm error).
+          DEBUG: 'semantic-release:*'
+          NPM_CONFIG_LOGLEVEL: verbose

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -1,0 +1,46 @@
+name: Republish a tagged version
+
+# One-shot recovery workflow. The v1.1.0 release on 2026-05-18 pushed the
+# tag and chore(release) commit but failed at the npm publish step (npm 10.9
+# bundled with Node 22 does not support OIDC Trusted Publishing without
+# NPM_TOKEN — needs npm >= 11.5.1). semantic-release is idempotent and won't
+# retry an existing tag, so this workflow lets a maintainer republish a tag
+# manually via workflow_dispatch.
+#
+# Delete this file once recovery is done; the regular release.yml is the
+# canonical path going forward.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g. v1.1.0)'
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  republish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Upgrade npm for OIDC Trusted Publishing
+        run: npm install -g npm@^11.5.1
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Contexte

La release v1.1.0 du 2026-05-18 (déclenchée par le merge de #13) a **partiellement échoué** :
- ✅ Tag `v1.1.0` créé et poussé sur le remote
- ✅ Commit `f9329be chore(release): 1.1.0 [skip ci]` sur `main`
- ✅ `CHANGELOG.md` + `package.json` mis à jour
- ❌ **Pas publié sur npm** (registry n'a que `1.0.0`)
- ❌ **Pas de GitHub Release v1.1.0**
- ❌ Run [`26031987634`](https://github.com/fruggr/zendesk-mcp-server/actions/runs/26031987634) terminé avec `exit code 1`

## Cause racine

semantic-release exécute **tous les hooks `prepare` avant tout `publish`**. Donc :
1. `prepare`: changelog → npm (bump) → git (commit + push + tag) ✅
2. `publish`: npm ❌ → github (jamais atteint)

`actions/setup-node@v4` avec `node-version: 22` livre **npm 10.9.x**. Le support complet de **Trusted Publishing OIDC sans `NPM_TOKEN`** n'existe qu'à partir de **npm 11.5.1**. `@semantic-release/npm` shell-out vers la CLI `npm publish`, qui sur npm 10.x n'effectue pas l'échange OIDC et se fait rejeter par le registry.

v1.0.0 avait fonctionné parce que le workflow bootstrap utilisait encore `NPM_TOKEN` ; le switch OIDC dans `07b9d2f` a fait de v1.1.0 la première vraie release sous OIDC (PR #10 entre les deux étant docs-only, pas de bump).

## Changements

### 1. `release.yml` — upgrade npm à >= 11.5.1
```yaml
- name: Upgrade npm to a version that supports OIDC Trusted Publishing
  run: npm install -g npm@^11.5.1
```
`actions/setup-node` n'a pas d'option `npm-version` ; `npm install -g` est la recette officielle pour forcer une version min sur les runners GitHub.

### 2. `release.yml` — logs verbeux
```yaml
DEBUG: 'semantic-release:*'
NPM_CONFIG_LOGLEVEL: verbose
```
Le prochain échec aura du contexte au lieu d'un simple `exit 1`.

### 3. `republish.yml` — workflow one-shot pour récupérer v1.1.0
semantic-release est idempotent et **refuse** de re-publier un tag existant. Pour rattraper v1.1.0 (qui est déjà taggué + sur `main`), un workflow `workflow_dispatch` qui checkout le tag et fait `npm publish --provenance --access public` directement. À supprimer une fois la recovery faite.

## Plan d'action après merge

1. **Vérifier côté npmjs.com** que le Trusted Publisher est configuré pour `release.yml` (et temporairement pour `republish.yml`). Si l'entrée est mal scopée, npm 11 ne suffira pas. ⚠️ Sans ça, échec identique.
2. **Lancer `republish.yml`** via l'onglet Actions avec `tag: v1.1.0`.
3. **Créer la GitHub Release v1.1.0** :
   ```bash
   gh release create v1.1.0 \
     --title "v1.1.0" \
     --notes "$(awk '/^## \[1.1.0\]/{flag=1;next} /^## /{flag=0} flag' CHANGELOG.md)" \
     --target f9329be
   ```
4. **Supprimer `republish.yml`** (PR de cleanup).
5. **Valider** en mergeant PR #14 (dependabot, ne déclenche pas de release mais valide le pipeline) ou en ouvrant une mini-PR `fix(docs):` pour produire v1.1.1.

## Ne pas faire

- ❌ Force-push pour réécrire `f9329be` : ce commit est dans la merge base des PRs ouvertes **#12** et **#14**, un rewrite forcerait un rebase douloureux.
- ❌ Supprimer le tag `v1.1.0` : `package.json` et `CHANGELOG.md` sur `main` y font référence.

## Risques résiduels

- L'ordre des plugins `.releaserc.json` reste inchangé : un futur échec de publish npm laissera à nouveau un tag orphelin (le push de `@semantic-release/git` se fait dans `prepare`, avant tout `publish` — réordonner ne change rien). Les logs verbeux (Change 2) rendent au moins le diag rapide.
- Si OIDC continue à poser des problèmes après ça, option de repli : repasser à un `NPM_TOKEN` granular publish-only — plus simple, fonctionne sur toute version de npm.

## Test plan

- [x] CI verte sur cette PR (pas de déclenchement release.yml puisque la PR cible main mais n'est pas mergée)
- [x] Trusted Publisher npmjs.com vérifié (manuel)
- [ ] Après merge : `republish.yml` lancé avec succès → `npm view @fruggr/zendesk-mcp-server@1.1.0` retourne le package
- [ ] `gh release create v1.1.0` exécuté → la release apparaît sur https://github.com/fruggr/zendesk-mcp-server/releases
- [ ] `republish.yml` supprimé
- [ ] Validation end-to-end : prochaine PR `feat:` ou `fix:` produit une release complète (npm + GitHub Release + tag)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ur5cxvuMez8m5za7PCfytS)_