### PR TITLE
chore(ci): bump artifact actions and silence unpinned-uses (#32)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -34,6 +34,13 @@ reviews:
       instructions: |
         Zendesk API calls in tests must go through MSW handlers in
         tests/msw-handlers.ts. Flag any test that hits the real network.
+    - path: '.github/workflows/**'
+      instructions: |
+        This project pins first-party actions (actions/*, pnpm/action-setup)
+        to floating major tags (@vN) by design. Do not raise unpinned-uses
+        / "pin to commit SHA" findings on these actions — the trade-off was
+        discussed and decided in issue #32. Renovate opens a PR when a new
+        major lands, and bumps go through normal review.
 
 knowledge_base:
   learnings:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - run: pnpm pack --pack-destination .
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: tarball
           path: '*.tgz'
@@ -44,7 +44,7 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: tarball
 


### PR DESCRIPTION
## Summary

Implements **option 3** from #32: keep floating major tags on first-party GitHub Actions, document the policy where it does functional work (silences CodeRabbit), and take the opportunity to bump artifact actions to their latest majors.

- **Bump actions** (`.github/workflows/ci.yml`):
  - `actions/upload-artifact` v6 → v7
  - `actions/download-artifact` v6 → v8 (only behavior change: hash mismatches now error instead of warn — a safety upgrade)
- **Silence CodeRabbit** (`.coderabbit.yaml`): add a `path_instructions` entry for `.github/workflows/**` telling the reviewer to skip `unpinned-uses` / "pin to commit SHA" findings on first-party actions. The entry text doubles as the inline policy record.

No prose section added to `AGENTS.md` / `CONTRIBUTING.md` — the closed issue is the historical record, and `.coderabbit.yaml` carries the policy where it actually has an effect. Avoids paying a permanent LLM-context tax on a once-a-year policy.

Rationale recap (from #32): all 7 `uses:` entries are first-party (`actions/*`, `pnpm/action-setup`); the marginal supply-chain win of SHA-pinning is small relative to rot/maintenance cost. Renovate already opens a PR when a new major lands (`renovate.json` has `{"matchManagers": ["github-actions"], "automerge": false}`), so bumps stay reviewed.

Original review thread that triggered the discussion: #31 (https://github.com/fruggr/zendesk-mcp-server/pull/31#discussion_r3294494709).

## Test plan

- [ ] CI `build-and-test` job green — `actions/upload-artifact@v7` uploads the `*.tgz`.
- [ ] CI `smoke-node20` job green — `actions/download-artifact@v8` retrieves the tarball and the smoke test prints `running via stdio`.
- [ ] CodeRabbit review does **not** raise `unpinned-uses` / SHA-pinning findings on the workflow files. If it still does, iterate on the `path_instructions` wording.

Closes #32

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEc2jv2Zx3GMHA8UBmG7Wy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions versions in CI/CD pipeline for improved compatibility and performance.
  * Refined code review configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fruggr/zendesk-mcp-server/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->