### PR TITLE
ci(release): fold non-triggering commit types into a collapsed notes section

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,7 +8,7 @@
       }
     ],
     [
-      "@semantic-release/release-notes-generator",
+      "./scripts/release-notes-collapsed.js",
       {
         "preset": "conventionalcommits",
         "presetConfig": {
@@ -25,7 +25,17 @@
             { "type": "build", "section": "Build System", "hidden": false },
             { "type": "ci", "section": "Continuous Integration", "hidden": false }
           ]
-        }
+        },
+        "collapsedSections": [
+          "Documentation",
+          "Styles",
+          "Chores",
+          "Code Refactoring",
+          "Tests",
+          "Build System",
+          "Continuous Integration"
+        ],
+        "collapsedSummary": "🔧 Internal changes (chore, ci, build, refactor, tests, docs…)"
       }
     ],
     [

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,22 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "conventionalcommits"
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance Improvements" },
+            { "type": "revert", "section": "Reverts" },
+            { "type": "docs", "section": "Documentation", "hidden": false },
+            { "type": "style", "section": "Styles", "hidden": false },
+            { "type": "chore", "section": "Chores", "hidden": false },
+            { "type": "refactor", "section": "Code Refactoring", "hidden": false },
+            { "type": "test", "section": "Tests", "hidden": false },
+            { "type": "build", "section": "Build System", "hidden": false },
+            { "type": "ci", "section": "Continuous Integration", "hidden": false }
+          ]
+        }
       }
     ],
     [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,3 +257,4 @@ Versions are **fully automated** via [semantic-release](https://github.com/seman
 - **Side effects of a release**: new git tag `vX.Y.Z`, `CHANGELOG.md` and `package.json` committed back to `main` with message `chore(release): X.Y.Z [skip ci]`, new GitHub Release with generated notes, new npm version published to `@fruggr/zendesk-mcp-server`.
 - **npm auth**: publishing uses NPM Trusted Publishing (OIDC) — no `NPM_TOKEN` secret is stored in the repo (except during the initial bootstrap of v1.0.0, documented inline in `release.yml`).
 - **If you want a release to happen**: land at least one `fix:` / `feat:` / breaking change commit in your PR. A PR made only of `chore:` / `docs:` will merge cleanly but produce no new version.
+- **Release notes**: a local wrapper (`scripts/release-notes-collapsed.js`) keeps non-triggering commits (`chore`, `ci`, `docs`…) in the notes but folds them into a collapsed `<details>` block. See `docs/release-automation.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -34,6 +34,30 @@ semantic-release scans commits since the last release
 
 The commit-type → release-level mapping lives in `.releaserc.json` (preset `conventionalcommits`).
 
+## Release notes content
+
+semantic-release generates the notes from **every** commit between the previous
+tag and the release commit — including the non-triggering ones (`chore`, `ci`,
+`build`, `test`, `refactor`, `docs`, `style`). By default the `conventionalcommits`
+preset hides those types, so they never surfaced in any changelog even though they
+belong to a release range.
+
+To keep them visible without drowning the consumer-facing notes (especially the
+Renovate `chore(deps)` churn), the `release-notes-generator` step is replaced by a
+thin local wrapper, [`scripts/release-notes-collapsed.js`](../scripts/release-notes-collapsed.js).
+It calls the official generator, then post-processes the markdown:
+
+- **Public sections** — Features, Bug Fixes, Performance Improvements, Reverts,
+  `⚠ BREAKING CHANGES` — stay at the top.
+- **Internal sections** — the non-triggering types above — are grouped into a single
+  collapsed `<details>` block placed underneath.
+
+No Handlebars template is reimplemented, so the wrapper survives preset version
+bumps. The collapsed section titles and the `<summary>` label are configurable via
+the `collapsedSections` / `collapsedSummary` plugin options in `.releaserc.json`.
+The wrapper requires `@semantic-release/release-notes-generator` as an explicit
+devDependency (kept on the same major as the one `semantic-release` bundles).
+
 ## Auto-merge policy
 
 | Update kind                                       | Vulnerability (security) | Non-vulnerability        |

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.5",
+    "@semantic-release/release-notes-generator": "^14.1.1",
     "@tsconfig/node20": "^20.1.9",
     "@tsconfig/strictest": "^2.0.8",
     "@types/hast": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@semantic-release/npm':
         specifier: ^13.1.5
         version: 13.1.5(semantic-release@25.0.3(typescript@6.0.3))
+      '@semantic-release/release-notes-generator':
+        specifier: ^14.1.1
+        version: 14.1.1(semantic-release@25.0.3(typescript@6.0.3))
       '@tsconfig/node20':
         specifier: ^20.1.9
         version: 20.1.9

--- a/scripts/release-notes-collapsed.js
+++ b/scripts/release-notes-collapsed.js
@@ -1,0 +1,84 @@
+/**
+ * Custom semantic-release "generateNotes" plugin.
+ *
+ * Wraps the official @semantic-release/release-notes-generator and post-processes
+ * its markdown so that "internal" commit types (chore, ci, build, test, refactor,
+ * docs, style…) are still listed in every release — addressing the gap where
+ * non-triggering commits never showed up in any changelog — but are tucked away
+ * in a single collapsed <details> block so the public-facing sections (Features,
+ * Bug Fixes, Performance Improvements, breaking changes…) stay front and center.
+ *
+ * No Handlebars templates are reimplemented, so this stays robust across preset
+ * version bumps: we only reorganize the rendered output.
+ *
+ * Plugin options (in addition to everything @semantic-release/release-notes-generator
+ * accepts, which is passed straight through):
+ *   - collapsedSections: string[]  section titles to move into the <details> block.
+ *   - collapsedSummary:   string    text shown on the collapsible <summary>.
+ */
+import { generateNotes as officialGenerateNotes } from '@semantic-release/release-notes-generator';
+
+const DEFAULT_COLLAPSED_SECTIONS = [
+  'Documentation',
+  'Styles',
+  'Code Refactoring',
+  'Tests',
+  'Build System',
+  'Continuous Integration',
+  'Chores',
+];
+
+const DEFAULT_SUMMARY = '🔧 Internal changes (chore, ci, build, refactor, tests, docs…)';
+
+export async function generateNotes(pluginConfig, context) {
+  const { collapsedSections = DEFAULT_COLLAPSED_SECTIONS, collapsedSummary = DEFAULT_SUMMARY } =
+    pluginConfig;
+
+  const notes = await officialGenerateNotes(pluginConfig, context);
+
+  return collapseInternalSections(notes, new Set(collapsedSections), collapsedSummary);
+}
+
+/**
+ * Splits the rendered notes into the leading header and the individual `### …`
+ * sections, then rebuilds them with the internal sections grouped inside a single
+ * collapsed <details> block placed after the public ones.
+ */
+export function collapseInternalSections(notes, collapsedSet, summary) {
+  if (!notes?.trim()) {
+    return notes;
+  }
+
+  // First chunk is the header (`## [x.y.z](…) (date)`), the rest are `### …` sections.
+  const chunks = notes.split(/\n(?=### )/);
+  if (chunks.length <= 1) {
+    return notes;
+  }
+
+  const header = chunks[0].trimEnd();
+  const publicSections = [];
+  const internalSections = [];
+
+  for (const chunk of chunks.slice(1)) {
+    const firstLine = chunk.split('\n', 1)[0];
+    const title = firstLine.replace(/^###\s+/, '').trim();
+
+    if (collapsedSet.has(title)) {
+      internalSections.push(chunk.trim());
+    } else {
+      publicSections.push(chunk.trim());
+    }
+  }
+
+  let output = header;
+
+  for (const section of publicSections) {
+    output += `\n\n${section}`;
+  }
+
+  if (internalSections.length > 0) {
+    output += `\n\n<details>\n<summary>${summary}</summary>\n\n${internalSections.join('\n\n')}\n</details>`;
+  }
+
+  return output;
+}

--- a/tests/unit/release-notes-collapsed.test.ts
+++ b/tests/unit/release-notes-collapsed.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error - plain JS semantic-release plugin, no type declarations
+import { collapseInternalSections } from '../../scripts/release-notes-collapsed.js';
+
+const COLLAPSED = new Set([
+  'Documentation',
+  'Styles',
+  'Chores',
+  'Code Refactoring',
+  'Tests',
+  'Build System',
+  'Continuous Integration',
+]);
+const SUMMARY = 'Internal changes';
+
+describe('collapseInternalSections', () => {
+  it('moves internal sections into a single collapsed <details> block after public ones', () => {
+    const notes = [
+      '## [1.2.0](url) (2026-05-31)',
+      '',
+      '### Features',
+      '',
+      '* add a thing (abc)',
+      '',
+      '### Chores',
+      '',
+      '* **deps:** bump dep (def)',
+      '',
+      '### Tests',
+      '',
+      '* cover edge case (ghi)',
+    ].join('\n');
+
+    const result = collapseInternalSections(notes, COLLAPSED, SUMMARY);
+
+    // Public section stays at top level, before the details block.
+    const featuresIdx = result.indexOf('### Features');
+    const detailsIdx = result.indexOf('<details>');
+    expect(featuresIdx).toBeGreaterThan(-1);
+    expect(detailsIdx).toBeGreaterThan(featuresIdx);
+
+    // Internal sections live inside the details block.
+    expect(result).toContain(`<summary>${SUMMARY}</summary>`);
+    expect(result.indexOf('### Chores')).toBeGreaterThan(detailsIdx);
+    expect(result.indexOf('### Tests')).toBeGreaterThan(detailsIdx);
+    expect(result.trimEnd().endsWith('</details>')).toBe(true);
+
+    // Exactly one collapsible wraps all internal sections.
+    expect(result.match(/<details>/g)).toHaveLength(1);
+  });
+
+  it('keeps breaking-change notes at the top, outside the collapsed block', () => {
+    const notes = [
+      '## [2.0.0](url) (2026-05-31)',
+      '',
+      '### ⚠ BREAKING CHANGES',
+      '',
+      '* removed v1 routes',
+      '',
+      '### Chores',
+      '',
+      '* **deps:** bump dep (def)',
+    ].join('\n');
+
+    const result = collapseInternalSections(notes, COLLAPSED, SUMMARY);
+
+    expect(result.indexOf('BREAKING CHANGES')).toBeLessThan(result.indexOf('<details>'));
+  });
+
+  it('emits no <details> block when there are no internal sections', () => {
+    const notes = ['## [1.0.1](url) (2026-05-31)', '', '### Bug Fixes', '', '* fix it (abc)'].join(
+      '\n',
+    );
+
+    const result = collapseInternalSections(notes, COLLAPSED, SUMMARY);
+
+    expect(result).not.toContain('<details>');
+    expect(result).toContain('### Bug Fixes');
+  });
+
+  it('returns the input unchanged when there are no sections', () => {
+    expect(collapseInternalSections('## [1.0.0](url) (2026-05-31)', COLLAPSED, SUMMARY)).toBe(
+      '## [1.0.0](url) (2026-05-31)',
+    );
+    expect(collapseInternalSections('', COLLAPSED, SUMMARY)).toBe('');
+  });
+});


### PR DESCRIPTION
## Problem

Release notes only ever contained the `feat`/`fix` commits that trigger a release. The non-triggering commits (`chore`, `docs`, `ci`, `refactor`, `test`, `build`, `style`) — which intentionally do not cut a release — never appeared in **any** changelog.

## Why

`@semantic-release/release-notes-generator` does include **all** commits in the `previous_tag..HEAD` range, but the `conventionalcommits` preset marks those types as `hidden: true` — present in the range, hidden from the rendered notes. (They remained reachable via the `compare/vX...vY` link in each release header, but were invisible in the notes body.)

## Approach

Rather than simply unhiding every type — which would flood the consumer-facing notes, especially with Renovate's `chore(deps)` churn — a thin local `generateNotes` plugin (`scripts/release-notes-collapsed.js`) wraps the official generator and post-processes its markdown:

- **Public sections** (Features, Bug Fixes, Performance Improvements, Reverts, `⚠ BREAKING CHANGES`) stay at the top.
- **Internal sections** (chore, ci, build, test, refactor, docs, style) are grouped into a single collapsed `<details>` block placed underneath.

No Handlebars template is reimplemented, so the wrapper survives preset version bumps. The `commit-analyzer` is untouched: these types still trigger no release on their own.

### Rendered example

```markdown
## [1.2.0](…/compare/v1.1.3...v1.2.0) (2026-…)

### Features
* **tickets:** add get_ticket_comments tool (aaaaaaa)

### Bug Fixes
* **auth:** refresh token before expiry (bbbbbbb)

<details>
<summary>🔧 Internal changes (chore, ci, build, refactor, tests, docs…)</summary>

### Documentation
* fix typo in README (hhhhhhh)

### Chores
* **deps:** update dependency zod to v4.4.3 (ccccccc)
…
</details>
```

## Details

- Adds `@semantic-release/release-notes-generator` as an explicit devDependency (previously only transitively available via `semantic-release`), pinned to the same major (`^14.1.1`) that `semantic-release@25` bundles, so the wrapper imports the exact same generator instance.
- Unit tests (`tests/unit/release-notes-collapsed.test.ts`): internal-section folding, `BREAKING CHANGES` kept on top, no `<details>` block when there are no internal commits, passthrough when there are no sections.
- `collapsedSections` / `collapsedSummary` are configurable in `.releaserc.json`.
- Documented in `docs/release-automation.md` with a pointer from `AGENTS.md`.

## Local gate

`pnpm check` (pre-existing unrelated warning only), `pnpm typecheck`, `pnpm build`, `pnpm test` (215 tests) all green.

https://claude.ai/code/session_01Uyz6TdPqRmcM3CRM1W8YJg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive documentation explaining how release notes are generated and organized, including the collapsing of internal commits into expandable sections.

* **Tests**
  * Added unit tests for release notes section collapsing functionality.

* **Chores**
  * Updated release configuration to organize commit types into public and internal sections.
  * Added release notes generation dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->