### PR TITLE
fix(renovate): make the supply-chain delay policy coherent (lockfile + security)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,10 +19,11 @@
     "minimumReleaseAgeBehaviour": "timestamp-optional"
   },
   "vulnerabilityAlerts": {
+    "description": "Security fixes surface immediately (a PR is opened as soon as the alert is detected) but are held by the same inherited 7-day minimumReleaseAge as every other update. internalChecksFilter 'flexible' keeps that PR visible with a pending renovate/stability-days check instead of suppressing it, so a freshly published fix is not auto-merged until it has aged past the supply-chain delay. A critical, actively-exploited CVE landing inside that window is merged manually.",
     "enabled": true,
     "commitMessagePrefix": "fix(security):",
     "labels": ["security"],
-    "minimumReleaseAge": "3 days",
+    "internalChecksFilter": "flexible",
     "packageRules": [
       {
         "matchUpdateTypes": ["patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,8 @@
     "enabled": true,
     "automerge": true,
     "schedule": ["before 8am on friday"],
-    "timezone": "Europe/Paris"
+    "timezone": "Europe/Paris",
+    "minimumReleaseAgeBehaviour": "timestamp-optional"
   },
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
Two fixes to the Renovate delay policy so the supply-chain `minimumReleaseAge` gate is consistent and never deadlocks automerge.

## 1. `lockFileMaintenance` no longer hangs on `stability-days`

The weekly `lockFileMaintenance` PR (e.g. #49) stays stuck even though automerge is enabled: `renovate/stability-days` is **pending** ("Updates have not met minimum release age requirement"), `mergeable_state: unstable`.

It is **not** a too-young version: every version locked in #49 is now ≥ 9 days old (youngest, `hono@4.12.22`, published May 22). The synthetic `lockFileMaintenance` upgrade simply has **no `releaseTimestamp`**, and under the default `minimumReleaseAgeBehaviour: timestamp-required` the inherited 7-day `minimumReleaseAge` keeps the check pending **forever**.

```diff
 "lockFileMaintenance": {
   ...
+  "minimumReleaseAgeBehaviour": "timestamp-optional"
 },
```

Supply-chain safety for the refreshed lockfile is already enforced by **pnpm itself** (`minimumReleaseAge: 10080` = 7 days in `pnpm-workspace.yaml`), which resolves direct + transitive deps to versions older than the delay. This only removes a redundant, broken second gate. Refs: renovatebot/renovate#38115, #10791, #39352.

## 2. Security updates aligned to the single 7-day delay

`vulnerabilityAlerts` pinned its own `minimumReleaseAge: "3 days"` while everything else (root config + pnpm) waits 7 days — two different delays for the same supply-chain concern, and the 3-day value was largely ineffective anyway (security updates tend to bypass the age gate).

```diff
 "vulnerabilityAlerts": {
+  "description": "... held by the same inherited 7-day delay; surfaced immediately, merged after aging ...",
   "enabled": true,
   "commitMessagePrefix": "fix(security):",
   "labels": ["security"],
-  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "flexible",
   "packageRules": [ ... ]
 },
```

- The explicit value is dropped so the security path inherits the **single 7-day delay** (no more "two delays" confusion).
- `internalChecksFilter: "flexible"` keeps the security PR **visible** the moment the alert is detected (awareness) with a pending `renovate/stability-days` check, instead of suppressing it like the global `strict` would.
- Auto-merge therefore fires only once the fix has **aged 7 days**; a critical, actively-exploited CVE inside that window is merged **manually**.
- Rationale: this server handles OAuth/API credentials, so an auto-merged poisoned release is a worse failure mode than a short, bounded exposure window on a dependency CVE.

### Caveat to verify

Renovate's handling of `minimumReleaseAge` on security updates is documented as a bypass and is version-dependent (see renovatebot/renovate#39952). The intent here is "surface fast, hold automerge until aged". We should confirm on the next real security alert that the `stability-days` check actually holds the merge; if the bypass auto-merges a fresh release anyway, the fallback is to disable automerge on the security path (manual merge for all).

## How to unblock #49

Once this is merged, tick the *rebase/retry* checkbox on #49 (or wait for the next Renovate run): the check is recomputed → green → automerge.

## Local gate

- `pnpm typecheck` clean
- `pnpm test` → 211/211 pass
- `pnpm build` OK
- `pnpm check`: one pre-existing, unrelated biome warning (`parseSections`, cheerio) left untouched for scope discipline
- Self-review on the config diff: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated lock-file maintenance behavior to allow optional timestamp handling.
  * Revised vulnerability alert configuration: updated description and adjusted internal checks filtering to a more flexible handling mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->