### PR TITLE
test: add end-to-end MCP integration tests over stdio transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,7 @@ Tests use vitest + MSW for mocking the Zendesk API.
 - **Bug fixes**: write or adapt an existing test to reproduce the bug first, then fix the code.
 - **Existing tests are sacred**: a failing existing test is a potential regression. Investigate and understand WHY it fails before changing it. Never modify an existing test just to make it pass without understanding the root cause.
 - **Zendesk API**: always use MSW handlers (`tests/msw-handlers.ts`) to mock Zendesk responses. Never call the real API in tests.
+- **Coverage follows the surface**: when you add or change a tool, mode, filter, or transport, extend the end-to-end tests in `tests/integration/` so the roundtrip stays covered — shared, transport-agnostic behaviour belongs in `registerCoreScenarios`.
 
 ## Code style
 

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -1,0 +1,119 @@
+import { HttpResponse, http } from 'msw';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getBaseUrl } from '../../src/constants';
+import { mswServer } from '../setup';
+import { type ConnectedClient, type IntegrationHarness, makeConfig } from './harness';
+
+const BASE = getBaseUrl('testsubdomain');
+
+/** Names of the text blocks returned by a tool call, joined for easy asserts. */
+const textOf = (result: { content?: Array<{ type: string; text?: string }> }): string =>
+  (result.content ?? [])
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text ?? '')
+    .join('\n');
+
+const toolNames = (tools: Array<{ name: string }>): string[] => tools.map((t) => t.name);
+
+/**
+ * Shared, transport-agnostic integration scenarios. Every assertion here goes
+ * through a real MCP client over the harness's transport — `tools/list` and
+ * `tools/call` cross the wire, the server dispatches to the actual tool, and the
+ * Zendesk HTTP call is served by MSW. A later HTTP harness reuses this verbatim.
+ */
+export const registerCoreScenarios = (harness: IntegrationHarness): void => {
+  describe(`[${harness.name}] core MCP roundtrip`, () => {
+    let connected: ConnectedClient | undefined;
+
+    afterEach(async () => {
+      await connected?.close();
+      connected = undefined;
+    });
+
+    describe('tools/list', () => {
+      it('exposes individual tools in "all" mode', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const { tools } = await connected.client.listTools();
+        const names = toolNames(tools);
+
+        expect(names).toContain('get_current_user');
+        expect(names).toContain('get_ticket');
+        expect(names).toContain('create_ticket');
+      });
+
+      it('exposes one proxy per namespace in "namespace" mode', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'namespace' }));
+        const { tools } = await connected.client.listTools();
+        const names = toolNames(tools);
+
+        expect(names).toContain('zendesk_tickets');
+        expect(names).toContain('zendesk_help_center');
+        expect(names).toContain('zendesk_users');
+        // No individual tools leak through the proxy facade.
+        expect(names).not.toContain('get_current_user');
+      });
+
+      it('exposes a single proxy in "single" mode', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'single' }));
+        const { tools } = await connected.client.listTools();
+
+        expect(toolNames(tools)).toEqual(['zendesk']);
+      });
+
+      it('applies the namespace filter', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'namespace', namespaces: ['users'] }));
+        const { tools } = await connected.client.listTools();
+
+        expect(toolNames(tools)).toEqual(['zendesk_users']);
+      });
+
+      it('applies the read-only filter', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all', readOnly: true }));
+        const names = toolNames((await connected.client.listTools()).tools);
+
+        expect(names).toContain('get_current_user');
+        expect(names).not.toContain('create_ticket');
+        expect(names).not.toContain('update_ticket');
+      });
+    });
+
+    describe('tools/call', () => {
+      it('dispatches a direct tool call to the mocked Zendesk API', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'get_current_user',
+          arguments: {},
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('Test User');
+      });
+
+      it('dispatches through the single proxy at runtime', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'single' }));
+        const result = await connected.client.callTool({
+          name: 'zendesk',
+          arguments: { operation: 'get_current_user', params: {} },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('Test User');
+      });
+
+      it('surfaces a Zendesk API error as an MCP tool error', async () => {
+        mswServer.use(
+          http.get(`${BASE}/users/me`, () => new HttpResponse('unauthorized', { status: 401 })),
+        );
+
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'get_current_user',
+          arguments: {},
+        });
+
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toContain('Authentication failed');
+      });
+    });
+  });
+};

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -1,10 +1,7 @@
-import { HttpResponse, http } from 'msw';
 import { afterEach, describe, expect, it } from 'vitest';
-import { getBaseUrl } from '../../src/constants';
+import { errorHandlers } from '../msw-handlers';
 import { mswServer } from '../setup';
 import { type ConnectedClient, type IntegrationHarness, makeConfig } from './harness';
-
-const BASE = getBaseUrl('testsubdomain');
 
 /** Names of the text blocks returned by a tool call, joined for easy asserts. */
 const textOf = (result: { content?: Array<{ type: string; text?: string }> }): string =>
@@ -101,9 +98,7 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
       });
 
       it('surfaces a Zendesk API error as an MCP tool error', async () => {
-        mswServer.use(
-          http.get(`${BASE}/users/me`, () => new HttpResponse('unauthorized', { status: 401 })),
-        );
+        mswServer.use(errorHandlers.usersMeUnauthorized);
 
         connected = await harness.connect(makeConfig({ mode: 'all' }));
         const result = await connected.client.callTool({

--- a/tests/integration/harness.ts
+++ b/tests/integration/harness.ts
@@ -1,0 +1,40 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { type Config, ConfigSchema } from '../../src/config';
+
+/**
+ * A client connected to a running MCP server through a real transport, plus a
+ * `close` that tears down both ends. The integration suites talk to the server
+ * exclusively through `client`, i.e. across the wire, never by calling handlers
+ * directly.
+ */
+export interface ConnectedClient {
+  client: Client;
+  close(): Promise<void>;
+}
+
+/**
+ * Transport-agnostic seam for the integration suite. Each transport (stdio
+ * today, HTTP in a later PR) provides one implementation; the shared scenarios
+ * in `core-scenarios.ts` run against any harness unchanged.
+ */
+export interface IntegrationHarness {
+  /** Short transport name, used to label the test suite (e.g. 'stdio'). */
+  readonly name: string;
+  /** Boot a server with `config` and return a client connected to it. */
+  connect(config: Config): Promise<ConnectedClient>;
+}
+
+/**
+ * Build a fully-valid test Config. The defaults match the MSW handlers, whose
+ * BASE is `https://testsubdomain.zendesk.com/...`, so requests made by the
+ * server are intercepted. Override any field per scenario.
+ */
+export const makeConfig = (overrides: Partial<Config> = {}): Config =>
+  ConfigSchema.parse({
+    subdomain: 'testsubdomain',
+    oauthClientId: 'testsubdomain_zendesk',
+    logLevel: 'info',
+    mode: 'all',
+    readOnly: false,
+    ...overrides,
+  });

--- a/tests/integration/stdio-harness.ts
+++ b/tests/integration/stdio-harness.ts
@@ -1,0 +1,35 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { Config } from '../../src/config';
+import { createMcpServer } from '../../src/server';
+import type { ConnectedClient, IntegrationHarness } from './harness';
+
+/**
+ * Exercises the stdio path end-to-end without spawning a process: the server is
+ * the same `McpServer` that `src/index.ts` connects to a `StdioServerTransport`,
+ * but here it is linked to the client through an in-memory pipe. This keeps the
+ * roundtrip (serialization, request/response correlation, tool dispatch) real
+ * while staying in-process for fast, deterministic tests.
+ */
+export const stdioHarness: IntegrationHarness = {
+  name: 'stdio',
+  async connect(config: Config): Promise<ConnectedClient> {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    // The token is opaque to the transport: MSW intercepts the Zendesk calls
+    // regardless of its value.
+    const server = createMcpServer(config, () => 'test-token');
+    await server.connect(serverTransport);
+
+    const client = new Client({ name: 'integration-test', version: '0.0.0' });
+    await client.connect(clientTransport);
+
+    return {
+      client,
+      close: async () => {
+        await client.close();
+        await server.close();
+      },
+    };
+  },
+};

--- a/tests/integration/stdio.test.ts
+++ b/tests/integration/stdio.test.ts
@@ -1,0 +1,7 @@
+import { registerCoreScenarios } from './core-scenarios';
+import { stdioHarness } from './stdio-harness';
+
+// Runs the shared MCP roundtrip scenarios against the stdio transport. When the
+// HTTP transport lands, a sibling http.test.ts will call registerCoreScenarios
+// with an http harness to get the same coverage for free.
+registerCoreScenarios(stdioHarness);

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -172,6 +172,15 @@ export const MOCK_COMMENT = {
   ],
 };
 
+// Opt-in error handlers for tests that exercise failure paths. Kept here so all
+// Zendesk mocking stays centralized; activate one per test via mswServer.use().
+export const errorHandlers = {
+  usersMeUnauthorized: http.get(
+    `${BASE}/users/me`,
+    () => new HttpResponse('unauthorized', { status: 401 }),
+  ),
+};
+
 export const handlers = [
   // Tickets
   http.get(`${BASE}/tickets/:id`, ({ params }) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,10 +14,10 @@ export default defineConfig({
       // Quality gate: fail the run if coverage drops below these baselines.
       // Ratchet these up as coverage improves; never lower them silently.
       thresholds: {
-        statements: 90,
-        branches: 75,
-        functions: 90,
-        lines: 90,
+        statements: 94,
+        branches: 77,
+        functions: 98,
+        lines: 95,
       },
     },
   },


### PR DESCRIPTION
## Summary

Closes #42 (stdio scope). Adds true end-to-end integration tests: a real MCP
`Client` talks to the server **across a transport**, the server dispatches to an
actual tool, the tool calls the Zendesk API which is served by **MSW**, and the
response is asserted back on the client. This is the roundtrip layer that the
existing unit tests (handlers called directly) and the boot smoke test don't
cover.

Only the **stdio** transport exists on this branch, so only stdio is implemented
here — but the suite is deliberately **transport-agnostic** so the upcoming HTTP
transport PR can reuse every scenario unchanged, giving it a ready-made safety net.

## What's added (`tests/integration/`)

- **`harness.ts`** — `IntegrationHarness` seam (`connect(config) → { client, close }`)
  and a `makeConfig` helper whose defaults match the MSW base URL.
- **`stdio-harness.ts`** — concrete stdio harness using the SDK's
  `InMemoryTransport.createLinkedPair()` against the same `createMcpServer` that
  `src/index.ts` wires to `StdioServerTransport`. Real roundtrip, in-process, fast.
- **`core-scenarios.ts`** — `registerCoreScenarios(harness)`, the shared,
  protocol-independent scenarios.
- **`stdio.test.ts`** — runs the shared scenarios against the stdio harness.

## Coverage

- `tools/list` per mode: `all` (individual tools), `namespace` (one proxy per
  namespace), `single` (one `zendesk` proxy).
- Filters: `--namespace` and `--read-only` reflected in the exposed tool set.
- `tools/call`: direct dispatch and dispatch through the single proxy, both
  hitting the mocked `/users/me`.
- Error propagation: a 401 from Zendesk surfaces as an MCP tool error
  (`isError: true`, message `Authentication failed…`).

## Future HTTP reuse

A later PR adds `http-harness.ts` + `http.test.ts` calling
`registerCoreScenarios(httpHarness)` plus HTTP-only cases (well-known endpoints,
`WWW-Authenticate`, bearer propagation). No change to the shared core needed.

## Verification

- `npx vitest run tests/integration/stdio.test.ts` → 8 passed
- Full `pnpm test` → all green; picked up automatically by the existing CI
  `pnpm test` step (vitest `include` is unrestricted).
- `pnpm typecheck` → clean (tests included under strictest).
- `pnpm check` → exit 0 (biome scans `src/` only; the lone warning is
  pre-existing and untouched).

https://claude.ai/code/session_01YNy3KXWFPpMnbAWmzUSxQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNy3KXWFPpMnbAWmzUSxQi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a shared integration test suite covering core end-to-end MCP roundtrips.
  * Verifies tool listing across modes, namespace/read-only filtering, proxy behavior, direct and proxied calls, and error surfacing.
  * Added a transport-agnostic test harness and an in-process stdio harness; registered core scenarios against it.
  * Added centralized error mock handlers for explicit failure-path testing.
  * Raised test coverage quality gates to stricter baselines.

* **Documentation**
  * Updated testing guidelines to require end-to-end coverage for tools, modes, filters, and transports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fruggr/zendesk-mcp-server/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->