### PR TITLE
chore(ci): add Renovate config for security-driven auto-release

### DIFF
--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -1,90 +1,90 @@
 # Release automation
 
-Ce document décrit comment les mises à jour de dépendances et les releases sont automatisées dans ce dépôt.
+This document describes how dependency updates and releases are automated in this repository.
 
-## Vue d'ensemble du flux
+## Flow overview
 
 ```
-Renovate detecte un update
+Renovate detects an update
         │
         ▼
-Ouvre une PR vers main (titre conventionalcommits)
+Opens a PR against main (conventionalcommits-style title)
         │
         ▼
 CI / build-and-test (vitest + tsc + biome)
         │
-        ▼ verte
-Auto-merge (si la PR y est éligible) ou revue manuelle
+        ▼ green
+Auto-merge (if the PR is eligible) or manual review
         │
         ▼
-Squash & merge → commit sur main avec le titre de la PR
+Squash & merge → commit on main using the PR title
         │
         ▼
 .github/workflows/release.yml (push:main)
         │
         ▼
-semantic-release lit les commits depuis la dernière release
+semantic-release scans commits since the last release
         │
-        ├─ commit `fix(security): …`   → release patch publiée sur npm + GitHub
-        ├─ commit `fix: …`              → release patch
-        ├─ commit `feat: …`             → release minor
-        ├─ commit `BREAKING CHANGE`     → release major
-        └─ commit `chore(deps): …`      → ignoré (pas de release)
+        ├─ commit `fix(security): …`   → patch release published on npm + GitHub
+        ├─ commit `fix: …`              → patch release
+        ├─ commit `feat: …`             → minor release
+        ├─ commit `BREAKING CHANGE`     → major release
+        └─ commit `chore(deps): …`      → ignored (no release)
 ```
 
-Le mapping types de commit → niveau de release vit dans `.releaserc.json` (preset `conventionalcommits`).
+The commit-type → release-level mapping lives in `.releaserc.json` (preset `conventionalcommits`).
 
-## Politique d'auto-merge
+## Auto-merge policy
 
-| Type d'update                                     | Vuln (security)    | Non-vuln                |
-| ------------------------------------------------- | ------------------ | ----------------------- |
-| **patch** sur `dependencies` (prod)               | auto-merge         | revue manuelle          |
-| **minor** sur `dependencies` (prod)               | revue manuelle     | revue manuelle          |
-| **patch** sur `devDependencies`                   | auto-merge         | auto-merge              |
-| **minor** sur `devDependencies`                   | revue manuelle\*   | auto-merge              |
-| **major** (toutes deps, prod et dev)              | dashboard approval | dashboard approval      |
-| GitHub Actions (`uses: org/action@…`)             | revue manuelle     | revue manuelle          |
+| Update kind                                       | Vulnerability (security) | Non-vulnerability        |
+| ------------------------------------------------- | ------------------------ | ------------------------ |
+| **patch** on `dependencies` (prod)                | auto-merge               | manual review            |
+| **minor** on `dependencies` (prod)                | manual review            | manual review            |
+| **patch** on `devDependencies`                    | auto-merge               | auto-merge               |
+| **minor** on `devDependencies`                    | manual review\*          | auto-merge               |
+| **major** (any deps, prod and dev)                | dashboard approval       | dashboard approval       |
+| GitHub Actions (`uses: org/action@…`)             | manual review            | manual review            |
 
-\* Les vuln minor déclenchent un préfixe `fix(security):` donc une release sera publiée à la merge ; on la garde manuelle pour permettre l'analyse d'impact.
+\* Vulnerability-minor updates carry the `fix(security):` prefix, so merging them publishes a release. We keep them under manual review to allow an impact assessment first.
 
-**Dashboard approval** signifie : aucune PR n'est ouverte automatiquement. L'update apparaît dans l'issue « Dependency Dashboard » créée par Renovate avec une case à cocher. Cocher la case déclenche la création de la PR. C'est conçu pour les majors qui demandent souvent une procédure de migration manuelle.
+**Dashboard approval** means: no PR is opened automatically. The update appears in the Renovate-managed "Dependency Dashboard" issue with a checkbox. Ticking the checkbox triggers PR creation. This is intentional for majors, which usually require reading the upstream CHANGELOG and following a migration procedure.
 
-Exemples concrets :
+Concrete examples:
 
-- Vuln patch dans `hono` (prod) → PR `fix(security): update hono to X` → auto-merge → release patch publiée.
-- Vuln minor dans `hono` (prod) → PR `fix(security): update hono to X` → **revue manuelle** → release patch publiée à la merge.
-- Vuln major dans `hono` (prod) → **pas de PR auto**, ligne dans le dashboard à approuver.
-- Update minor de `vitest` (devDep) → PR `chore(deps): update vitest to X` → auto-merge → pas de release.
-- Update major de `vitest` (devDep) → ligne dans le dashboard, approbation manuelle requise.
-- Update patch non-vuln de `hono` (prod) → PR `chore(deps): update hono to X` → revue manuelle → pas de release à la merge.
-- Bump du digest d'une GitHub Action → PR `chore(deps): update actions/X` → revue manuelle → pas de release.
+- Patch vulnerability in `hono` (prod) → PR `fix(security): update hono to X` → auto-merge → patch release published.
+- Minor vulnerability in `hono` (prod) → PR `fix(security): update hono to X` → **manual review** → patch release published on merge.
+- Major vulnerability in `hono` (prod) → **no auto PR**, entry in the dashboard awaiting approval.
+- Minor update of `vitest` (devDep) → PR `chore(deps): update vitest to X` → auto-merge → no release.
+- Major update of `vitest` (devDep) → entry in the dashboard, manual approval required.
+- Non-vuln patch update of `hono` (prod) → PR `chore(deps): update hono to X` → manual review → no release on merge.
+- GitHub Action digest bump → PR `chore(deps): update actions/X` → manual review → no release.
 
-## Pré-requis admin (à valider hors PR)
+## Admin prerequisites (out-of-PR settings)
 
-Ces réglages ne peuvent pas être versionnés ; un admin du repo (ou de l'org) doit les appliquer **une fois** :
+These cannot be versioned; a repository (or org) admin must apply them **once**:
 
-1. **Installer la GitHub App Renovate** sur le dépôt via https://github.com/apps/renovate. Aucun secret à créer.
-2. **Settings → General → Pull Requests** :
+1. **Install the Renovate GitHub App** on the repository via https://github.com/apps/renovate. No secret to create.
+2. **Settings → General → Pull Requests**:
    - Allow auto-merge ✓
    - Allow squash merging ✓
-   - Default to PR title for squash merges ✓ (**critique** : sans ça, le titre `fix(security):` n'arrive pas dans le commit squashé sur `main` et la release n'est pas publiée)
-3. **Settings → Branches → Branch protection rules** pour `main` :
+   - Default to PR title for squash merges ✓ (**critical**: without this, the `fix(security):` prefix is not carried into the squash commit on `main`, and no release is published)
+3. **Settings → Branches → Branch protection rules** for `main`:
    - Require status checks to pass before merging ✓
-   - Required check : `CI / build-and-test`
-   - (Sans cette protection, `platformAutomerge` mergerait la PR avant que la CI ait fini.)
-4. **Settings → Code security → Dependabot security updates** : OFF. Renovate prend le relais via `vulnerabilityAlerts` (GHSA) + `osvVulnerabilityAlerts` (Google OSV) et on évite les PR en doublon.
+   - Required check: `CI / build-and-test`
+   - (Without this protection, `platformAutomerge` would merge the PR before CI finishes.)
+4. **Settings → Code security → Dependabot security updates**: OFF. Renovate takes over via `vulnerabilityAlerts` (GHSA) + `osvVulnerabilityAlerts` (Google OSV), and we avoid duplicate PRs.
 
-## Pause ou désactivation
+## Pause or disable
 
-- **Mettre Renovate en pause sur ce repo** : ajouter `"enabled": false` à la racine de `renovate.json` et commiter, ou cocher « rate limited » dans la Dependency Dashboard.
-- **Désactiver l'auto-merge globalement** : remplacer `"platformAutomerge": true` par `false` dans `renovate.json`. Les PR continueront d'être créées mais devront être mergées manuellement.
-- **Désactiver l'auto-merge sur une catégorie précise** : retirer le `"automerge": true` du `packageRules` concerné.
+- **Pause Renovate on this repo**: add `"enabled": false` at the root of `renovate.json` and commit, or tick "rate limited" in the Dependency Dashboard.
+- **Disable auto-merge globally**: replace `"platformAutomerge": true` with `false` in `renovate.json`. PRs keep being opened, but must be merged manually.
+- **Disable auto-merge for one category**: remove `"automerge": true` from the relevant `packageRules` entry.
 
-## Procédure d'élargissement futur
+## Future broadening
 
-Quand la couverture de tests sera jugée suffisante pour automatiser plus largement :
+Once test coverage is deemed sufficient to automate more widely:
 
-- Auto-merger les `dependencies` prod en patch non-vuln : ajouter dans `packageRules`
+- Auto-merge non-vuln prod `dependencies` patches by adding to `packageRules`:
   ```json
   {
     "matchDepTypes": ["dependencies"],
@@ -92,6 +92,6 @@ Quand la couverture de tests sera jugée suffisante pour automatiser plus largem
     "automerge": true
   }
   ```
-- Auto-merger les GitHub Actions en patch : remplacer la règle `github-actions` actuelle par une variante avec `matchUpdateTypes: ["patch"]` et `automerge: true`.
+- Auto-merge GitHub Actions patches: replace the current `github-actions` rule with one matching `matchUpdateTypes: ["patch"]` and `automerge: true`.
 
-Garder les majors en `dependencyDashboardApproval: true` : ils nécessitent presque toujours une lecture du CHANGELOG amont.
+Keep majors at `dependencyDashboardApproval: true`: they almost always require reading the upstream CHANGELOG.

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -1,0 +1,97 @@
+# Release automation
+
+Ce document décrit comment les mises à jour de dépendances et les releases sont automatisées dans ce dépôt.
+
+## Vue d'ensemble du flux
+
+```
+Renovate detecte un update
+        │
+        ▼
+Ouvre une PR vers main (titre conventionalcommits)
+        │
+        ▼
+CI / build-and-test (vitest + tsc + biome)
+        │
+        ▼ verte
+Auto-merge (si la PR y est éligible) ou revue manuelle
+        │
+        ▼
+Squash & merge → commit sur main avec le titre de la PR
+        │
+        ▼
+.github/workflows/release.yml (push:main)
+        │
+        ▼
+semantic-release lit les commits depuis la dernière release
+        │
+        ├─ commit `fix(security): …`   → release patch publiée sur npm + GitHub
+        ├─ commit `fix: …`              → release patch
+        ├─ commit `feat: …`             → release minor
+        ├─ commit `BREAKING CHANGE`     → release major
+        └─ commit `chore(deps): …`      → ignoré (pas de release)
+```
+
+Le mapping types de commit → niveau de release vit dans `.releaserc.json` (preset `conventionalcommits`).
+
+## Politique d'auto-merge
+
+| Type d'update                                     | Vuln (security)    | Non-vuln                |
+| ------------------------------------------------- | ------------------ | ----------------------- |
+| **patch** sur `dependencies` (prod)               | auto-merge         | revue manuelle          |
+| **minor** sur `dependencies` (prod)               | revue manuelle     | revue manuelle          |
+| **patch** sur `devDependencies`                   | auto-merge         | auto-merge              |
+| **minor** sur `devDependencies`                   | revue manuelle\*   | auto-merge              |
+| **major** (toutes deps, prod et dev)              | dashboard approval | dashboard approval      |
+| GitHub Actions (`uses: org/action@…`)             | revue manuelle     | revue manuelle          |
+
+\* Les vuln minor déclenchent un préfixe `fix(security):` donc une release sera publiée à la merge ; on la garde manuelle pour permettre l'analyse d'impact.
+
+**Dashboard approval** signifie : aucune PR n'est ouverte automatiquement. L'update apparaît dans l'issue « Dependency Dashboard » créée par Renovate avec une case à cocher. Cocher la case déclenche la création de la PR. C'est conçu pour les majors qui demandent souvent une procédure de migration manuelle.
+
+Exemples concrets :
+
+- Vuln patch dans `hono` (prod) → PR `fix(security): update hono to X` → auto-merge → release patch publiée.
+- Vuln minor dans `hono` (prod) → PR `fix(security): update hono to X` → **revue manuelle** → release patch publiée à la merge.
+- Vuln major dans `hono` (prod) → **pas de PR auto**, ligne dans le dashboard à approuver.
+- Update minor de `vitest` (devDep) → PR `chore(deps): update vitest to X` → auto-merge → pas de release.
+- Update major de `vitest` (devDep) → ligne dans le dashboard, approbation manuelle requise.
+- Update patch non-vuln de `hono` (prod) → PR `chore(deps): update hono to X` → revue manuelle → pas de release à la merge.
+- Bump du digest d'une GitHub Action → PR `chore(deps): update actions/X` → revue manuelle → pas de release.
+
+## Pré-requis admin (à valider hors PR)
+
+Ces réglages ne peuvent pas être versionnés ; un admin du repo (ou de l'org) doit les appliquer **une fois** :
+
+1. **Installer la GitHub App Renovate** sur le dépôt via https://github.com/apps/renovate. Aucun secret à créer.
+2. **Settings → General → Pull Requests** :
+   - Allow auto-merge ✓
+   - Allow squash merging ✓
+   - Default to PR title for squash merges ✓ (**critique** : sans ça, le titre `fix(security):` n'arrive pas dans le commit squashé sur `main` et la release n'est pas publiée)
+3. **Settings → Branches → Branch protection rules** pour `main` :
+   - Require status checks to pass before merging ✓
+   - Required check : `CI / build-and-test`
+   - (Sans cette protection, `platformAutomerge` mergerait la PR avant que la CI ait fini.)
+4. **Settings → Code security → Dependabot security updates** : OFF. Renovate prend le relais via `vulnerabilityAlerts` (GHSA) + `osvVulnerabilityAlerts` (Google OSV) et on évite les PR en doublon.
+
+## Pause ou désactivation
+
+- **Mettre Renovate en pause sur ce repo** : ajouter `"enabled": false` à la racine de `renovate.json` et commiter, ou cocher « rate limited » dans la Dependency Dashboard.
+- **Désactiver l'auto-merge globalement** : remplacer `"platformAutomerge": true` par `false` dans `renovate.json`. Les PR continueront d'être créées mais devront être mergées manuellement.
+- **Désactiver l'auto-merge sur une catégorie précise** : retirer le `"automerge": true` du `packageRules` concerné.
+
+## Procédure d'élargissement futur
+
+Quand la couverture de tests sera jugée suffisante pour automatiser plus largement :
+
+- Auto-merger les `dependencies` prod en patch non-vuln : ajouter dans `packageRules`
+  ```json
+  {
+    "matchDepTypes": ["dependencies"],
+    "matchUpdateTypes": ["patch"],
+    "automerge": true
+  }
+  ```
+- Auto-merger les GitHub Actions en patch : remplacer la règle `github-actions` actuelle par une variante avec `matchUpdateTypes: ["patch"]` et `automerge: true`.
+
+Garder les majors en `dependencyDashboardApproval: true` : ils nécessitent presque toujours une lecture du CHANGELOG amont.

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -4,7 +4,7 @@ This document describes how dependency updates and releases are automated in thi
 
 ## Flow overview
 
-```
+```text
 Renovate detects an update
         │
         ▼

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":dependencyDashboard"
+  ],
+  "rangeStrategy": "replace",
+  "platformAutomerge": true,
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "commitMessagePrefix": "fix(security):",
+    "labels": ["security"],
+    "packageRules": [
+      {
+        "matchUpdateTypes": ["patch"],
+        "automerge": true
+      }
+    ]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Replace Dependabot with **Renovate** so that **security updates** automatically trigger a patch release through semantic-release, while every other dependency update stays a silent `chore(deps)`.

### How it works

- `vulnerabilityAlerts.commitMessagePrefix: "fix(security):"` → every security PR carries a conventionalcommits title that `commit-analyzer` (preset `conventionalcommits`, `.releaserc.json`) interprets as a `patch`.
- `:semanticCommitTypeAll(chore)` → every other PR keeps `chore(deps): …` (ignored by semantic-release ⇒ no release).
- `platformAutomerge: true` plus targeted auto-merge on:
  - vulnerability **patch** updates only,
  - devDependencies **patch + minor** updates (non-vuln).
- **Major** updates (any deps, vulns included) never open a PR automatically: they show up in the Renovate-managed **Dependency Dashboard** issue with an approval checkbox — appropriate for upgrades that usually require reading the upstream CHANGELOG.
- `osvVulnerabilityAlerts: true` extends vulnerability detection from GHSA to Google OSV.

### Files added

- `renovate.json` (validated with `renovate-config-validator`)
- `docs/release-automation.md`: flow diagram, auto-merge policy, admin checklist, pause/broadening procedure

## Admin prerequisites (apply before or right after merge)

Merging this PR is not enough — a repo admin has to apply these settings **once** (they cannot be versioned):

- [ ] **Install the Renovate GitHub App**: https://github.com/apps/renovate
- [ ] **Settings → General → Pull Requests**:
  - [ ] Allow auto-merge
  - [ ] Allow squash merging
  - [ ] Default to PR title for squash merges _(critical — without this, the `fix(security):` prefix is not carried into the squash commit on `main`)_
- [ ] **Branch protection on `main`**: require status check `CI / build-and-test` _(without it, `platformAutomerge` would merge the PR before CI finishes)_
- [ ] **Settings → Code security → Dependabot security updates: OFF** _(avoids duplicate PRs with Renovate)_

## Test plan

- [ ] `renovate.json` schema validated locally with `npx --package=renovate -- renovate-config-validator` ⇒ `Config validated successfully`
- [ ] After the GitHub App is installed, the "Dependency Dashboard" issue is auto-created
- [ ] On the next non-security Renovate PR (e.g. a minor devDep bump): title starts with `chore(deps):`, auto-merge engages when eligible, and after merge `release.yml` runs but publishes nothing (semantic-release logs "no release published")
- [ ] On the next real patch vulnerability (or simulated via a fork pinning an outdated dep): title starts with `fix(security):`, `security` label applied, auto-merge after green CI, then a patch release is published on npm + GitHub Releases
- [ ] On an intentionally red CI: no Renovate PR merges (not even a vuln patch)
- [ ] No PR is opened automatically for any major update (devDep or prod); it appears in the Dependency Dashboard with its approval checkbox

https://claude.ai/code/session_01Cv7zF6pDMXvyo6oSNHutcX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive release automation docs describing the end-to-end workflow, CI gating checks, semantic-release mapping for versioning, auto-merge policy matrix, admin setup steps, and controls for pausing or adjusting automation.

* **Chores**
  * Configured automated dependency and security update handling with granular auto-merge rules by update type/severity, dashboard approval for majors, and special handling for security updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fruggr/zendesk-mcp-server/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->