### PR TITLE
feat(annotations): expose accurate hints to MCP clients

### DIFF
--- a/.claude/skills/functional-testing/SKILL.md
+++ b/.claude/skills/functional-testing/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: functional-testing
+description: Drive the inter-LLM functional test harness for this MCP server. Use when the user invokes /functional-testing — either with a scenario slug (e.g. `01-namespace-readonly`) or `all`. Reads STATE.md, produces a bridge prompt for the local executor, then ingests reports and writes verdicts. Never reads `expected.md` until the executor has already pushed its report.
+---
+
+# Functional testing — leading LLM protocol
+
+You are the **leading LLM** in a two-LLM functional test loop. The other LLM
+runs locally on the user's machine (Claude Code CLI), executes scenarios
+against the real MCP server build, and pushes its artifacts. You drive the
+loop without ever running the server yourself.
+
+## Invocation forms
+
+- `/functional-testing <NN-slug>` — drive a single scenario.
+- `/functional-testing all` — drive every scenario in `STATE.md` not yet
+  `done`, in order.
+
+## Loop per scenario
+
+1. **Read state.** Open `tests/functional/STATE.md`. Confirm the scenario
+   exists and its status. If the user passed `all`, pick the first non-`done`
+   row.
+2. **Refuse if not your turn.** If `holder` in the frontmatter is not
+   `leading`, the executor still owes a push. Tell the user, stop.
+3. **Read the spec, NOT the expected.** Open
+   `tests/functional/scenarios/<slug>/spec.md`. Do **NOT** open
+   `expected.md` yet — opening it before the executor reports would let bias
+   leak into the bridge prompt.
+4. **Produce a bridge prompt** for the user to paste into their local Claude
+   Code session. Template:
+
+   ```
+   Tu es dans le repo zendesk-mcp-server, branche locale doit être à jour
+   avec origin/<branch-from-STATE>.
+   Lis tests/functional/scenarios/<slug>/spec.md et applique strictement
+   ses instructions.
+   Ne lis PAS expected.md — c'est le critère de verdict, le voir biaiserait
+   ton rapport.
+   Écris reports/<slug>.raw.json + reports/<slug>.report.md.
+   Quand fini, mets à jour tests/functional/STATE.md (status=done,
+   holder=leading), commit et push.
+   Préviens-moi.
+   ```
+
+   Adapt the language to the user's (`AGENTS.md` says GitHub = English, chat
+   = user's language).
+5. **Wait for the user to confirm the push.** No polling. The user signals
+   you in chat.
+6. **Pull and read.** `git pull origin <branch>`. Open the executor's
+   artifacts: `reports/<slug>.raw.json` (canonical, ground truth) and
+   `reports/<slug>.report.md` (executor's narrative + assertion fence).
+7. **Now read `expected.md`.** Open
+   `tests/functional/scenarios/<slug>/expected.md`. Compare each assertion ID
+   between the report fence and the expected values. Re-verify each against
+   `raw.json` — don't trust the executor's `actual` blindly; they may have
+   miscopied.
+8. **Write the verdict** at `tests/functional/reports/<slug>.verdict.md`:
+
+   ```markdown
+   # Verdict — <slug>
+
+   | ID  | Status | Notes                                                  |
+   | --- | ------ | ------------------------------------------------------ |
+   | A1  | OK     | -                                                      |
+   | A2  | FAIL   | Expected X, raw shows Y. See `raw.json` `.tools[1]`.   |
+
+   ## Summary
+
+   <green / list of failing IDs>
+
+   ## Proposed actions
+
+   - <if any FAIL: pointer to the code fix, file:line>
+   ```
+
+9. **Update `STATE.md`.** Set the scenario row to `OK` or `FAIL`. Bump
+   `holder` back to `executor` only if you need them to re-run (e.g. report
+   was incomplete). Otherwise leave `holder: leading` and consider the
+   scenario closed.
+10. **Commit and push** the verdict and STATE update.
+11. **If FAIL with a clear root cause:** propose the code fix on the branch
+    in a **separate commit** (don't conflate harness output with code
+    changes). Push, mention to the user.
+
+## When `all`
+
+Loop steps 1-11 for each pending scenario, in order. Stop on the first FAIL
+and surface the diagnosis to the user before continuing — the executor may
+need to re-run after a code fix.
+
+## Hard rules
+
+- Never read `expected.md` before the executor has pushed their report.
+- Never edit `spec.md` or `expected.md` mid-run.
+- Never push a code fix and the verdict in the same commit.
+- If you can't reach a verdict (raw JSON corrupted, missing artifact), say so
+  in `verdict.md` and ask the user — don't fabricate.

--- a/.claude/skills/functional-testing/SKILL.md
+++ b/.claude/skills/functional-testing/SKILL.md
@@ -13,14 +13,27 @@ loop without ever running the server yourself.
 ## Invocation forms
 
 - `/functional-testing <NN-slug>` — drive a single scenario.
-- `/functional-testing all` — drive every scenario in `STATE.md` not yet
-  `done`, in order.
+- `/functional-testing all` — drive every scenario in `STATE.md` whose
+  status is not yet final (i.e. not `OK` and not `FAIL`), in order.
+
+## Scenario status lifecycle
+
+`STATE.md` rows go through three states:
+
+| status     | written by   | meaning                                                |
+| ---------- | ------------ | ------------------------------------------------------ |
+| `pending`  | initial      | scenario declared, executor has not yet run it         |
+| `done`     | executor     | report pushed, awaiting leading-LLM verdict            |
+| `OK`/`FAIL`| leading LLM  | verdict written; row is now final                      |
+
+`/functional-testing all` picks the first row whose status is `pending` or
+`done` (everything that hasn't reached a final verdict).
 
 ## Loop per scenario
 
 1. **Read state.** Open `tests/functional/STATE.md`. Confirm the scenario
-   exists and its status. If the user passed `all`, pick the first non-`done`
-   row.
+   exists and its status. If the user passed `all`, pick the first row whose
+   status is not yet final (still `pending` or `done`).
 2. **Refuse if not your turn.** If `holder` in the frontmatter is not
    `leading`, the executor still owes a push. Tell the user, stop.
 3. **Read the spec, NOT the expected.** Open
@@ -75,10 +88,11 @@ loop without ever running the server yourself.
    - <if any FAIL: pointer to the code fix, file:line>
    ```
 
-9. **Update `STATE.md`.** Set the scenario row to `OK` or `FAIL`. Bump
-   `holder` back to `executor` only if you need them to re-run (e.g. report
-   was incomplete). Otherwise leave `holder: leading` and consider the
-   scenario closed.
+9. **Update `STATE.md`.** Set the scenario `status` to `OK` or `FAIL` —
+   this is the final state, overwriting the `done` that the executor wrote.
+   Bump `holder` back to `executor` only if you need them to re-run (e.g.
+   report was incomplete); in that case revert `status` to `pending`.
+   Otherwise leave `holder: leading` and consider the scenario closed.
 10. **Commit and push** the verdict and STATE update.
 11. **If FAIL with a clear root cause:** propose the code fix on the branch
     in a **separate commit** (don't conflate harness output with code

--- a/.claude/skills/functional-testing/SKILL.md
+++ b/.claude/skills/functional-testing/SKILL.md
@@ -30,14 +30,14 @@ loop without ever running the server yourself.
 4. **Produce a bridge prompt** for the user to paste into their local Claude
    Code session. Template:
 
-   ```
+   ```text
    Tu es dans le repo zendesk-mcp-server, branche locale doit être à jour
    avec origin/<branch-from-STATE>.
    Lis tests/functional/scenarios/<slug>/spec.md et applique strictement
    ses instructions.
    Ne lis PAS expected.md — c'est le critère de verdict, le voir biaiserait
    ton rapport.
-   Écris reports/<slug>.raw.json + reports/<slug>.report.md.
+   Écris tests/functional/reports/<slug>.raw.json + tests/functional/reports/<slug>.report.md.
    Quand fini, mets à jour tests/functional/STATE.md (status=done,
    holder=leading), commit et push.
    Préviens-moi.
@@ -48,8 +48,9 @@ loop without ever running the server yourself.
 5. **Wait for the user to confirm the push.** No polling. The user signals
    you in chat.
 6. **Pull and read.** `git pull origin <branch>`. Open the executor's
-   artifacts: `reports/<slug>.raw.json` (canonical, ground truth) and
-   `reports/<slug>.report.md` (executor's narrative + assertion fence).
+   artifacts: `tests/functional/reports/<slug>.raw.json` (canonical, ground
+   truth) and `tests/functional/reports/<slug>.report.md` (executor's
+   narrative + assertion fence).
 7. **Now read `expected.md`.** Open
    `tests/functional/scenarios/<slug>/expected.md`. Compare each assertion ID
    between the report fence and the expected values. Re-verify each against

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ testing in `docs/live-testing.md`.
 
 ## Testing
 
+## Testing
+
 - New features: TDD — failing test first. Bug fixes: reproduce with a test first.
 - Existing tests are sacred: a failure is a potential regression — find the root
   cause before touching the test.
@@ -37,6 +39,9 @@ testing in `docs/live-testing.md`.
 - Extend `tests/integration/` when you add/change a tool, mode, filter or
   transport; shared behaviour goes in `registerCoreScenarios`. Coverage
   thresholds in `vitest.config.ts` are a ratchet.
+- Inter-LLM functional tests (proxy annotations, `[RO]` prefix on `tools/list`)
+  live in `tests/functional/`; invoke via `/functional-testing`. Details in
+  `tests/functional/README.md`.
 
 ## Code style
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as z from 'zod/v4';
 import type { Config } from './config';
 import { filterTools, groupByNamespace } from './routing/registry';
+import type { ToolAnnotations } from './tools/definitions';
 import { createAllTools, type ToolDefinition } from './tools/index';
 import { type Logger, silentLogger } from './utils/logger';
 import { readPackageInfo } from './utils/package-info';
@@ -31,25 +32,42 @@ export const buildOperationList = (
     )
     .join('\n');
 
+// A proxy aggregates N sub-operations. Hints follow the safest plausible
+// reading: readOnly/idempotent only if EVERY op is, destructive as soon as
+// ANY op is. openWorld is always true (we always hit Zendesk).
+// Mistral/Vibe ignore annotations entirely, hence the `[RO]` prefix below.
+export const aggregateAnnotations = (
+  tools: ReadonlyArray<Pick<ToolDefinition, 'annotations'>>,
+): ToolAnnotations => ({
+  readOnlyHint: tools.every((t) => t.annotations.readOnlyHint),
+  destructiveHint: tools.some((t) => t.annotations.destructiveHint),
+  idempotentHint: tools.every((t) => t.annotations.idempotentHint),
+  openWorldHint: true,
+});
+
 const registerProxyTool = (
   server: McpServer,
   toolName: string,
   title: string,
   tools: ToolDefinition[],
   handlerMap: Map<string, ToolDefinition>,
+  readOnlyMode: boolean,
 ): void => {
   const operationNames = tools.map((t) => t.name);
   const operationList = buildOperationList(tools);
+  const annotations = aggregateAnnotations(tools);
+  const prefix = readOnlyMode ? '[RO] ' : '';
 
   server.registerTool(
     toolName,
     {
       title,
-      description: `${title}. Specify the operation and its parameters.\n\nAvailable operations:\n${operationList}`,
+      description: `${prefix}${title}. Specify the operation and its parameters.\n\nAvailable operations:\n${operationList}`,
       inputSchema: z.object({
         operation: z.string().describe(`One of: ${operationNames.join(', ')}`),
         params: z.record(z.string(), z.unknown()).default({}).describe('Operation parameters'),
       }),
+      annotations,
     },
     async ({ operation, params }) => {
       const def = handlerMap.get(operation);
@@ -130,13 +148,20 @@ export const createMcpServer = (
       for (const [namespace, tools] of grouped) {
         const label = NAMESPACE_LABELS[namespace];
         if (label) {
-          registerProxyTool(server, label.toolName, label.title, tools, handlerMap);
+          registerProxyTool(
+            server,
+            label.toolName,
+            label.title,
+            tools,
+            handlerMap,
+            config.readOnly,
+          );
         }
       }
       break;
     }
     case 'single': {
-      registerProxyTool(server, 'zendesk', 'Zendesk', filteredTools, handlerMap);
+      registerProxyTool(server, 'zendesk', 'Zendesk', filteredTools, handlerMap, config.readOnly);
       break;
     }
   }

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -436,7 +436,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       }),
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: true,
       },
@@ -584,7 +584,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       }),
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: true,
       },
@@ -901,7 +901,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       }),
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: true,
       },

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -337,7 +337,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       }),
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: true,
       },
@@ -492,7 +492,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       }),
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: true,
       },

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -1,0 +1,81 @@
+# Functional test harness
+
+End-to-end behavioural tests for the MCP server, driven by **two LLMs
+communicating through committed files**. Designed to validate features that
+unit tests can't reach: the actual wire-level output of `tools/list`,
+real `tools/call` round-trips, client-visible annotations, description
+strings, etc.
+
+## Roles
+
+| Role                  | Lives in       | Reads                                                          | Writes                                                              |
+| --------------------- | -------------- | -------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **Leading LLM**       | Web Claude     | `scenarios/<N>/spec.md`, `scenarios/<N>/expected.md`, reports  | `STATE.md`, `reports/<N>.verdict.md`, optional code fixes           |
+| **Executing LLM**     | Local Claude   | `scenarios/<N>/spec.md`, `STATE.md`                            | `reports/<N>.raw.json`, `reports/<N>.report.md`, `STATE.md`         |
+
+`scenarios/` is read-only for the executor. `reports/` is the comm channel.
+`STATE.md` is shared, but the `holder` field acts as a narrative lock — only
+the holder pushes.
+
+**Critical:** the executor must NOT open `expected.md`. It encodes the verdict
+criteria — seeing it would bias the report.
+
+## Channels
+
+Each scenario declares which channels it uses in its frontmatter (`channels`):
+
+- **A — Subprocess `tools/list`.** Executor runs
+  `bin/dump-tools-list.mjs` which spawns the local server build and dumps
+  `tools/list` as canonical JSON. No Zendesk network call (auth only fires on
+  `tools/call`). All current scenarios use channel A.
+- **B — MCP Zendesk in the executor's Claude Code stack.** For future
+  scenarios that exercise runtime behaviour (e.g. a new tool, proxy routing).
+  Requires the executor to have configured a Zendesk MCP server locally
+  pointing at the `fruggr` instance. Not exercised by the v1 scenarios.
+
+## Prerequisites (executor side)
+
+1. Build the server once: `pnpm build`.
+2. Source the local Zendesk credentials (perso, never commit):
+   ```sh
+   export ZENDESK_SUBDOMAIN=fruggr
+   # ZENDESK_OAUTH_CLIENT_ID defaults to ${subdomain}_zendesk; override if needed
+   ```
+3. For channel B scenarios only: ensure your Claude Code MCP config exposes a
+   Zendesk server bound to `fruggr`.
+
+## Adding a scenario for a future PR
+
+1. Create `scenarios/<NN>-<slug>/spec.md` with frontmatter:
+   ```yaml
+   ---
+   pr: <number>
+   mode: namespace | single | all
+   read_only: true | false
+   namespaces: []          # optional --namespace filters
+   channels: [A]           # or [A, B]
+   ---
+   ```
+2. Body of `spec.md`: the exact commands to run, the artifacts to write, the
+   assertion fence template (IDs + descriptions, no expected values).
+3. Create `scenarios/<NN>-<slug>/expected.md` with a header banner warning the
+   executor not to open it, then the expected value per assertion ID.
+4. Append a row to `STATE.md` with `status: pending`.
+5. Invoke the leading LLM via `/functional-testing <NN-slug>` (or `all`).
+
+## Why `[RO]` isn't tested in mode `all`
+
+The `[RO]` prefix is added by `registerProxyTool` (`src/server.ts`) and only
+applies to proxy descriptions in `namespace` / `single` modes. In `--mode all`,
+each tool is registered individually with its original description — there is
+no proxy to prefix. Scenarios 01 and 03 cover the prefix already; a 5th
+no-prefix-in-all scenario would be empty.
+
+## Cleaning between runs
+
+`reports/<scenario>.*` are committed (they're the comm channel). Between PRs,
+clear them with:
+
+```sh
+rm tests/functional/reports/*.json tests/functional/reports/*.md
+```

--- a/tests/functional/STATE.md
+++ b/tests/functional/STATE.md
@@ -1,0 +1,19 @@
+---
+branch: claude/laughing-lovelace-HmZOn
+current_run: 2026-05-30-pr53
+holder: executor
+---
+
+# Functional test run state
+
+`holder` is the narrative lock — only the holder pushes commits. Pass `holder`
+to the other LLM before pushing. The leading LLM (web) reads reports and writes
+verdicts; the executing LLM (local Claude Code CLI) runs scenarios and writes
+raw + report artifacts.
+
+| Scenario               | Status  | Last update |
+| ---------------------- | ------- | ----------- |
+| 01-namespace-readonly  | pending | -           |
+| 02-namespace-mixed     | pending | -           |
+| 03-single-readonly     | pending | -           |
+| 04-all-baseline        | pending | -           |

--- a/tests/functional/STATE.md
+++ b/tests/functional/STATE.md
@@ -1,7 +1,7 @@
 ---
 branch: claude/laughing-lovelace-HmZOn
 current_run: 2026-05-30-pr53
-holder: executor
+holder: leading
 ---
 
 # Functional test run state
@@ -13,7 +13,7 @@ raw + report artifacts.
 
 | Scenario               | Status  | Last update |
 | ---------------------- | ------- | ----------- |
-| 01-namespace-readonly  | pending | -           |
-| 02-namespace-mixed     | pending | -           |
-| 03-single-readonly     | pending | -           |
-| 04-all-baseline        | pending | -           |
+| 01-namespace-readonly  | OK      | 2026-06-06  |
+| 02-namespace-mixed     | OK      | 2026-06-06  |
+| 03-single-readonly     | OK      | 2026-06-06  |
+| 04-all-baseline        | OK      | 2026-06-06  |

--- a/tests/functional/bin/dump-tools-list.mjs
+++ b/tests/functional/bin/dump-tools-list.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..', '..');
+const serverEntry = resolve(repoRoot, 'dist', 'index.js');
+
+const parseArgs = (argv) => {
+  const out = { mode: undefined, readOnly: false, namespaces: [], tools: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--mode') out.mode = argv[++i];
+    else if (a === '--read-only') out.readOnly = true;
+    else if (a === '--namespace') out.namespaces.push(argv[++i]);
+    else if (a === '--tool') out.tools.push(argv[++i]);
+    else {
+      console.error(`Unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  if (!out.mode) {
+    console.error('Missing --mode <single|namespace|all>');
+    process.exit(2);
+  }
+  return out;
+};
+
+const die = (msg, code = 1) => {
+  console.error(msg);
+  process.exit(code);
+};
+
+const subdomain = process.env.ZENDESK_SUBDOMAIN;
+if (!subdomain) {
+  die(
+    'ZENDESK_SUBDOMAIN is not set. See the "Functional testing" section in AGENTS.md ' +
+      'for how to configure the reference Zendesk instance (fruggr) locally.',
+  );
+}
+if (!existsSync(serverEntry)) {
+  die(`Server bundle not found at ${serverEntry}. Run "pnpm build" first.`);
+}
+
+const opts = parseArgs(process.argv.slice(2));
+
+const serverArgs = [serverEntry, subdomain, '--mode', opts.mode];
+if (opts.readOnly) serverArgs.push('--read-only');
+for (const ns of opts.namespaces) serverArgs.push('--namespace', ns);
+for (const t of opts.tools) serverArgs.push('--tool', t);
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: serverArgs,
+  env: process.env,
+  stderr: 'inherit',
+});
+
+const client = new Client({ name: 'functional-test-dump', version: '0.0.0' });
+
+const timeout = setTimeout(() => {
+  die('Timed out after 30s waiting for tools/list.');
+}, 30_000);
+
+try {
+  await client.connect(transport);
+  const result = await client.listTools();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+} finally {
+  clearTimeout(timeout);
+  await client.close().catch(() => {});
+}

--- a/tests/functional/bin/dump-tools-list.mjs
+++ b/tests/functional/bin/dump-tools-list.mjs
@@ -9,14 +9,23 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..', '..', '..');
 const serverEntry = resolve(repoRoot, 'dist', 'index.js');
 
+const MODES = new Set(['single', 'namespace', 'all']);
+
 const parseArgs = (argv) => {
   const out = { mode: undefined, readOnly: false, namespaces: [], tools: [] };
+  const requireValue = (flag, value) => {
+    if (value === undefined) {
+      console.error(`Missing value for ${flag}`);
+      process.exit(2);
+    }
+    return value;
+  };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === '--mode') out.mode = argv[++i];
+    if (a === '--mode') out.mode = requireValue('--mode', argv[++i]);
     else if (a === '--read-only') out.readOnly = true;
-    else if (a === '--namespace') out.namespaces.push(argv[++i]);
-    else if (a === '--tool') out.tools.push(argv[++i]);
+    else if (a === '--namespace') out.namespaces.push(requireValue('--namespace', argv[++i]));
+    else if (a === '--tool') out.tools.push(requireValue('--tool', argv[++i]));
     else {
       console.error(`Unknown argument: ${a}`);
       process.exit(2);
@@ -24,6 +33,10 @@ const parseArgs = (argv) => {
   }
   if (!out.mode) {
     console.error('Missing --mode <single|namespace|all>');
+    process.exit(2);
+  }
+  if (!MODES.has(out.mode)) {
+    console.error(`Invalid --mode "${out.mode}". Expected one of: single, namespace, all.`);
     process.exit(2);
   }
   return out;

--- a/tests/functional/reports/01-namespace-readonly.raw.json
+++ b/tests/functional/reports/01-namespace-readonly.raw.json
@@ -1,0 +1,106 @@
+{
+  "tools": [
+    {
+      "name": "zendesk_tickets",
+      "title": "Zendesk Tickets",
+      "description": "[RO] Zendesk Tickets. Specify the operation and its parameters.\n\nAvailable operations:\n- **get_ticket**: Retrieve a Zendesk ticket by ID, including its comments if requested.\n- **get_ticket_attachments**: Retrieve ticket attachments.\n- **search_tickets**: Search tickets using Zendesk query syntax (e.g., \"status:open assignee:me\", \"priority:urgent type:incident\").\n- **list_tickets**: List tickets with cursor-based pagination, sorted by most recently updated.\n- **get_linked_incidents**: Get all incident tickets linked to a problem ticket.\n- **search**: Search across tickets, users, and organizations.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "description": "One of: get_ticket, get_ticket_attachments, search_tickets, list_tickets, get_linked_incidents, search"
+          },
+          "params": {
+            "default": {},
+            "description": "Operation parameters",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": ["operation"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "zendesk_help_center",
+      "title": "Zendesk Help Center",
+      "description": "[RO] Zendesk Help Center. Specify the operation and its parameters.\n\nAvailable operations:\n- **search_articles**: Full-text search across Help Center articles (metadata only, no body).\n- **get_article**: Retrieve an article by ID with full body content.\n- **list_categories**: List all Help Center categories.\n- **list_sections**: List sections, optionally filtered by category ID and locale.\n- **list_articles**: List articles (metadata only, no body).\n- **list_article_translations**: List all available translations for an article (metadata only, no body: locale, title, draft, updated_at).\n- **list_permission_groups**: List all Guide permission groups.\n- **list_content_tags**: List all Guide content tags.\n- **list_labels**: List all article labels.\n- **list_user_segments**: List all user segments.\n- **list_article_attachments**: List all attachments for an article.\n- **get_article_outline**: Return a compact outline of an article (list of sections delimited by h1/h2/h3, with word counts) for the given locale (defaults to source_locale).\n- **get_article_section**: Retrieve the content of a single section of an article in a given locale.\n- **compare_translations**: Compare section structure between two locales of the same article, matched by index.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "description": "One of: search_articles, get_article, list_categories, list_sections, list_articles, list_article_translations, list_permission_groups, list_content_tags, list_labels, list_user_segments, list_article_attachments, get_article_outline, get_article_section, compare_translations"
+          },
+          "params": {
+            "default": {},
+            "description": "Operation parameters",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": ["operation"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "zendesk_users",
+      "title": "Zendesk Users",
+      "description": "[RO] Zendesk Users. Specify the operation and its parameters.\n\nAvailable operations:\n- **get_current_user**: Get the currently authenticated Zendesk user.\n- **search_users**: Search for users by name, email, or other criteria using Zendesk search query syntax.\n- **get_user**: Retrieve a user by ID.\n- **get_organization**: Retrieve an organization by ID.\n- **list_organizations**: List all organizations with pagination.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "description": "One of: get_current_user, search_users, get_user, get_organization, list_organizations"
+          },
+          "params": {
+            "default": {},
+            "description": "Operation parameters",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": ["operation"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    }
+  ]
+}

--- a/tests/functional/reports/01-namespace-readonly.report.md
+++ b/tests/functional/reports/01-namespace-readonly.report.md
@@ -1,0 +1,33 @@
+# Report — 01-namespace-readonly
+
+Mode `namespace --read-only`. Dumped `tools/list` via
+`bin/dump-tools-list.mjs` into `01-namespace-readonly.raw.json`. The server
+registered 25 underlying read-only tools (stderr log) and exposed **3 proxy
+tools**. Each proxy carries the aggregated read-only annotation set and a
+`[RO] ` description prefix.
+
+Observations (verbatim from `raw.json`):
+
+- `.tools[]` length = 3 → `zendesk_tickets`, `zendesk_help_center`, `zendesk_users`.
+- All three annotations objects are identical:
+  `{ readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true }`.
+- All three descriptions begin with the literal `"[RO] "`.
+
+```json
+{
+  "scenario": "01-namespace-readonly",
+  "mode": "namespace",
+  "readOnly": true,
+  "branch": "claude/laughing-lovelace-HmZOn",
+  "assertions": [
+    { "id": "A1", "desc": "tools/list returns exactly 3 entries",                          "pass": true, "actual": "3 entries" },
+    { "id": "A2", "desc": "tool names are {zendesk_tickets, zendesk_help_center, zendesk_users}", "pass": true, "actual": "zendesk_tickets, zendesk_help_center, zendesk_users" },
+    { "id": "A3", "desc": "every tool has annotations.readOnlyHint === true",              "pass": true, "actual": "all 3 readOnlyHint=true" },
+    { "id": "A4", "desc": "every tool has annotations.destructiveHint === false",          "pass": true, "actual": "all 3 destructiveHint=false" },
+    { "id": "A5", "desc": "every tool has annotations.idempotentHint === true",            "pass": true, "actual": "all 3 idempotentHint=true" },
+    { "id": "A6", "desc": "every tool has annotations.openWorldHint === true",             "pass": true, "actual": "all 3 openWorldHint=true" },
+    { "id": "A7", "desc": "every tool description starts with the literal '[RO] '",        "pass": true, "actual": "all 3 descriptions start with '[RO] '" }
+  ],
+  "summary": "green — 3 read-only proxies, aggregated read-only annotations, [RO] prefix on all"
+}
+```

--- a/tests/functional/reports/01-namespace-readonly.verdict.md
+++ b/tests/functional/reports/01-namespace-readonly.verdict.md
@@ -1,0 +1,20 @@
+# Verdict — 01-namespace-readonly
+
+| ID  | Status | Notes                                                                 |
+| --- | ------ | --------------------------------------------------------------------- |
+| A1  | OK     | `.tools.length === 3`.                                                |
+| A2  | OK     | Set equality with {zendesk_tickets, zendesk_help_center, zendesk_users}. |
+| A3  | OK     | `readOnlyHint === true` on all 3 (`raw.json` `.tools[*].annotations`). |
+| A4  | OK     | `destructiveHint === false` on all 3.                                 |
+| A5  | OK     | `idempotentHint === true` on all 3.                                   |
+| A6  | OK     | `openWorldHint === true` on all 3.                                    |
+| A7  | OK     | All 3 descriptions start with the literal `[RO] ` (bracket-R-O-bracket-space). |
+
+## Summary
+
+🟢 All 7 assertions pass. `--mode namespace --read-only` exposes 3 read-only
+proxies with correctly aggregated annotations and the `[RO] ` prefix.
+
+## Proposed actions
+
+None — scenario closed `OK`.

--- a/tests/functional/reports/02-namespace-mixed.raw.json
+++ b/tests/functional/reports/02-namespace-mixed.raw.json
@@ -1,0 +1,106 @@
+{
+  "tools": [
+    {
+      "name": "zendesk_tickets",
+      "title": "Zendesk Tickets",
+      "description": "Zendesk Tickets. Specify the operation and its parameters.\n\nAvailable operations:\n- **get_ticket**: Retrieve a Zendesk ticket by ID, including its comments if requested.\n- **get_ticket_attachments**: Retrieve ticket attachments.\n- **search_tickets**: Search tickets using Zendesk query syntax (e.g., \"status:open assignee:me\", \"priority:urgent type:incident\").\n- **create_ticket**: Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags. (write)\n- **update_ticket**: Update an existing ticket (status, priority, type, assignee, group, subject, tags, custom fields). (write)\n- **add_private_note**: Add an internal note (not visible to requester) to a ticket. (write)\n- **add_public_comment**: Add a public comment (visible to requester) to a ticket. (write)\n- **list_tickets**: List tickets with cursor-based pagination, sorted by most recently updated.\n- **get_linked_incidents**: Get all incident tickets linked to a problem ticket.\n- **manage_tags**: Add or remove tags on a ticket. (write)\n- **search**: Search across tickets, users, and organizations.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "description": "One of: get_ticket, get_ticket_attachments, search_tickets, create_ticket, update_ticket, add_private_note, add_public_comment, list_tickets, get_linked_incidents, manage_tags, search"
+          },
+          "params": {
+            "default": {},
+            "description": "Operation parameters",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": ["operation"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "zendesk_help_center",
+      "title": "Zendesk Help Center",
+      "description": "Zendesk Help Center. Specify the operation and its parameters.\n\nAvailable operations:\n- **search_articles**: Full-text search across Help Center articles (metadata only, no body).\n- **get_article**: Retrieve an article by ID with full body content.\n- **list_categories**: List all Help Center categories.\n- **list_sections**: List sections, optionally filtered by category ID and locale.\n- **list_articles**: List articles (metadata only, no body).\n- **list_article_translations**: List all available translations for an article (metadata only, no body: locale, title, draft, updated_at).\n- **create_article_translation**: Create a translation for an existing article in a specific locale. (write)\n- **update_article_translation**: Update article content (title, body) in a specific locale. (write)\n- **list_permission_groups**: List all Guide permission groups.\n- **create_article**: Create a new article in a section. (write)\n- **update_article**: Update article metadata only (draft, promoted, labels, tags, visibility, section, sort position, etc.). (write)\n- **list_content_tags**: List all Guide content tags.\n- **create_content_tag**: Create a new content tag for Guide articles. (write)\n- **list_labels**: List all article labels.\n- **list_user_segments**: List all user segments.\n- **list_article_attachments**: List all attachments for an article.\n- **get_article_outline**: Return a compact outline of an article (list of sections delimited by h1/h2/h3, with word counts) for the given locale (defaults to source_locale).\n- **get_article_section**: Retrieve the content of a single section of an article in a given locale.\n- **update_article_section**: Replace the content of a single section of an article in a given locale, keeping the rest of the body intact. (write)\n- **compare_translations**: Compare section structure between two locales of the same article, matched by index.\n- **create_article_attachment**: Upload an attachment to an article. (write)",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "description": "One of: search_articles, get_article, list_categories, list_sections, list_articles, list_article_translations, create_article_translation, update_article_translation, list_permission_groups, create_article, update_article, list_content_tags, create_content_tag, list_labels, list_user_segments, list_article_attachments, get_article_outline, get_article_section, update_article_section, compare_translations, create_article_attachment"
+          },
+          "params": {
+            "default": {},
+            "description": "Operation parameters",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": ["operation"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "zendesk_users",
+      "title": "Zendesk Users",
+      "description": "Zendesk Users. Specify the operation and its parameters.\n\nAvailable operations:\n- **get_current_user**: Get the currently authenticated Zendesk user.\n- **search_users**: Search for users by name, email, or other criteria using Zendesk search query syntax.\n- **get_user**: Retrieve a user by ID.\n- **get_organization**: Retrieve an organization by ID.\n- **list_organizations**: List all organizations with pagination.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "description": "One of: get_current_user, search_users, get_user, get_organization, list_organizations"
+          },
+          "params": {
+            "default": {},
+            "description": "Operation parameters",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": ["operation"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    }
+  ]
+}

--- a/tests/functional/reports/02-namespace-mixed.report.md
+++ b/tests/functional/reports/02-namespace-mixed.report.md
@@ -1,0 +1,34 @@
+# Report — 02-namespace-mixed
+
+Mode `namespace` (no `--read-only`). Dumped `tools/list` into
+`02-namespace-mixed.raw.json`. The server registered 37 underlying tools and
+exposed **3 proxy tools**. No `[RO] ` prefix anywhere. Annotations aggregate
+per namespace: a namespace with at least one write op reports
+`readOnlyHint=false, destructiveHint=true`; an all-read namespace
+(`zendesk_users`) keeps `readOnlyHint=true, destructiveHint=false`.
+
+Observations (verbatim from `raw.json`):
+
+- `.tools[]` length = 3.
+- `zendesk_tickets`: `{ readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }`.
+- `zendesk_help_center`: `{ readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }`.
+- `zendesk_users`: `{ readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true }`.
+- No description begins with `"[RO] "`.
+
+```json
+{
+  "scenario": "02-namespace-mixed",
+  "mode": "namespace",
+  "readOnly": false,
+  "branch": "claude/laughing-lovelace-HmZOn",
+  "assertions": [
+    { "id": "A1", "desc": "tools/list returns exactly 3 entries",                                       "pass": true, "actual": "3 entries" },
+    { "id": "A2", "desc": "zendesk_tickets has readOnlyHint=false and destructiveHint=true",            "pass": true, "actual": "readOnlyHint=false, destructiveHint=true" },
+    { "id": "A3", "desc": "zendesk_help_center has readOnlyHint=false and destructiveHint=true",        "pass": true, "actual": "readOnlyHint=false, destructiveHint=true" },
+    { "id": "A4", "desc": "zendesk_users has readOnlyHint=true and destructiveHint=false",              "pass": true, "actual": "readOnlyHint=true, destructiveHint=false" },
+    { "id": "A5", "desc": "every tool has openWorldHint=true",                                          "pass": true, "actual": "all 3 openWorldHint=true" },
+    { "id": "A6", "desc": "no tool description starts with '[RO] '",                                    "pass": true, "actual": "0 of 3 descriptions have the [RO] prefix" }
+  ],
+  "summary": "green — 3 proxies, write namespaces destructive, users read-only, no [RO] prefix"
+}
+```

--- a/tests/functional/reports/02-namespace-mixed.verdict.md
+++ b/tests/functional/reports/02-namespace-mixed.verdict.md
@@ -1,0 +1,21 @@
+# Verdict — 02-namespace-mixed
+
+| ID  | Status | Notes                                                                          |
+| --- | ------ | ------------------------------------------------------------------------------ |
+| A1  | OK     | `.tools.length === 3`, names {zendesk_tickets, zendesk_help_center, zendesk_users}. |
+| A2  | OK     | `zendesk_tickets`: `readOnlyHint=false`, `destructiveHint=true` (aggregates writes). |
+| A3  | OK     | `zendesk_help_center`: `readOnlyHint=false`, `destructiveHint=true`.           |
+| A4  | OK     | `zendesk_users`: `readOnlyHint=true`, `destructiveHint=false` — load-bearing `every`/`some` aggregation confirmed. |
+| A5  | OK     | `openWorldHint === true` on all 3.                                             |
+| A6  | OK     | No description carries the `[RO] ` prefix (0 of 3).                             |
+
+## Summary
+
+🟢 All 6 assertions pass. `--mode namespace` (no `--read-only`) aggregates
+annotations per namespace correctly: write-bearing namespaces are destructive,
+the all-read `zendesk_users` namespace stays read-only, and no `[RO] ` prefix
+leaks outside read-only mode.
+
+## Proposed actions
+
+None — scenario closed `OK`.

--- a/tests/functional/reports/03-single-readonly.raw.json
+++ b/tests/functional/reports/03-single-readonly.raw.json
@@ -1,0 +1,38 @@
+{
+  "tools": [
+    {
+      "name": "zendesk",
+      "title": "Zendesk",
+      "description": "[RO] Zendesk. Specify the operation and its parameters.\n\nAvailable operations:\n- **get_ticket**: Retrieve a Zendesk ticket by ID, including its comments if requested.\n- **get_ticket_attachments**: Retrieve ticket attachments.\n- **search_tickets**: Search tickets using Zendesk query syntax (e.g., \"status:open assignee:me\", \"priority:urgent type:incident\").\n- **list_tickets**: List tickets with cursor-based pagination, sorted by most recently updated.\n- **get_linked_incidents**: Get all incident tickets linked to a problem ticket.\n- **search**: Search across tickets, users, and organizations.\n- **search_articles**: Full-text search across Help Center articles (metadata only, no body).\n- **get_article**: Retrieve an article by ID with full body content.\n- **list_categories**: List all Help Center categories.\n- **list_sections**: List sections, optionally filtered by category ID and locale.\n- **list_articles**: List articles (metadata only, no body).\n- **list_article_translations**: List all available translations for an article (metadata only, no body: locale, title, draft, updated_at).\n- **list_permission_groups**: List all Guide permission groups.\n- **list_content_tags**: List all Guide content tags.\n- **list_labels**: List all article labels.\n- **list_user_segments**: List all user segments.\n- **list_article_attachments**: List all attachments for an article.\n- **get_article_outline**: Return a compact outline of an article (list of sections delimited by h1/h2/h3, with word counts) for the given locale (defaults to source_locale).\n- **get_article_section**: Retrieve the content of a single section of an article in a given locale.\n- **compare_translations**: Compare section structure between two locales of the same article, matched by index.\n- **get_current_user**: Get the currently authenticated Zendesk user.\n- **search_users**: Search for users by name, email, or other criteria using Zendesk search query syntax.\n- **get_user**: Retrieve a user by ID.\n- **get_organization**: Retrieve an organization by ID.\n- **list_organizations**: List all organizations with pagination.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "description": "One of: get_ticket, get_ticket_attachments, search_tickets, list_tickets, get_linked_incidents, search, search_articles, get_article, list_categories, list_sections, list_articles, list_article_translations, list_permission_groups, list_content_tags, list_labels, list_user_segments, list_article_attachments, get_article_outline, get_article_section, compare_translations, get_current_user, search_users, get_user, get_organization, list_organizations"
+          },
+          "params": {
+            "default": {},
+            "description": "Operation parameters",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "required": ["operation"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    }
+  ]
+}

--- a/tests/functional/reports/03-single-readonly.report.md
+++ b/tests/functional/reports/03-single-readonly.report.md
@@ -1,0 +1,32 @@
+# Report — 03-single-readonly
+
+Mode `single --read-only`. Dumped `tools/list` into
+`03-single-readonly.raw.json`. The server registered 25 underlying read-only
+tools and exposed **1 proxy tool** named `zendesk`, aggregating all read ops
+with a `[RO] ` description prefix.
+
+Observations (verbatim from `raw.json`):
+
+- `.tools[]` length = 1.
+- `.tools[0].name` = `"zendesk"`.
+- `.tools[0].annotations` = `{ readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true }`.
+- `.tools[0].description` begins with `"[RO] "`.
+
+```json
+{
+  "scenario": "03-single-readonly",
+  "mode": "single",
+  "readOnly": true,
+  "branch": "claude/laughing-lovelace-HmZOn",
+  "assertions": [
+    { "id": "A1", "desc": "tools/list returns exactly 1 entry",                  "pass": true, "actual": "1 entry" },
+    { "id": "A2", "desc": "the tool name is exactly 'zendesk'",                  "pass": true, "actual": "zendesk" },
+    { "id": "A3", "desc": "annotations.readOnlyHint === true",                   "pass": true, "actual": "readOnlyHint=true" },
+    { "id": "A4", "desc": "annotations.destructiveHint === false",               "pass": true, "actual": "destructiveHint=false" },
+    { "id": "A5", "desc": "annotations.idempotentHint === true",                 "pass": true, "actual": "idempotentHint=true" },
+    { "id": "A6", "desc": "annotations.openWorldHint === true",                  "pass": true, "actual": "openWorldHint=true" },
+    { "id": "A7", "desc": "description starts with the literal '[RO] '",        "pass": true, "actual": "description starts with '[RO] '" }
+  ],
+  "summary": "green — single 'zendesk' proxy, read-only annotations, [RO] prefix"
+}
+```

--- a/tests/functional/reports/03-single-readonly.verdict.md
+++ b/tests/functional/reports/03-single-readonly.verdict.md
@@ -1,0 +1,21 @@
+# Verdict — 03-single-readonly
+
+| ID  | Status | Notes                                                            |
+| --- | ------ | ---------------------------------------------------------------- |
+| A1  | OK     | `.tools.length === 1`.                                           |
+| A2  | OK     | `.tools[0].name === 'zendesk'`.                                  |
+| A3  | OK     | `readOnlyHint === true`.                                         |
+| A4  | OK     | `destructiveHint === false`.                                     |
+| A5  | OK     | `idempotentHint === true`.                                       |
+| A6  | OK     | `openWorldHint === true`.                                        |
+| A7  | OK     | Description starts with the literal `[RO] `.                     |
+
+## Summary
+
+🟢 All 7 assertions pass. `--mode single --read-only` exposes one `zendesk`
+proxy aggregating all read ops, with read-only annotations and the `[RO] `
+prefix.
+
+## Proposed actions
+
+None — scenario closed `OK`.

--- a/tests/functional/reports/04-all-baseline.raw.json
+++ b/tests/functional/reports/04-all-baseline.raw.json
@@ -1,0 +1,1385 @@
+{
+  "tools": [
+    {
+      "name": "get_ticket",
+      "title": "Get Zendesk Ticket",
+      "description": "Retrieve a Zendesk ticket by ID, including its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "include_comments": {
+            "default": false,
+            "description": "Include ticket comments",
+            "type": "boolean"
+          }
+        },
+        "required": ["ticket_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_ticket_attachments",
+      "title": "Get Zendesk Ticket Attachments",
+      "description": "Retrieve ticket attachments. Images are embedded inline; other files are listed as text references.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "attachment_ids": {
+            "description": "Attachment IDs to fetch directly (e.g. extracted from a previous get_ticket(include_comments=true) call). When provided, skips the comments fetch entirely. When omitted, all attachments of the ticket are returned.",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          }
+        },
+        "required": ["ticket_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "search_tickets",
+      "title": "Search Zendesk Tickets",
+      "description": "Search tickets using Zendesk query syntax (e.g., \"status:open assignee:me\", \"priority:urgent type:incident\"). Returns total count.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Zendesk search query string"
+          },
+          "per_page": {
+            "default": 100,
+            "description": "Results per page",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["query"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_ticket",
+      "title": "Create Zendesk Ticket",
+      "description": "Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "subject": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Ticket subject"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Ticket description"
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["urgent", "high", "normal", "low"]
+          },
+          "type": {
+            "type": "string",
+            "enum": ["problem", "incident", "question", "task"]
+          },
+          "assignee_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "group_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "custom_fields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "value": {}
+              },
+              "required": ["id", "value"]
+            }
+          }
+        },
+        "required": ["subject", "description"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "update_ticket",
+      "title": "Update Zendesk Ticket",
+      "description": "Update an existing ticket (status, priority, type, assignee, group, subject, tags, custom fields).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["new", "open", "pending", "hold", "solved", "closed"]
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["urgent", "high", "normal", "low"]
+          },
+          "type": {
+            "type": "string",
+            "enum": ["problem", "incident", "question", "task"]
+          },
+          "assignee_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "group_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "subject": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "custom_fields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "value": {}
+              },
+              "required": ["id", "value"]
+            }
+          }
+        },
+        "required": ["ticket_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "add_private_note",
+      "title": "Add Private Note",
+      "description": "Add an internal note (not visible to requester) to a ticket.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Note content"
+          }
+        },
+        "required": ["ticket_id", "body"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "add_public_comment",
+      "title": "Add Public Comment",
+      "description": "Add a public comment (visible to requester) to a ticket.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Comment content"
+          }
+        },
+        "required": ["ticket_id", "body"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_tickets",
+      "title": "List Zendesk Tickets",
+      "description": "List tickets with cursor-based pagination, sorted by most recently updated.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "page_size": {
+            "default": 100,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "description": "Pagination cursor",
+            "type": "string"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_linked_incidents",
+      "title": "Get Linked Incidents",
+      "description": "Get all incident tickets linked to a problem ticket.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "problem_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Problem ticket ID"
+          }
+        },
+        "required": ["problem_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "manage_tags",
+      "title": "Manage Ticket Tags",
+      "description": "Add or remove tags on a ticket.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "add": {
+            "description": "Tags to add",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "remove": {
+            "description": "Tags to remove",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["ticket_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "search",
+      "title": "Zendesk Unified Search",
+      "description": "Search across tickets, users, and organizations. Supports filters like \"type:ticket status:open\", \"type:user role:agent\". Returns total count and paginated results (100 per page). Organization results include name and ID only — use get_organization for full details (tags, domains, details).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Zendesk search query"
+          },
+          "per_page": {
+            "default": 100,
+            "description": "Results per page (max 100)",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number (1-based)",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["query"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "search_articles",
+      "title": "Search Help Center Articles",
+      "description": "Full-text search across Help Center articles (metadata only, no body). Use get_article for full content. Supports locale filtering. Returns total count.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Search query"
+          },
+          "locale": {
+            "description": "Filter by locale (e.g., \"en-us\", \"fr\")",
+            "type": "string"
+          },
+          "per_page": {
+            "default": 100,
+            "description": "Results per page",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["query"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_article",
+      "title": "Get Help Center Article",
+      "description": "Retrieve an article by ID with full body content. For large articles, prefer get_article_outline + get_article_section to save tokens. Optionally specify locale for a translated version. Returns body (HTML), metadata, source_locale, and list of available translations.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "locale": {
+            "description": "Locale for translated version",
+            "type": "string"
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_categories",
+      "title": "List Help Center Categories",
+      "description": "List all Help Center categories. Optionally filter by locale.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string"
+          },
+          "page_size": {
+            "default": 100,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "type": "string"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_sections",
+      "title": "List Help Center Sections",
+      "description": "List sections, optionally filtered by category ID and locale.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "category_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "locale": {
+            "type": "string"
+          },
+          "page_size": {
+            "default": 100,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "type": "string"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_articles",
+      "title": "List Help Center Articles",
+      "description": "List articles (metadata only, no body). Use get_article for full content. Optionally filter by section ID and locale. Supports sort_by (\"title\", \"created_at\", \"updated_at\") and include_translations: true to show available translation locales per article. Note: include_translations must be re-sent on each paginated request.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "section_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "locale": {
+            "type": "string"
+          },
+          "page_size": {
+            "default": 100,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "type": "string"
+          },
+          "sort_by": {
+            "default": "position",
+            "description": "Sort field",
+            "type": "string",
+            "enum": ["created_at", "updated_at", "position", "title"]
+          },
+          "sort_order": {
+            "default": "asc",
+            "description": "Sort direction",
+            "type": "string",
+            "enum": ["asc", "desc"]
+          },
+          "include_translations": {
+            "default": false,
+            "description": "Include available translation locales per article (causes 1 extra API call per article)",
+            "type": "boolean"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_article_translations",
+      "title": "List Article Translations",
+      "description": "List all available translations for an article (metadata only, no body: locale, title, draft, updated_at). Use get_article with locale for full translated content.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_article_translation",
+      "title": "Create Article Translation",
+      "description": "Create a translation for an existing article in a specific locale.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "locale": {
+            "type": "string",
+            "description": "Target locale (e.g., \"fr\", \"de\")"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Translated body (HTML)"
+          },
+          "draft": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": ["article_id", "locale", "title", "body"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "update_article_translation",
+      "title": "Update Article Translation",
+      "description": "Update article content (title, body) in a specific locale. For targeted edits on one or a few sections, prefer update_article_section — this tool replaces the FULL body and re-sends the entire article on each write. Use the article's source_locale (from get_article) for the default language, or another locale for translations.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "locale": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "draft": {
+            "type": "boolean"
+          }
+        },
+        "required": ["article_id", "locale"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_permission_groups",
+      "title": "List Permission Groups",
+      "description": "List all Guide permission groups. Use this to find the permission_group_id required when creating articles.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_article",
+      "title": "Create Help Center Article",
+      "description": "Create a new article in a section. The locale becomes the article's source_locale. Requires a permission_group_id (use list_permission_groups to find available IDs). To add content in other locales afterwards, use create_article_translation.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "section_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Article body (HTML)"
+          },
+          "permission_group_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Permission group ID (use list_permission_groups to find it)"
+          },
+          "user_segment_id": {
+            "description": "User segment ID for visibility (use list_user_segments to find it). Defaults to everyone.",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "author_id": {
+            "description": "Author user ID. Defaults to the authenticated user.",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "content_tag_ids": {
+            "description": "Content tag IDs (use list_content_tags to find them)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "locale": {
+            "type": "string"
+          },
+          "draft": {
+            "default": true,
+            "type": "boolean"
+          },
+          "promoted": {
+            "default": false,
+            "type": "boolean"
+          },
+          "label_names": {
+            "description": "Label names for search ranking (use list_labels to see existing labels)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["section_id", "title", "body", "permission_group_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "update_article",
+      "title": "Update Help Center Article",
+      "description": "Update article metadata only (draft, promoted, labels, tags, visibility, section, sort position, etc.). Does NOT update content (title, body) — use update_article_translation for that.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "promoted": {
+            "type": "boolean"
+          },
+          "label_names": {
+            "description": "Label names for search ranking",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "content_tag_ids": {
+            "description": "Content tag IDs",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "user_segment_id": {
+            "description": "User segment ID for visibility",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "author_id": {
+            "description": "Author user ID",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "permission_group_id": {
+            "description": "Permission group ID",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "section_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "position": {
+            "description": "Sort position within the section (manual ordering only; 0 = first/top). New articles default to position 0. To move an article to the END of its section, set this to one more than the highest current position: read the highest position P from list_articles with sort_by=\"position\", sort_order=\"desc\", then set position = P + 1.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_content_tags",
+      "title": "List Content Tags",
+      "description": "List all Guide content tags. Content tags are visible to end users and help them find related articles.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_content_tag",
+      "title": "Create Content Tag",
+      "description": "Create a new content tag for Guide articles.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Content tag name"
+          }
+        },
+        "required": ["name"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_labels",
+      "title": "List Article Labels",
+      "description": "List all article labels. Labels improve Help Center search ranking and are not visible to end users.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_user_segments",
+      "title": "List User Segments",
+      "description": "List all user segments. User segments control article visibility (who can view). Use the ID when creating or updating articles.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_article_attachments",
+      "title": "List Article Attachments",
+      "description": "List all attachments for an article.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_article_outline",
+      "title": "Get Article Outline",
+      "description": "Return a compact outline of an article (list of sections delimited by h1/h2/h3, with word counts) for the given locale (defaults to source_locale). Includes available translations with their outdated status. Use get_article_section to fetch a specific section.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "locale": {
+            "description": "Locale of the body to outline (defaults to article source_locale)",
+            "type": "string"
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_article_section",
+      "title": "Get Article Section",
+      "description": "Retrieve the content of a single section of an article in a given locale. Use get_article_outline first to discover section indexes. Default format=\"html\" for round-trip safety. Pass format=\"markdown\" only for human review — the Markdown representation is lossy on some structures (<pre> with <br>, tables with multi-<p> cells are kept as raw HTML to limit the damage, but do not round-trip markdown content back through update_article_section).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "locale": {
+            "type": "string",
+            "description": "Locale of the body (e.g., \"en-us\", \"fr\")"
+          },
+          "section_index": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991,
+            "description": "0-based index of the section (see get_article_outline)"
+          },
+          "format": {
+            "default": "html",
+            "description": "Output format. \"html\" (default) is round-trip safe. \"markdown\" is lossy on some HTML structures — use only for human review, not before update_article_section.",
+            "type": "string",
+            "enum": ["html", "markdown"]
+          }
+        },
+        "required": ["article_id", "locale", "section_index"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "update_article_section",
+      "title": "Update Article Section",
+      "description": "Replace the content of a single section of an article in a given locale, keeping the rest of the body intact. The server fetches the current body, replaces the targeted section, and PUTs the full reconstructed body via the Translations API. Default format=\"html\" for fidelity. Use format=\"markdown\" only when you control the input and know it does not rely on structures that round-trip poorly (code blocks with line breaks, tables with multi-paragraph cells). The section heading is preserved and is NOT part of the replaced content.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "locale": {
+            "type": "string",
+            "description": "Locale of the translation to update"
+          },
+          "section_index": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991,
+            "description": "0-based index of the section to replace (see get_article_outline)"
+          },
+          "content": {
+            "type": "string",
+            "description": "New content for the section (heading excluded). HTML by default, Markdown if format=\"markdown\"."
+          },
+          "format": {
+            "default": "html",
+            "description": "Input format. \"html\" (default) is the safe path. \"markdown\" is converted to HTML server-side but may introduce artifacts on complex content.",
+            "type": "string",
+            "enum": ["html", "markdown"]
+          }
+        },
+        "required": ["article_id", "locale", "section_index", "content"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "compare_translations",
+      "title": "Compare Article Translations",
+      "description": "Compare section structure between two locales of the same article, matched by index. Returns a compact table (one row per section) with status: \"ok\" (both present, source/target word count ratio within 25%), \"different\" (word count ratio diverges by more than 25% — size signal only, NOT a semantic divergence: two locales may legitimately differ in verbosity) or \"missing\" (section absent in target). Useful to spot structurally stale or missing sections; do not interpret \"different\" as an edit regression on its own.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "source_locale": {
+            "type": "string",
+            "description": "Source (reference) locale"
+          },
+          "target_locale": {
+            "type": "string",
+            "description": "Target locale to compare against source"
+          }
+        },
+        "required": ["article_id", "source_locale", "target_locale"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_article_attachment",
+      "title": "Create Article Attachment",
+      "description": "Upload an attachment to an article. Provide file content as base64-encoded string.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "file_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "File name (e.g., \"screenshot.png\")"
+          },
+          "file_base64": {
+            "type": "string",
+            "minLength": 1,
+            "description": "File content encoded as base64"
+          },
+          "content_type": {
+            "default": "application/octet-stream",
+            "description": "MIME type (e.g., \"image/png\", \"application/pdf\")",
+            "type": "string"
+          }
+        },
+        "required": ["article_id", "file_name", "file_base64"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_current_user",
+      "title": "Get Current Zendesk User",
+      "description": "Get the currently authenticated Zendesk user. Useful to verify identity and permissions.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "search_users",
+      "title": "Search Zendesk Users",
+      "description": "Search for users by name, email, or other criteria using Zendesk search query syntax. Returns total count.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Search query"
+          },
+          "per_page": {
+            "default": 100,
+            "description": "Results per page",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["query"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_user",
+      "title": "Get Zendesk User",
+      "description": "Retrieve a user by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "User ID"
+          }
+        },
+        "required": ["user_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_organization",
+      "title": "Get Zendesk Organization",
+      "description": "Retrieve an organization by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organization_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Organization ID"
+          }
+        },
+        "required": ["organization_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_organizations",
+      "title": "List Zendesk Organizations",
+      "description": "List all organizations with pagination.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "page_size": {
+            "default": 100,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "type": "string"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    }
+  ]
+}

--- a/tests/functional/reports/04-all-baseline.report.md
+++ b/tests/functional/reports/04-all-baseline.report.md
@@ -1,0 +1,33 @@
+# Report — 04-all-baseline
+
+Mode `all`. Dumped `tools/list` into `04-all-baseline.raw.json`. The server
+registered and exposed **37 individual tools**, each with its own non-empty
+`annotations` object intact. No proxy, no `[RO] ` prefix anywhere — flat mode
+is not regressed by PR #53.
+
+Observations (verbatim from `raw.json`):
+
+- `.tools[]` length = 37.
+- 0 entries have an empty/missing `annotations` object (all 37 non-empty).
+- All 37 entries have `openWorldHint=true`.
+- `get_current_user`: `{ readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: true }`.
+- `manage_tags`: `{ readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true }` → `destructiveHint=true`.
+- 0 descriptions begin with `"[RO] "`.
+
+```json
+{
+  "scenario": "04-all-baseline",
+  "mode": "all",
+  "readOnly": false,
+  "branch": "claude/laughing-lovelace-HmZOn",
+  "assertions": [
+    { "id": "A1", "desc": "tools/list returns exactly 37 entries",                                   "pass": true, "actual": "37 entries" },
+    { "id": "A2", "desc": "every entry has a non-empty annotations object",                          "pass": true, "actual": "0 of 37 entries have empty/missing annotations" },
+    { "id": "A3", "desc": "every entry has openWorldHint=true",                                      "pass": true, "actual": "all 37 openWorldHint=true" },
+    { "id": "A4", "desc": "get_current_user has readOnlyHint=true and destructiveHint=false",        "pass": true, "actual": "readOnlyHint=true, destructiveHint=false" },
+    { "id": "A5", "desc": "manage_tags has destructiveHint=true",                                    "pass": true, "actual": "destructiveHint=true" },
+    { "id": "A6", "desc": "no description starts with '[RO] '",                                      "pass": true, "actual": "0 of 37 descriptions have the [RO] prefix" }
+  ],
+  "summary": "green — 37 flat tools, every annotations object intact, no [RO] prefix"
+}
+```

--- a/tests/functional/reports/04-all-baseline.verdict.md
+++ b/tests/functional/reports/04-all-baseline.verdict.md
@@ -1,0 +1,20 @@
+# Verdict — 04-all-baseline
+
+| ID  | Status | Notes                                                                       |
+| --- | ------ | --------------------------------------------------------------------------- |
+| A1  | OK     | `.tools.length === 37` (10 tickets + 21 Help Center + 5 user/org + 1 search). |
+| A2  | OK     | All 37 entries have a populated `annotations` object (0 empty/missing).      |
+| A3  | OK     | `openWorldHint === true` on all 37.                                          |
+| A4  | OK     | `get_current_user`: `readOnlyHint=true`, `destructiveHint=false`.            |
+| A5  | OK     | `manage_tags.destructiveHint === true` (no regression of commit `10d846b`).  |
+| A6  | OK     | No description carries the `[RO] ` prefix (0 of 37).                          |
+
+## Summary
+
+🟢 All 6 assertions pass. `--mode all` flat baseline is intact — 37 individual
+tools, each with its own annotations object, no proxy and no `[RO] ` prefix.
+PR #53 does not regress flat mode.
+
+## Proposed actions
+
+None — scenario closed `OK`.

--- a/tests/functional/scenarios/01-namespace-readonly/expected.md
+++ b/tests/functional/scenarios/01-namespace-readonly/expected.md
@@ -1,0 +1,24 @@
+# ⚠️ LEADING LLM ONLY — DO NOT READ IF YOU ARE THE EXECUTOR
+
+Reading this file biases the report. Stop now and read only `spec.md`.
+
+---
+
+## Expected values (verdict criteria)
+
+- **A1 — count.** `result.tools.length === 3`.
+- **A2 — names.** Set equality with `{"zendesk_tickets", "zendesk_help_center", "zendesk_users"}`. Order is irrelevant.
+- **A3 — readOnlyHint.** `true` on all 3.
+- **A4 — destructiveHint.** `false` on all 3. (Aggregation: `some` of zero destructive ops is `false`. In read-only mode, every sub-tool is read-only by construction.)
+- **A5 — idempotentHint.** `true` on all 3. (Every read op is idempotent.)
+- **A6 — openWorldHint.** `true` on all 3 (hard-coded in `aggregateAnnotations`).
+- **A7 — `[RO] ` prefix.** Every description must literally start with the 5
+  characters `[` `R` `O` `]` ` ` (bracket-R-O-bracket-space).
+
+## Failure diagnostics
+
+| If FAIL on | Likely cause                                                                            | Where to look                     |
+| ---------- | --------------------------------------------------------------------------------------- | --------------------------------- |
+| A1, A2     | Routing filter broken or namespace registration regressed                               | `src/routing/registry.ts`, `src/server.ts` `case 'namespace'` |
+| A3-A6      | `aggregateAnnotations` not wired to proxy tool registration                             | `src/server.ts` `registerProxyTool` |
+| A7         | `[RO] ` prefix not applied when `config.readOnly === true` in proxy mode                | `src/server.ts` (search for `[RO]`) |

--- a/tests/functional/scenarios/01-namespace-readonly/expected.md
+++ b/tests/functional/scenarios/01-namespace-readonly/expected.md
@@ -12,7 +12,7 @@ Reading this file biases the report. Stop now and read only `spec.md`.
 - **A4 — destructiveHint.** `false` on all 3. (Aggregation: `some` of zero destructive ops is `false`. In read-only mode, every sub-tool is read-only by construction.)
 - **A5 — idempotentHint.** `true` on all 3. (Every read op is idempotent.)
 - **A6 — openWorldHint.** `true` on all 3 (hard-coded in `aggregateAnnotations`).
-- **A7 — `[RO] ` prefix.** Every description must literally start with the 5
+- **A7 — `[RO]` prefix.** Every description must literally start with the 5
   characters `[` `R` `O` `]` ` ` (bracket-R-O-bracket-space).
 
 ## Failure diagnostics
@@ -21,4 +21,4 @@ Reading this file biases the report. Stop now and read only `spec.md`.
 | ---------- | --------------------------------------------------------------------------------------- | --------------------------------- |
 | A1, A2     | Routing filter broken or namespace registration regressed                               | `src/routing/registry.ts`, `src/server.ts` `case 'namespace'` |
 | A3-A6      | `aggregateAnnotations` not wired to proxy tool registration                             | `src/server.ts` `registerProxyTool` |
-| A7         | `[RO] ` prefix not applied when `config.readOnly === true` in proxy mode                | `src/server.ts` (search for `[RO]`) |
+| A7         | `[RO]` prefix not applied when `config.readOnly === true` in proxy mode                | `src/server.ts` (search for `[RO]`) |

--- a/tests/functional/scenarios/01-namespace-readonly/spec.md
+++ b/tests/functional/scenarios/01-namespace-readonly/spec.md
@@ -9,7 +9,7 @@ channels: [A]
 # 01 — namespace + read-only
 
 Verify that proxy tools in `--mode namespace --read-only` expose correct
-aggregated annotations and a `[RO] ` description prefix.
+aggregated annotations and a `[RO]` description prefix.
 
 ## Steps
 

--- a/tests/functional/scenarios/01-namespace-readonly/spec.md
+++ b/tests/functional/scenarios/01-namespace-readonly/spec.md
@@ -1,0 +1,62 @@
+---
+pr: 53
+mode: namespace
+read_only: true
+namespaces: []
+channels: [A]
+---
+
+# 01 — namespace + read-only
+
+Verify that proxy tools in `--mode namespace --read-only` expose correct
+aggregated annotations and a `[RO] ` description prefix.
+
+## Steps
+
+1. Make sure you've built once on this branch: `pnpm build`.
+2. Make sure `ZENDESK_SUBDOMAIN` is exported (see `tests/functional/README.md`).
+3. Dump `tools/list` to `reports/01-namespace-readonly.raw.json`:
+
+   ```sh
+   node tests/functional/bin/dump-tools-list.mjs \
+     --mode namespace --read-only \
+     > tests/functional/reports/01-namespace-readonly.raw.json
+   ```
+
+4. Open the raw JSON. Inspect each tool entry under `.tools[]`. Look at
+   `name`, `description` (first ~20 chars), and the full `annotations` object.
+5. Fill in the report below at
+   `tests/functional/reports/01-namespace-readonly.report.md`.
+
+## Assertions to record
+
+For each assertion, set `pass: true|false`, fill `actual` with the value you
+observed in the raw JSON, and copy the `desc` verbatim. **Do not** look up
+expected values — `expected.md` is off-limits to you.
+
+```json
+{
+  "scenario": "01-namespace-readonly",
+  "mode": "namespace",
+  "readOnly": true,
+  "branch": "claude/laughing-lovelace-HmZOn",
+  "assertions": [
+    { "id": "A1", "desc": "tools/list returns exactly 3 entries",                          "pass": null, "actual": null },
+    { "id": "A2", "desc": "tool names are {zendesk_tickets, zendesk_help_center, zendesk_users}", "pass": null, "actual": null },
+    { "id": "A3", "desc": "every tool has annotations.readOnlyHint === true",              "pass": null, "actual": null },
+    { "id": "A4", "desc": "every tool has annotations.destructiveHint === false",          "pass": null, "actual": null },
+    { "id": "A5", "desc": "every tool has annotations.idempotentHint === true",            "pass": null, "actual": null },
+    { "id": "A6", "desc": "every tool has annotations.openWorldHint === true",             "pass": null, "actual": null },
+    { "id": "A7", "desc": "every tool description starts with the literal '[RO] '",        "pass": null, "actual": null }
+  ],
+  "summary": "<one-line synthesis: green / which IDs failed>"
+}
+```
+
+## When done
+
+1. Update `tests/functional/STATE.md`: set this scenario `status: done`,
+   bump `holder` to `leading`.
+2. `git add tests/functional/reports/01-namespace-readonly.* tests/functional/STATE.md`.
+3. Commit with `test(functional): run scenario 01-namespace-readonly` and push.
+4. Notify the leading LLM in chat.

--- a/tests/functional/scenarios/02-namespace-mixed/expected.md
+++ b/tests/functional/scenarios/02-namespace-mixed/expected.md
@@ -1,0 +1,20 @@
+# ⚠️ LEADING LLM ONLY — DO NOT READ IF YOU ARE THE EXECUTOR
+
+---
+
+## Expected values
+
+- **A1.** `tools.length === 3`, names `{zendesk_tickets, zendesk_help_center, zendesk_users}`.
+- **A2.** `zendesk_tickets` aggregates writes (e.g. `create_ticket`, `update_ticket`, `manage_tags`), so `readOnlyHint=false` and `destructiveHint=true`.
+- **A3.** `zendesk_help_center` aggregates writes (article/section edits), so `readOnlyHint=false` and `destructiveHint=true`.
+- **A4.** `zendesk_users` is fully read-only by construction (all 5 sub-tools have `readOnly: true` in `src/tools/users.ts`). The aggregate keeps `readOnlyHint=true`, `destructiveHint=false`. **This is the load-bearing assertion of this scenario** — confirms aggregation is "every"/"some" semantics, not blanket-off-when-not-in-`--read-only`.
+- **A5.** `openWorldHint=true` is hard-coded in `aggregateAnnotations`.
+- **A6.** No description starts with `[RO] ` — the prefix only applies when the server runs with `--read-only`.
+
+## Failure diagnostics
+
+| If FAIL on | Likely cause                                                                                | Where to look                          |
+| ---------- | ------------------------------------------------------------------------------------------- | -------------------------------------- |
+| A2, A3     | `aggregateAnnotations` semantics regressed (e.g. swapped `every`/`some`)                    | `src/server.ts` `aggregateAnnotations` |
+| A4         | Aggregation now hard-codes `readOnlyHint=false` outside `--read-only` (regression)          | `src/server.ts` `aggregateAnnotations` |
+| A6         | `[RO] ` prefix leaked into non-read-only mode                                               | `src/server.ts` `registerProxyTool`    |

--- a/tests/functional/scenarios/02-namespace-mixed/expected.md
+++ b/tests/functional/scenarios/02-namespace-mixed/expected.md
@@ -9,7 +9,7 @@
 - **A3.** `zendesk_help_center` aggregates writes (article/section edits), so `readOnlyHint=false` and `destructiveHint=true`.
 - **A4.** `zendesk_users` is fully read-only by construction (all 5 sub-tools have `readOnly: true` in `src/tools/users.ts`). The aggregate keeps `readOnlyHint=true`, `destructiveHint=false`. **This is the load-bearing assertion of this scenario** — confirms aggregation is "every"/"some" semantics, not blanket-off-when-not-in-`--read-only`.
 - **A5.** `openWorldHint=true` is hard-coded in `aggregateAnnotations`.
-- **A6.** No description starts with `[RO] ` — the prefix only applies when the server runs with `--read-only`.
+- **A6.** No description starts with `[RO]` — the prefix only applies when the server runs with `--read-only`.
 
 ## Failure diagnostics
 
@@ -17,4 +17,4 @@
 | ---------- | ------------------------------------------------------------------------------------------- | -------------------------------------- |
 | A2, A3     | `aggregateAnnotations` semantics regressed (e.g. swapped `every`/`some`)                    | `src/server.ts` `aggregateAnnotations` |
 | A4         | Aggregation now hard-codes `readOnlyHint=false` outside `--read-only` (regression)          | `src/server.ts` `aggregateAnnotations` |
-| A6         | `[RO] ` prefix leaked into non-read-only mode                                               | `src/server.ts` `registerProxyTool`    |
+| A6         | `[RO]` prefix leaked into non-read-only mode                                               | `src/server.ts` `registerProxyTool`    |

--- a/tests/functional/scenarios/02-namespace-mixed/spec.md
+++ b/tests/functional/scenarios/02-namespace-mixed/spec.md
@@ -9,7 +9,7 @@ channels: [A]
 # 02 — namespace, mixed (no read-only)
 
 Verify that proxy tools in `--mode namespace` (without `--read-only`) expose
-correct aggregated annotations and **no** `[RO] ` prefix. Proxies that
+correct aggregated annotations and **no** `[RO]` prefix. Proxies that
 aggregate at least one write op must report `destructiveHint: true`. Proxies
 whose sub-tools are all read-only (e.g. `zendesk_users`) must keep
 `readOnlyHint: true`.

--- a/tests/functional/scenarios/02-namespace-mixed/spec.md
+++ b/tests/functional/scenarios/02-namespace-mixed/spec.md
@@ -1,0 +1,55 @@
+---
+pr: 53
+mode: namespace
+read_only: false
+namespaces: []
+channels: [A]
+---
+
+# 02 — namespace, mixed (no read-only)
+
+Verify that proxy tools in `--mode namespace` (without `--read-only`) expose
+correct aggregated annotations and **no** `[RO] ` prefix. Proxies that
+aggregate at least one write op must report `destructiveHint: true`. Proxies
+whose sub-tools are all read-only (e.g. `zendesk_users`) must keep
+`readOnlyHint: true`.
+
+## Steps
+
+1. `pnpm build` if not already done on this branch.
+2. Ensure `ZENDESK_SUBDOMAIN` is exported.
+3. Dump:
+
+   ```sh
+   node tests/functional/bin/dump-tools-list.mjs --mode namespace \
+     > tests/functional/reports/02-namespace-mixed.raw.json
+   ```
+
+4. Inspect annotations per tool. Write the report at
+   `tests/functional/reports/02-namespace-mixed.report.md`.
+
+## Assertions to record
+
+```json
+{
+  "scenario": "02-namespace-mixed",
+  "mode": "namespace",
+  "readOnly": false,
+  "branch": "claude/laughing-lovelace-HmZOn",
+  "assertions": [
+    { "id": "A1", "desc": "tools/list returns exactly 3 entries",                                       "pass": null, "actual": null },
+    { "id": "A2", "desc": "zendesk_tickets has readOnlyHint=false and destructiveHint=true",            "pass": null, "actual": null },
+    { "id": "A3", "desc": "zendesk_help_center has readOnlyHint=false and destructiveHint=true",        "pass": null, "actual": null },
+    { "id": "A4", "desc": "zendesk_users has readOnlyHint=true and destructiveHint=false",              "pass": null, "actual": null },
+    { "id": "A5", "desc": "every tool has openWorldHint=true",                                          "pass": null, "actual": null },
+    { "id": "A6", "desc": "no tool description starts with '[RO] '",                                    "pass": null, "actual": null }
+  ],
+  "summary": "<one-line synthesis>"
+}
+```
+
+## When done
+
+1. Update `STATE.md`: `02-namespace-mixed` → `done`, `holder` → `leading`.
+2. Commit `tests/functional/reports/02-namespace-mixed.*` and `STATE.md`.
+3. Push and notify.

--- a/tests/functional/scenarios/03-single-readonly/expected.md
+++ b/tests/functional/scenarios/03-single-readonly/expected.md
@@ -1,0 +1,19 @@
+# ⚠️ LEADING LLM ONLY — DO NOT READ IF YOU ARE THE EXECUTOR
+
+---
+
+## Expected values
+
+- **A1.** `tools.length === 1`.
+- **A2.** `tools[0].name === 'zendesk'` (hard-coded in `src/server.ts` `case 'single'`).
+- **A3-A5.** All read-only flags true. In `--read-only` mode the filter strips every write op, so the aggregate trivially satisfies `every read-only / not destructive / every idempotent`.
+- **A6.** `openWorldHint=true` (hard-coded in `aggregateAnnotations`).
+- **A7.** Description starts with `[RO] `.
+
+## Failure diagnostics
+
+| If FAIL on | Likely cause                                                              | Where to look                       |
+| ---------- | ------------------------------------------------------------------------- | ----------------------------------- |
+| A1, A2     | Single-mode registration broken                                           | `src/server.ts` `case 'single'`     |
+| A3-A6      | `aggregateAnnotations` not applied to single proxy                        | `src/server.ts` `registerProxyTool` |
+| A7         | `[RO] ` prefix logic skipped for single mode                              | `src/server.ts` `registerProxyTool` |

--- a/tests/functional/scenarios/03-single-readonly/expected.md
+++ b/tests/functional/scenarios/03-single-readonly/expected.md
@@ -8,7 +8,7 @@
 - **A2.** `tools[0].name === 'zendesk'` (hard-coded in `src/server.ts` `case 'single'`).
 - **A3-A5.** All read-only flags true. In `--read-only` mode the filter strips every write op, so the aggregate trivially satisfies `every read-only / not destructive / every idempotent`.
 - **A6.** `openWorldHint=true` (hard-coded in `aggregateAnnotations`).
-- **A7.** Description starts with `[RO] `.
+- **A7.** Description starts with `[RO]`.
 
 ## Failure diagnostics
 
@@ -16,4 +16,4 @@
 | ---------- | ------------------------------------------------------------------------- | ----------------------------------- |
 | A1, A2     | Single-mode registration broken                                           | `src/server.ts` `case 'single'`     |
 | A3-A6      | `aggregateAnnotations` not applied to single proxy                        | `src/server.ts` `registerProxyTool` |
-| A7         | `[RO] ` prefix logic skipped for single mode                              | `src/server.ts` `registerProxyTool` |
+| A7         | `[RO]` prefix logic skipped for single mode                              | `src/server.ts` `registerProxyTool` |

--- a/tests/functional/scenarios/03-single-readonly/spec.md
+++ b/tests/functional/scenarios/03-single-readonly/spec.md
@@ -1,0 +1,53 @@
+---
+pr: 53
+mode: single
+read_only: true
+namespaces: []
+channels: [A]
+---
+
+# 03 — single + read-only
+
+Verify the single-proxy mode in read-only: one tool, aggregated annotations
+across all read ops, `[RO] ` prefix.
+
+## Steps
+
+1. `pnpm build` if not already done.
+2. Ensure `ZENDESK_SUBDOMAIN` is exported.
+3. Dump:
+
+   ```sh
+   node tests/functional/bin/dump-tools-list.mjs --mode single --read-only \
+     > tests/functional/reports/03-single-readonly.raw.json
+   ```
+
+4. Inspect the single tool and write the report at
+   `tests/functional/reports/03-single-readonly.report.md`.
+
+## Assertions to record
+
+```json
+{
+  "scenario": "03-single-readonly",
+  "mode": "single",
+  "readOnly": true,
+  "branch": "claude/laughing-lovelace-HmZOn",
+  "assertions": [
+    { "id": "A1", "desc": "tools/list returns exactly 1 entry",                  "pass": null, "actual": null },
+    { "id": "A2", "desc": "the tool name is exactly 'zendesk'",                  "pass": null, "actual": null },
+    { "id": "A3", "desc": "annotations.readOnlyHint === true",                   "pass": null, "actual": null },
+    { "id": "A4", "desc": "annotations.destructiveHint === false",               "pass": null, "actual": null },
+    { "id": "A5", "desc": "annotations.idempotentHint === true",                 "pass": null, "actual": null },
+    { "id": "A6", "desc": "annotations.openWorldHint === true",                  "pass": null, "actual": null },
+    { "id": "A7", "desc": "description starts with the literal '[RO] '",        "pass": null, "actual": null }
+  ],
+  "summary": "<one-line synthesis>"
+}
+```
+
+## When done
+
+1. Update `STATE.md`.
+2. Commit and push.
+3. Notify.

--- a/tests/functional/scenarios/03-single-readonly/spec.md
+++ b/tests/functional/scenarios/03-single-readonly/spec.md
@@ -9,7 +9,7 @@ channels: [A]
 # 03 — single + read-only
 
 Verify the single-proxy mode in read-only: one tool, aggregated annotations
-across all read ops, `[RO] ` prefix.
+across all read ops, `[RO]` prefix.
 
 ## Steps
 

--- a/tests/functional/scenarios/04-all-baseline/expected.md
+++ b/tests/functional/scenarios/04-all-baseline/expected.md
@@ -1,0 +1,28 @@
+# ⚠️ LEADING LLM ONLY — DO NOT READ IF YOU ARE THE EXECUTOR
+
+---
+
+## Expected values
+
+- **A1.** `tools.length === 37`. Breakdown: 10 ticket tools + 21 Help Center
+  tools + 5 user/organization tools + 1 unified search tool. If the count
+  drifts, update the documentation listed in `AGENTS.md` "Documentation
+  maintenance" before running.
+- **A2.** Every entry must have a populated `annotations` object — no
+  `undefined`, no empty `{}`.
+- **A3.** `openWorldHint=true` everywhere (every tool hits Zendesk over the
+  network).
+- **A4.** `get_current_user`: read-only and non-destructive (sanity sample).
+- **A5.** `manage_tags.destructiveHint=true` — verified by the previous PR
+  (commit `10d846b`). Guards against a regression of that fix.
+- **A6.** `[RO] ` prefix is a proxy-mode-only feature; in `--mode all` no
+  description should carry it.
+
+## Failure diagnostics
+
+| If FAIL on | Likely cause                                                              | Where to look                       |
+| ---------- | ------------------------------------------------------------------------- | ----------------------------------- |
+| A1         | Tool added/removed without doc sync, or registry drift                    | `AGENTS.md` "Documentation maintenance", `src/tools/index.ts` |
+| A2, A3     | `createAllTools` skipped annotations on a new tool                        | per-namespace `src/tools/*.ts`      |
+| A4, A5     | Annotation regression on a specific tool                                  | `src/tools/users.ts`, `src/tools/tickets.ts` (search `manage_tags`) |
+| A6         | `[RO] ` prefix leaked into individual tool descriptions                   | `src/server.ts` `case 'all'`        |

--- a/tests/functional/scenarios/04-all-baseline/expected.md
+++ b/tests/functional/scenarios/04-all-baseline/expected.md
@@ -15,7 +15,7 @@
 - **A4.** `get_current_user`: read-only and non-destructive (sanity sample).
 - **A5.** `manage_tags.destructiveHint=true` — verified by the previous PR
   (commit `10d846b`). Guards against a regression of that fix.
-- **A6.** `[RO] ` prefix is a proxy-mode-only feature; in `--mode all` no
+- **A6.** `[RO]` prefix is a proxy-mode-only feature; in `--mode all` no
   description should carry it.
 
 ## Failure diagnostics
@@ -25,4 +25,4 @@
 | A1         | Tool added/removed without doc sync, or registry drift                    | `AGENTS.md` "Documentation maintenance", `src/tools/index.ts` |
 | A2, A3     | `createAllTools` skipped annotations on a new tool                        | per-namespace `src/tools/*.ts`      |
 | A4, A5     | Annotation regression on a specific tool                                  | `src/tools/users.ts`, `src/tools/tickets.ts` (search `manage_tags`) |
-| A6         | `[RO] ` prefix leaked into individual tool descriptions                   | `src/server.ts` `case 'all'`        |
+| A6         | `[RO]` prefix leaked into individual tool descriptions                   | `src/server.ts` `case 'all'`        |

--- a/tests/functional/scenarios/04-all-baseline/spec.md
+++ b/tests/functional/scenarios/04-all-baseline/spec.md
@@ -23,7 +23,7 @@ own `annotations` object intact (PR #53 must not regress flat mode).
    ```
 
 4. Inspect the raw JSON. Confirm the tool count, sample a few entries (one
-   read, one write, `manage_tags`), and verify no `[RO] ` prefix anywhere.
+   read, one write, `manage_tags`), and verify no `[RO]` prefix anywhere.
 5. Write the report at `tests/functional/reports/04-all-baseline.report.md`.
 
 ## Assertions to record

--- a/tests/functional/scenarios/04-all-baseline/spec.md
+++ b/tests/functional/scenarios/04-all-baseline/spec.md
@@ -1,0 +1,53 @@
+---
+pr: 53
+mode: all
+read_only: false
+namespaces: []
+channels: [A]
+---
+
+# 04 — all (flat baseline, non-regression)
+
+Sanity check that `--mode all` still exposes every individual tool with its
+own `annotations` object intact (PR #53 must not regress flat mode).
+
+## Steps
+
+1. `pnpm build` if not already done.
+2. Ensure `ZENDESK_SUBDOMAIN` is exported.
+3. Dump:
+
+   ```sh
+   node tests/functional/bin/dump-tools-list.mjs --mode all \
+     > tests/functional/reports/04-all-baseline.raw.json
+   ```
+
+4. Inspect the raw JSON. Confirm the tool count, sample a few entries (one
+   read, one write, `manage_tags`), and verify no `[RO] ` prefix anywhere.
+5. Write the report at `tests/functional/reports/04-all-baseline.report.md`.
+
+## Assertions to record
+
+```json
+{
+  "scenario": "04-all-baseline",
+  "mode": "all",
+  "readOnly": false,
+  "branch": "claude/laughing-lovelace-HmZOn",
+  "assertions": [
+    { "id": "A1", "desc": "tools/list returns exactly 37 entries",                                   "pass": null, "actual": null },
+    { "id": "A2", "desc": "every entry has a non-empty annotations object",                          "pass": null, "actual": null },
+    { "id": "A3", "desc": "every entry has openWorldHint=true",                                      "pass": null, "actual": null },
+    { "id": "A4", "desc": "get_current_user has readOnlyHint=true and destructiveHint=false",        "pass": null, "actual": null },
+    { "id": "A5", "desc": "manage_tags has destructiveHint=true",                                    "pass": null, "actual": null },
+    { "id": "A6", "desc": "no description starts with '[RO] '",                                      "pass": null, "actual": null }
+  ],
+  "summary": "<one-line synthesis>"
+}
+```
+
+## When done
+
+1. Update `STATE.md`.
+2. Commit and push.
+3. Notify.

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import type { Config } from '../../src/config';
-import { buildOperationList, createMcpServer, summarizeDescription } from '../../src/server';
+import {
+  aggregateAnnotations,
+  buildOperationList,
+  createMcpServer,
+  summarizeDescription,
+} from '../../src/server';
+import type { ToolAnnotations } from '../../src/tools/definitions';
+
+const ann = (overrides: Partial<ToolAnnotations> = {}): ToolAnnotations => ({
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: true,
+  ...overrides,
+});
+
+type RegisteredTool = { description?: string; annotations?: ToolAnnotations };
+const introspect = (server: ReturnType<typeof createMcpServer>): Record<string, RegisteredTool> =>
+  (server as unknown as { _registeredTools: Record<string, RegisteredTool> })._registeredTools;
 
 const baseConfig: Config = {
   subdomain: 'testsubdomain',
@@ -57,11 +75,7 @@ describe('createMcpServer', () => {
       getToken,
     );
 
-    const registered = (
-      server as unknown as {
-        _registeredTools: Record<string, { description?: string }>;
-      }
-    )._registeredTools;
+    const registered = introspect(server);
     const names = Object.keys(registered);
 
     expect(names).toEqual(['zendesk_help_center']);
@@ -72,6 +86,88 @@ describe('createMcpServer', () => {
     expect(description).toContain('get_article');
     expect(description).not.toContain('create_article');
     expect(description).not.toContain('update_article');
+  });
+
+  it('marks read-only proxies with readOnlyHint=true and a [RO] description prefix', () => {
+    const server = createMcpServer(
+      {
+        ...baseConfig,
+        mode: 'namespace',
+        namespaces: ['help_center'],
+        readOnly: true,
+      },
+      getToken,
+    );
+
+    const proxy = introspect(server)['zendesk_help_center'];
+    expect(proxy?.annotations).toMatchObject({
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true,
+    });
+    expect(proxy?.description ?? '').toMatch(/^\[RO\] /);
+  });
+
+  it('flags a mixed namespace proxy as destructive but not read-only', () => {
+    const server = createMcpServer(
+      { ...baseConfig, mode: 'namespace', namespaces: ['tickets'] },
+      getToken,
+    );
+
+    const proxy = introspect(server)['zendesk_tickets'];
+    expect(proxy?.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+    });
+    expect(proxy?.description ?? '').not.toMatch(/^\[RO\] /);
+  });
+
+  it('aggregates the single-proxy annotations across every namespace', () => {
+    const server = createMcpServer({ ...baseConfig, mode: 'single' }, getToken);
+
+    const proxy = introspect(server)['zendesk'];
+    expect(proxy?.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: true,
+      openWorldHint: true,
+    });
+  });
+});
+
+describe('aggregateAnnotations', () => {
+  it('returns readOnly + idempotent when every op is read-only and idempotent', () => {
+    const result = aggregateAnnotations([
+      { annotations: ann({ readOnlyHint: true, idempotentHint: true }) },
+      { annotations: ann({ readOnlyHint: true, idempotentHint: true }) },
+    ]);
+    expect(result).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    });
+  });
+
+  it('drops readOnly as soon as one op is write', () => {
+    const result = aggregateAnnotations([
+      { annotations: ann({ readOnlyHint: true, idempotentHint: true }) },
+      { annotations: ann({ readOnlyHint: false, idempotentHint: false }) },
+    ]);
+    expect(result.readOnlyHint).toBe(false);
+  });
+
+  it('raises destructive as soon as one op is destructive', () => {
+    const result = aggregateAnnotations([
+      { annotations: ann({ readOnlyHint: true }) },
+      { annotations: ann({ destructiveHint: true }) },
+    ]);
+    expect(result.destructiveHint).toBe(true);
+  });
+
+  it('always reports openWorldHint=true (this server always hits Zendesk)', () => {
+    const result = aggregateAnnotations([{ annotations: ann({ openWorldHint: false }) }]);
+    expect(result.openWorldHint).toBe(true);
   });
 });
 

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -169,6 +169,24 @@ describe('aggregateAnnotations', () => {
     const result = aggregateAnnotations([{ annotations: ann({ openWorldHint: false }) }]);
     expect(result.openWorldHint).toBe(true);
   });
+
+  it('drops idempotentHint as soon as one op is non-idempotent', () => {
+    const result = aggregateAnnotations([
+      { annotations: ann({ readOnlyHint: true, idempotentHint: true }) },
+      { annotations: ann({ readOnlyHint: false, idempotentHint: false }) },
+    ]);
+    expect(result.idempotentHint).toBe(false);
+  });
+
+  it('handles an empty tool list with the every/some vacuous defaults', () => {
+    const result = aggregateAnnotations([]);
+    expect(result).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    });
+  });
 });
 
 describe('summarizeDescription', () => {

--- a/tests/unit/tools/annotations.test.ts
+++ b/tests/unit/tools/annotations.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { createAllTools, type ToolContext } from '../../../src/tools';
+
+const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
+const tools = createAllTools(ctx);
+
+describe('tool annotation invariants', () => {
+  it('every tool: readOnly matches annotations.readOnlyHint', () => {
+    const violations = tools
+      .filter((t) => t.annotations.readOnlyHint !== t.readOnly)
+      .map((t) => t.name);
+    expect(violations).toEqual([]);
+  });
+
+  it('every tool: a read-only tool cannot be destructive', () => {
+    const violations = tools
+      .filter((t) => t.readOnly && t.annotations.destructiveHint)
+      .map((t) => t.name);
+    expect(violations).toEqual([]);
+  });
+
+  it('every tool: openWorldHint=true (this server always hits Zendesk)', () => {
+    const violations = tools.filter((t) => !t.annotations.openWorldHint).map((t) => t.name);
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

MCP clients (Claude Desktop, Claude Code, Cursor, VS Code MCP…) read per-tool
`annotations` — `readOnlyHint`, `destructiveHint`, `idempotentHint` — to
decide which tools to auto-approve and which to gate behind a confirmation
prompt. This server exposes two gaps today:

1. **Proxy tools (`zendesk_tickets` in `--mode namespace`, `zendesk` in
   `--mode single`) ship with no annotations at all** — the client can infer
   nothing and falls back to the most conservative decision on every call.
2. **Five PUT tools** (`update_ticket`, `manage_tags`, `update_article`,
   `update_article_section`, `update_article_translation`) **wrongly
   advertise `destructiveHint: false`** — clients that auto-approve
   non-destructive operations write without asking.

This PR:

- Aggregates the hints of each proxy's sub-operations (`every` semantics for
  `readOnly`/`idempotent`, `some` for `destructive`). User-visible effect:
  `zendesk_users` keeps `readOnlyHint: true` even outside `--read-only` (all
  5 sub-tools are read-only by construction) — user lookups can still
  auto-approve.
- Prefixes proxy descriptions with `[RO] ` when the server runs with
  `--read-only`, for clients that ignore annotations (Mistral, Vibe — see
  the comment in `src/server.ts`). A read-only deployment now reads as
  read-only in the client UI.
- Corrects `destructiveHint` to `true` on the 5 write tools.

As a bonus, this PR introduces **a reusable functional-testing harness**
(`tests/functional/` + `/functional-testing` skill) that dumps the JSON-RPC
`tools/list` output across the 4 key combinations (`namespace`+RO,
`namespace` mixed, `single`+RO, `all` baseline) and lets a second LLM drive
the verdict. Future PRs that touch the tool surface get a turnkey way to
add a regression scenario without changing the harness itself.

## Type of change

- [x] Bug fix — `destructiveHint` corrected on 5 PUT tools
- [x] New feature — aggregated annotations + `[RO] ` prefix on proxies
- [x] Tooling / CI — inter-LLM functional testing harness

## Author checklist

- [x] `pnpm test` passes locally (226 tests)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (1 pre-existing warning, unrelated)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
      (CodeRabbit findings from the same iteration addressed in 9dc2dad)
- [x] Documentation is updated where needed (`AGENTS.md` "Functional
      testing", `tests/functional/README.md`)
- [x] If this PR adds an MCP tool: N/A — no new tool, only annotations on
      existing ones

## Notes for the reviewer

- The load-bearing assertion is scenario 02's A4: `zendesk_users` must keep
  `readOnlyHint: true` outside `--read-only`. It is what proves the
  aggregation is `every`/`some` semantics, not a blanket flag flip.
- Visible behaviour change: agents that previously auto-approved
  `update_ticket`, `manage_tags` and the `update_article*` tools will now
  ask for confirmation. That is the intended effect — the previous data
  was wrong.
- The functional harness lives next to `tests/integration/` (introduced by
  #54) on purpose: integration validates the vitest round-trip, functional
  produces a diffable dump and a committed two-LLM verdict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only mode for proxy tools with visual `[RO]` prefix on descriptions.
  * Implemented annotation aggregation to properly identify destructive operations across tool sets.

* **Improvements**
  * Updated Help Center and Ticket tools to correctly mark write operations (`update_article`, `update_ticket`, `manage_tags`) as destructive.

* **Tests & Documentation**
  * Expanded functional testing framework with comprehensive scenario definitions and test harness documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->