### PR TITLE
fix(security): patch transitive vulns + enable Renovate lockfile maintenance

### DIFF
--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -45,7 +45,7 @@ The commit-type → release-level mapping lives in `.releaserc.json` (preset `co
 | **major** (any deps, prod and dev)                | dashboard approval       | dashboard approval       |
 | **patch / minor** on `pnpm` (`packageManager`)    | auto-merge               | auto-merge               |
 | **patch / minor** on `pnpm.overrides` entries     | auto-merge               | auto-merge               |
-| Weekly `lockFileMaintenance` (Friday)             | auto-merge               | auto-merge               |
+| Weekly `lockFileMaintenance` (Friday before 8am, Europe/Paris) | auto-merge | auto-merge |
 | GitHub Actions (`uses: org/action@…`)             | manual review            | manual review            |
 
 \* Vulnerability-minor updates carry the `fix(security):` prefix, so merging them publishes a release. We keep them under manual review to allow an impact assessment first.
@@ -62,7 +62,7 @@ Concrete examples:
 - Patch or minor bump of `pnpm` (via `packageManager` field) → PR `chore(deps): update pnpm to X` → auto-merge → no release. The corepack hash in `packageManager` is updated automatically by Renovate when the format is `pnpm@VERSION+sha512.HASH`.
 - Non-vuln patch update of `hono` (prod) → PR `chore(deps): update hono to X` → manual review → no release on merge.
 - GitHub Action digest bump → PR `chore(deps): update actions/X` → manual review → no release.
-- Weekly Friday lockfile maintenance → PR `chore(deps): lock file maintenance` → auto-merge → no release. Picks up transitive updates whose parent ranges already allow the new version (e.g. a `^3.0.1`-ranged transitive moving from 3.1.0 to 3.1.2).
+- Weekly Friday lockfile maintenance (before 8am, Europe/Paris) → PR `chore(deps): lock file maintenance` → auto-merge → no release. Picks up transitive updates whose parent ranges already allow the new version (e.g. a `^3.0.1`-ranged transitive moving from 3.1.0 to 3.1.2).
 
 ## Transitive vulnerabilities
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -44,6 +44,8 @@ The commit-type → release-level mapping lives in `.releaserc.json` (preset `co
 | **minor** on `devDependencies`                    | manual review\*          | auto-merge               |
 | **major** (any deps, prod and dev)                | dashboard approval       | dashboard approval       |
 | **patch / minor** on `pnpm` (`packageManager`)    | auto-merge               | auto-merge               |
+| **patch / minor** on `pnpm.overrides` entries     | auto-merge               | auto-merge               |
+| Weekly `lockFileMaintenance` (Friday)             | auto-merge               | auto-merge               |
 | GitHub Actions (`uses: org/action@…`)             | manual review            | manual review            |
 
 \* Vulnerability-minor updates carry the `fix(security):` prefix, so merging them publishes a release. We keep them under manual review to allow an impact assessment first.
@@ -60,6 +62,16 @@ Concrete examples:
 - Patch or minor bump of `pnpm` (via `packageManager` field) → PR `chore(deps): update pnpm to X` → auto-merge → no release. The corepack hash in `packageManager` is updated automatically by Renovate when the format is `pnpm@VERSION+sha512.HASH`.
 - Non-vuln patch update of `hono` (prod) → PR `chore(deps): update hono to X` → manual review → no release on merge.
 - GitHub Action digest bump → PR `chore(deps): update actions/X` → manual review → no release.
+- Weekly Friday lockfile maintenance → PR `chore(deps): lock file maintenance` → auto-merge → no release. Picks up transitive updates whose parent ranges already allow the new version (e.g. a `^3.0.1`-ranged transitive moving from 3.1.0 to 3.1.2).
+
+## Transitive vulnerabilities
+
+`vulnerabilityAlerts` only acts on dependencies that appear in `package.json`. For vulnerabilities deep in the tree (visible in `pnpm-lock.yaml` only), two mechanisms cover the gap:
+
+1. **`lockFileMaintenance`** (weekly, Friday morning) regenerates `pnpm-lock.yaml`. Any transitive whose parent range already accepts the patched version moves up — no manifest change needed. This covers the common case.
+2. **`pnpm.overrides`** in `package.json` is required when the parent pins the vulnerable transitive at an exact version (or a range that excludes the patched one). The first time, a maintainer opens a `fix(security):` PR adding the override; from then on, Renovate auto-bumps the override entry via the dedicated `matchDepTypes: ["pnpm.overrides"]` rule (patch / minor only).
+
+**Caveat — semver hygiene in the npm ecosystem.** Bumping a transitive via lockfile-only regen relies on the parent's declared semver range being accurate. Some maintainers ship breaking changes in patch/minor versions. The auto-merged `lockFileMaintenance` PR is therefore guarded by CI (typecheck + tests); a regression should fail the build and block the merge. Skim the diff when reviewing CI failures on these PRs.
 
 ## Admin prerequisites (out-of-PR settings)
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
     "unified": "11.0.5",
     "zod": "4.3.6"
   },
+  "pnpm": {
+    "overrides": {
+      "ip-address": "^10.2.0"
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.7",
     "@semantic-release/changelog": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ip-address: ^10.2.0
+
 importers:
 
   .:
@@ -98,7 +101,7 @@ importers:
         version: 0.4.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -1456,8 +1459,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -1761,8 +1764,8 @@ packages:
     resolution: {integrity: sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==}
     engines: {node: '>=12'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2578,8 +2581,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -2606,8 +2609,8 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -4082,7 +4085,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4132,7 +4135,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -4591,7 +4594,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -4615,7 +4618,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -4646,7 +4649,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -5033,7 +5036,7 @@ snapshots:
       from2: 2.3.0
       p-is-promise: 3.0.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -5845,14 +5848,14 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.14)(tsx@4.21.0):
+  postcss-load-config@6.0.1(postcss@8.5.15)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       tsx: 4.21.0
 
-  postcss@8.5.14:
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -5880,7 +5883,7 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -6430,7 +6433,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -6441,7 +6444,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.14)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(postcss@8.5.15)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -6450,7 +6453,7 @@ snapshots:
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -6584,7 +6587,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       rolldown: 1.0.0-rc.16
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
   "rangeStrategy": "replace",
   "platformAutomerge": true,
   "osvVulnerabilityAlerts": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["before 6am on friday"]
+  },
   "vulnerabilityAlerts": {
     "enabled": true,
     "commitMessagePrefix": "fix(security):",
@@ -32,6 +37,11 @@
     },
     {
       "matchDepNames": ["pnpm"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
+      "matchDepTypes": ["pnpm.overrides"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
     },

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,8 @@
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["before 6am on friday"]
+    "schedule": ["before 8am on friday"],
+    "timezone": "Europe/Paris"
   },
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
## Summary

Two-step PR: a process change that lets Renovate handle transitive vulnerabilities going forward, plus a one-shot fix that closes the 4 open Dependabot alerts.

## Why

The 4 open Dependabot alerts (2 High, 2 Moderate) are all detected in `pnpm-lock.yaml`, not in `package.json` — i.e. **transitive dependencies** of `@modelcontextprotocol/sdk@1.29.0` (which is already at its latest version, so we can't bump the parent). Renovate's `vulnerabilityAlerts` only acts on manifest deps, so it stayed silent. This PR adds the missing pieces.

## What changes

### 1. Process — `chore(ci): enable Renovate lockFileMaintenance and auto-bump pnpm overrides`

- **`lockFileMaintenance`**: Friday morning (`before 6am on friday`), Renovate regenerates `pnpm-lock.yaml`. Any transitive whose parent semver range already accepts a patched version moves up automatically. Auto-merge on green CI.
- **`pnpm.overrides` rule**: when a parent pins a vulnerable transitive at an exact version, a maintainer writes an `pnpm.overrides` entry once; Renovate then auto-bumps the override entry on patch/minor releases of the overridden package.
- **Doc**: `docs/release-automation.md` updated — new rows in the auto-merge table, new "Transitive vulnerabilities" section, and a caveat about npm-ecosystem semver hygiene (auto-merged lockfile regens rely on CI as the guardrail).

### 2. Fix — `fix(security): patch fast-uri, qs and ip-address transitive vulnerabilities`

| Package | Old | New | Mechanism | CVE class |
|---|---|---|---|---|
| `fast-uri` | 3.1.0 | 3.1.2 | lockfile-only (`ajv ^3.0.1` accepted it) | Path traversal + host confusion (High) |
| `qs` | 6.15.1 | 6.15.2 | lockfile-only (`body-parser ^6.14.1` accepted it) | DoS in `qs.stringify` (Moderate) |
| `ip-address` | 10.1.0 | 10.2.0 | `pnpm.overrides` (`express-rate-limit` pins `10.1.0` exact) | XSS in `Address6` (Moderate) |

This commit is the one with the `fix(security):` prefix — semantic-release will publish a patch (`1.1.1` → `1.1.2`) when it lands on `main`.

## Test plan

- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 198/198 passing
- [x] `pnpm check` clean (1 pre-existing warning)
- [x] `pnpm build` succeeds
- [x] `node scripts/smoke-test.mjs` ok
- [ ] CI green on this PR
- [ ] On merge: semantic-release publishes `1.1.2`
- [ ] 4 Dependabot alerts auto-close

## Follow-ups

- Watch the first auto-merged Friday `lockFileMaintenance` PR to confirm the schedule and auto-merge work as configured.
- pnpm 11 migration still tracked in #25.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cv7zF6pDMXvyo6oSNHutcX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release automation documentation with expanded auto-merge policies for dependency updates and new guidance on handling transitive vulnerabilities through automated lockfile maintenance.

* **Chores**
  * Enabled automatic weekly dependency maintenance with automerging for patch and minor updates.
  * Added dependency version override to ensure consistent resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fruggr/zendesk-mcp-server/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->