### PR TITLE
feat(dev): enable live testing of the MCP server on a branch

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,9 @@
     "zendesk-local": {
       "command": "pnpm",
       "args": ["exec", "tsx", "src/index.ts", "--mode", "all"],
-      "env": {}
+      "env": {
+        "ZENDESK_SUBDOMAIN": "fruggr"
+      }
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "zendesk-local": {
+      "command": "pnpm",
+      "args": ["exec", "tsx", "src/index.ts", "--mode", "all"],
+      "env": {}
+    }
+  }
+}

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -65,7 +65,7 @@ pnpm mcp:live list -- --mode namespace        # forward server flags after `--`
 
 # Call a tool (needs creds for a real Zendesk response)
 pnpm mcp:live call get_current_user '{}'
-pnpm mcp:live call get_ticket '{"ticketId": 123}' -- --mode all
+pnpm mcp:live call get_ticket '{"ticket_id": 123}' -- --mode all
 ```
 
 It links a real MCP `Client` to the server over an in-memory transport

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -1,0 +1,74 @@
+# Live-testing the MCP server (in a PR / web session)
+
+Two complementary ways to drive a running instance of this server against the
+**current branch**, so changes can be exercised before merge.
+
+| | What you get | Needs Zendesk creds? | Needs egress to `*.zendesk.com`? |
+|---|---|---|---|
+| **A. `.mcp.json`** | Real `mcp__zendesk-local__*` tools, callable live inside a Claude Code session | Yes (for real data) | Yes |
+| **B. `scripts/mcp-live.ts`** | One-shot client you run from the terminal | Only for `call` against real data | Only for real `call`s |
+
+Both boot the same `createMcpServer` the production entry point uses
+(`src/index.ts`), so what you test is the actual server, not a stub.
+
+## Auth note (important)
+
+The OAuth 2.1 PKCE flow opens a **browser**, which does not work in a headless
+remote/web environment. For live testing, use **API-token mode** by setting:
+
+```
+ZENDESK_SUBDOMAIN=<your-subdomain>
+ZENDESK_EMAIL=<agent@company.com>
+ZENDESK_API_TOKEN=<token>
+```
+
+In a Claude Code web environment, inject these as environment variables in the
+environment configuration (not committed). `list` / schema validation work
+without credentials; only real API calls require them.
+
+## A. `.mcp.json` — live tools inside a session
+
+A project-scoped `.mcp.json` is committed at the repo root:
+
+```json
+{
+  "mcpServers": {
+    "zendesk-local": {
+      "command": "pnpm",
+      "args": ["exec", "tsx", "src/index.ts", "--mode", "all"],
+      "env": {}
+    }
+  }
+}
+```
+
+- Runs the server straight from **source** via `tsx`, so it always reflects the
+  checked-out branch (no build step). Requires `pnpm install` to have run.
+- `--mode all` exposes the 37 individual tools so you can call any operation
+  directly. Drop it for the default `namespace` mode, or pass
+  `--read-only` / `--namespace <ns>` to scope the surface.
+- Credentials come from the environment (see auth note above) — none are stored
+  in the file.
+
+MCP servers are connected at **session startup**, not hot-reloaded. So: commit
+`.mcp.json` to the branch, then open a **new** Claude Code session on that
+branch. The tools appear as `mcp__zendesk-local__*` and can be called live.
+
+## B. `scripts/mcp-live.ts` — one-shot client, no registration
+
+Works immediately in any conversation/terminal, no session restart:
+
+```bash
+# List the tools the server would expose (no creds needed)
+pnpm mcp:live list
+pnpm mcp:live list -- --mode namespace        # forward server flags after `--`
+
+# Call a tool (needs creds for a real Zendesk response)
+pnpm mcp:live call get_current_user '{}'
+pnpm mcp:live call get_ticket '{"ticketId": 123}' -- --mode all
+```
+
+It links a real MCP `Client` to the server over an in-memory transport
+(identical to `tests/integration/stdio-harness.ts`), so `tools/list` and
+`tools/call` cross the wire and dispatch through the genuine handlers. Use it
+for quick manual checks or as a basis for scripted/CI assertions.

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -47,8 +47,9 @@ A project-scoped `.mcp.json` is committed at the repo root:
 - `--mode all` exposes the 37 individual tools so you can call any operation
   directly. Drop it for the default `namespace` mode, or pass
   `--read-only` / `--namespace <ns>` to scope the surface.
-- Credentials come from the environment (see auth note above) — none are stored
-  in the file.
+- `ZENDESK_SUBDOMAIN` is set in the file (`fruggr`) since it is not a secret;
+  the actual credentials (`ZENDESK_EMAIL` + `ZENDESK_API_TOKEN`) still come from
+  the environment (see auth note above) and are never stored in the file.
 
 MCP servers are connected at **session startup**, not hot-reloaded. So: commit
 `.mcp.json` to the branch, then open a **new** Claude Code session on that

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -36,7 +36,9 @@ A project-scoped `.mcp.json` is committed at the repo root:
     "zendesk-local": {
       "command": "pnpm",
       "args": ["exec", "tsx", "src/index.ts", "--mode", "all"],
-      "env": {}
+      "env": {
+        "ZENDESK_SUBDOMAIN": "fruggr"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "vitest run",
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage",
-    "test:smoke": "pnpm build && node scripts/smoke-test.mjs"
+    "test:smoke": "pnpm build && node scripts/smoke-test.mjs",
+    "mcp:live": "tsx scripts/mcp-live.ts"
   },
   "keywords": [
     "mcp",

--- a/scripts/mcp-live.ts
+++ b/scripts/mcp-live.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env tsx
+/**
+ * Live driver for the Zendesk MCP server — boots the *current source tree* and
+ * talks to it through a real MCP client over an in-memory transport, exactly
+ * like `tests/integration` but interactive and against a live config.
+ *
+ * It does NOT register itself as an MCP server (no `.mcp.json` needed); it is a
+ * one-shot client you can run from any branch to exercise tools live.
+ *
+ * Usage:
+ *   pnpm tsx scripts/mcp-live.ts list                       # list exposed tools
+ *   pnpm tsx scripts/mcp-live.ts call <tool> '<json-params>' # call one tool
+ *
+ * Anything after `--` is forwarded to the server config parser, so the full CLI
+ * surface (`--mode`, `--namespace`, `--read-only`, `--tool`) is available:
+ *   pnpm tsx scripts/mcp-live.ts list -- --mode namespace
+ *   pnpm tsx scripts/mcp-live.ts call get_current_user '{}' -- --mode all
+ *
+ * Auth: real Zendesk calls need ZENDESK_SUBDOMAIN + ZENDESK_EMAIL +
+ * ZENDESK_API_TOKEN in the environment (API-token / Basic auth). The OAuth flow
+ * is intentionally unsupported here because it opens a browser.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { buildBasicAuthHeader } from '../src/auth/api-token';
+import { loadConfig } from '../src/config';
+import { createMcpServer } from '../src/server';
+
+const argv = process.argv.slice(2);
+const sep = argv.indexOf('--');
+const own = sep === -1 ? argv : argv.slice(0, sep);
+const configArgs = sep === -1 ? [] : argv.slice(sep + 1);
+
+const [command, toolName, rawParams] = own;
+
+const fail = (message: string): never => {
+  console.error(message);
+  process.exit(1);
+};
+
+const config = loadConfig(configArgs);
+
+// Mirror src/index.ts: prefer API-token auth. OAuth is unusable headless, so a
+// missing token only errors when a tool actually tries to reach Zendesk —
+// `list` and arg validation still work without credentials.
+const getToken =
+  config.zendeskEmail && config.zendeskApiToken
+    ? () => buildBasicAuthHeader(config.zendeskEmail as string, config.zendeskApiToken as string)
+    : () =>
+        fail(
+          'Live calls need ZENDESK_EMAIL + ZENDESK_API_TOKEN (OAuth needs a browser). ' +
+            'Set them in the environment, or use `list` which requires no token.',
+        );
+
+const main = async (): Promise<void> => {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const server = createMcpServer(config, getToken);
+  await server.connect(serverTransport);
+
+  const client = new Client({ name: 'mcp-live', version: '0.0.0' });
+  await client.connect(clientTransport);
+
+  try {
+    if (command === 'list' || command === undefined) {
+      const { tools } = await client.listTools();
+      console.log(`# ${tools.length} tool(s) in "${config.mode}" mode\n`);
+      for (const tool of tools) {
+        const firstLine = (tool.description ?? '').split('\n')[0];
+        console.log(`- ${tool.name}: ${firstLine}`);
+      }
+      return;
+    }
+
+    if (command === 'call') {
+      if (!toolName) fail("Usage: mcp-live.ts call <tool> ['<json-params>']");
+      let args: Record<string, unknown> = {};
+      if (rawParams) {
+        try {
+          args = JSON.parse(rawParams);
+        } catch (error) {
+          fail(`Invalid JSON params: ${(error as Error).message}`);
+        }
+      }
+      const result = await client.callTool({ name: toolName as string, arguments: args });
+      console.log(JSON.stringify(result, null, 2));
+      if (result.isError) process.exitCode = 1;
+      return;
+    }
+
+    fail(`Unknown command "${command}". Use "list" or "call".`);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+};
+
+main().catch((error) => {
+  console.error('mcp-live failed:', error);
+  process.exit(1);
+});

--- a/scripts/mcp-live.ts
+++ b/scripts/mcp-live.ts
@@ -42,7 +42,16 @@ const fail = (message: string): never => {
 // never touch Zendesk — so when no subdomain is provided (env or positional
 // arg), fall back to a placeholder. This keeps credential-free inspection
 // working; a real `call` still needs a real subdomain + token.
-if (!process.env['ZENDESK_SUBDOMAIN'] && !configArgs.some((a) => !a.startsWith('-'))) {
+// Skip values that follow a value-taking flag (e.g. `all` in `--mode all`),
+// otherwise the placeholder is wrongly skipped. Keep in sync with the
+// value-taking flags in `src/config.ts` `parseCliArgs`.
+const VALUE_FLAGS = new Set(['--mode', '--namespace', '--tool', '--log-level']);
+const hasPositionalSubdomain = configArgs.some((arg, i) => {
+  if (arg.startsWith('-')) return false;
+  const prev = configArgs[i - 1];
+  return !(prev && VALUE_FLAGS.has(prev));
+});
+if (!process.env['ZENDESK_SUBDOMAIN'] && !hasPositionalSubdomain) {
   process.env['ZENDESK_SUBDOMAIN'] = 'mcp-live-placeholder';
 }
 

--- a/scripts/mcp-live.ts
+++ b/scripts/mcp-live.ts
@@ -38,19 +38,30 @@ const fail = (message: string): never => {
   process.exit(1);
 };
 
+// `subdomain` is required by the config schema, but `list` and arg validation
+// never touch Zendesk — so when no subdomain is provided (env or positional
+// arg), fall back to a placeholder. This keeps credential-free inspection
+// working; a real `call` still needs a real subdomain + token.
+if (!process.env['ZENDESK_SUBDOMAIN'] && !configArgs.some((a) => !a.startsWith('-'))) {
+  process.env['ZENDESK_SUBDOMAIN'] = 'mcp-live-placeholder';
+}
+
 const config = loadConfig(configArgs);
 
 // Mirror src/index.ts: prefer API-token auth. OAuth is unusable headless, so a
 // missing token only errors when a tool actually tries to reach Zendesk —
-// `list` and arg validation still work without credentials.
+// `list` and arg validation still work without credentials. Throwing (rather
+// than exiting) lets the MCP layer surface a clean tool error instead of
+// killing the process.
 const getToken =
   config.zendeskEmail && config.zendeskApiToken
     ? () => buildBasicAuthHeader(config.zendeskEmail as string, config.zendeskApiToken as string)
-    : () =>
-        fail(
+    : (): string => {
+        throw new Error(
           'Live calls need ZENDESK_EMAIL + ZENDESK_API_TOKEN (OAuth needs a browser). ' +
             'Set them in the environment, or use `list` which requires no token.',
         );
+      };
 
 const main = async (): Promise<void> => {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();


### PR DESCRIPTION
## Goal

Make it possible to drive a **running instance** of the server against the current branch, so changes can be exercised live (in a PR / web session) before merge. Two complementary approaches, both booting the real `createMcpServer` from `src/index.ts` — not a stub.

## What's added

| | What you get | Needs creds? | Needs egress? |
|---|---|---|---|
| **`.mcp.json`** | Real `mcp__zendesk-local__*` tools, callable live inside a Claude Code session | Yes (real data) | Yes |
| **`scripts/mcp-live.ts`** (`pnpm mcp:live`) | One-shot MCP client to list/call tools from the terminal | Only for real `call`s | Only for real `call`s |

- **`.mcp.json`** — project-scoped stdio config running `tsx src/index.ts --mode all`, so the server always reflects the checked-out branch (no build step). Credentials come from the environment; none are stored in the file. MCP servers load at session **startup**, so this takes effect on a new session opened on the branch.
- **`scripts/mcp-live.ts`** — links a real MCP `Client` to the server over an in-memory transport (same seam as `tests/integration/stdio-harness.ts`). `list` needs no creds; `call` uses API-token auth. OAuth is intentionally unsupported here (it opens a browser, unusable headless).
- **`docs/live-testing.md`** — documents both approaches and the auth / egress constraints.

## Auth note

Live calls require **API-token mode** (`ZENDESK_SUBDOMAIN` + `ZENDESK_EMAIL` + `ZENDESK_API_TOKEN`) injected as environment variables. OAuth's browser flow does not work in a headless environment.

## Verification

- `pnpm test` → **211/211** pass
- `pnpm typecheck` clean, biome clean on new files
- `pnpm mcp:live list` → 3 proxies (namespace) / 37 tools (`-- --mode all`)
- `call` without creds fails with a clear, actionable message

https://claude.ai/code/session_01WEzNwmYbYA2t4RYtbRiwxD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEzNwmYbYA2t4RYtbRiwxD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for live-testing the MCP server, covering two run modes, auth notes, and command examples.

* **New Features**
  * Added a one-shot CLI for listing and invoking MCP server tools.
  * Added a local MCP server configuration for easier development and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->