### PR TITLE
build: restore prepare script for git protocol installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ pnpm build
 node dist/index.js <your-subdomain>
 ```
 
+Or run a development branch directly from GitHub (handy for testing PRs without publishing to npm) — the `prepare` script builds the package automatically on install:
+
+```bash
+# Latest main
+npx -y github:fruggr/zendesk-mcp-server <your-subdomain>
+
+# A specific branch / tag / commit
+npx -y github:fruggr/zendesk-mcp-server#my-feature-branch <your-subdomain>
+```
+
 ## Authentication
 
 The server supports two authentication methods:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "check": "biome check src/",
     "check:fix": "biome check --write src/",


### PR DESCRIPTION
## Summary

Restores the ability to run the server directly from a git URL — e.g.

```bash
npx -y github:fruggr/zendesk-mcp-server#my-feature-branch <subdomain>
```

— which is handy for testing a dev branch without publishing to npm.

## Context

Commit 972ae68 ("feat!: publish to npm under @fruggr...") removed the
`"prepare": "npm run build"` script from `package.json` when the
package switched to `@fruggr` + semantic-release on npm. The commit
message explicitly noted:

> The `prepare` script was removed; builds on install are no longer
> triggered — use `pnpm build` explicitly in development workflows.

A side-effect was that installing from a git source no longer produced
`dist/index.js`, so the `bin` failed to launch.

## Change

- Re-add `"prepare": "npm run build"` to `package.json`. `prepare` is
  the canonical npm lifecycle hook that runs after `npm install` from a
  git source, **with devDependencies still available**, so `tsdown`
  builds the dist before npm prunes dev deps and exposes `bin`.
- Keep `prepublishOnly` as a belt-and-braces guard for npm publishes.
- Document the git-install workflow in the README's Installation
  section.

## Why this doesn't break anything

- npm publish flow is unchanged (the published tarball already ships
  `dist/`, and `prepublishOnly` still runs).
- CI runs `pnpm install --frozen-lockfile` which now also triggers an
  install-time build; the explicit `pnpm build` step is then a no-op /
  idempotent. Minor extra build time (~1s), no semantic change.
- Local dev installs (`pnpm install`) now build once on install. Same
  trade-off, negligible.
- No code, no API, no runtime behavior changes.

## Test plan

- [x] `pnpm install --frozen-lockfile` from a clean state → `prepare`
      runs, `dist/index.js` is produced and chmod +x'd.
- [x] `pnpm check` (1 pre-existing warning, unrelated).
- [x] `pnpm typecheck` passes.
- [x] `pnpm test` — 198/198 pass.
- [x] `node scripts/smoke-test.mjs` — ok.
- [ ] CI green on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_011TtGCAgYk9B2mpNWjHz4og)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to support running development versions directly from GitHub.

* **Chores**
  * Added automatic build script execution during package installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fruggr/zendesk-mcp-server/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->