### PR TITLE
chore(ci): bump checkout, setup-node, pnpm/action-setup to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # semantic-release v25+ requires Node >= 22.14. Keep ci.yml on
           # Node 20 (matching `engines.node`) to test against the minimum


### PR DESCRIPTION
## Summary

Bumps the three GitHub Actions flagged by Renovate in #21 to their `v6` major. They all touch the same two workflow files and have no functional interdependency, so they ship together per #27.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `pnpm/action-setup` | v4 | v6 |

Six occurrences updated across `.github/workflows/ci.yml` and `.github/workflows/release.yml`. No other inputs changed.

## Breaking-change review

- **`actions/setup-node@v6`** — v5 added auto-detect caching from the `packageManager` field; v6 limits the auto-detect to npm only. We are unaffected: both workflows pass `cache: pnpm` explicitly, so caching keeps working.
- **`actions/checkout@v6`** — Persistent credentials now live under `$RUNNER_TEMP` (requires runner ≥ v2.329.0, which `ubuntu-latest` already satisfies). `release.yml` uses `persist-credentials: false`, so the storage-location change is moot there.
- **`pnpm/action-setup@v6`** — Adds pnpm v11 support. We don't pin `version:`; the action reads `packageManager` from `package.json` (`pnpm@10.33.4`), which v6 still supports.

## Test plan

- [ ] CI workflow goes green on this PR end-to-end (`pnpm check`, `pnpm typecheck`, `pnpm test`, `pnpm build`, smoke test).
- [ ] pnpm cache is restored/saved by `actions/setup-node@v6` (visible in the setup-node step log).
- [ ] `release.yml` only runs on push to `main`; its change mirrors `ci.yml`, so a green CI here is the validation signal.

Closes #27. Refs Renovate dashboard #21.

https://claude.ai/code/session_019KSGgaung4GJEVmBzK9cbC

---
_Generated by [Claude Code](https://claude.ai/code/session_019KSGgaung4GJEVmBzK9cbC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure dependencies to the latest versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fruggr/zendesk-mcp-server/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->