### PR TITLE
feat(help-center): expose article sort position on update_article

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ zendesk-mcp-server acme --namespace tickets
 | `list_user_segments` | List user segments (article visibility) | read |
 | `compare_translations` | Section-level diff between two locales of an article | read |
 | `create_article` | Create a new article in a section | write |
-| `update_article` | Update article metadata (draft, labels, tags, visibility, section) | write |
+| `update_article` | Update article metadata (draft, labels, tags, visibility, section, sort position) | write |
 | `create_article_translation` | Create a translation for an article | write |
 | `update_article_translation` | Update an article's translation (full body) | write |
 | `update_article_section` | Replace a single section of an article | write |

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -579,7 +579,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           .min(0)
           .optional()
           .describe(
-            'Sort position within the section (manual ordering only; 0 = first/top). New articles default to position 0. To move an article to the END of its section, set this to the highest current position in the section — read it from list_articles with sort_by="position", sort_order="desc".',
+            'Sort position within the section (manual ordering only; 0 = first/top). New articles default to position 0. To move an article to the END of its section, set this to one more than the highest current position: read the highest position P from list_articles with sort_by="position", sort_order="desc", then set position = P + 1.',
           ),
       }),
       annotations: {

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -562,7 +562,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Update Help Center Article',
       description:
-        'Update article metadata only (draft, promoted, labels, tags, visibility, section, etc.). Does NOT update content (title, body) — use update_article_translation for that.',
+        'Update article metadata only (draft, promoted, labels, tags, visibility, section, sort position, etc.). Does NOT update content (title, body) — use update_article_translation for that.',
       inputSchema: z.object({
         article_id: z.number().int(),
         draft: z.boolean().optional(),
@@ -573,6 +573,14 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         author_id: z.number().int().optional().describe('Author user ID'),
         permission_group_id: z.number().int().optional().describe('Permission group ID'),
         section_id: z.number().int().optional(),
+        position: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            'Sort position within the section (manual ordering only; 0 = first/top). New articles default to position 0. To move an article to the END of its section, set this to the highest current position in the section — read it from list_articles with sort_by="position", sort_order="desc".',
+          ),
       }),
       annotations: {
         readOnlyHint: false,

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -81,6 +81,7 @@ export const formatArticleSummary = (article: ZendeskArticle): string =>
     `## ${article.title} (${article.id})`,
     `- **Locale**: ${article.locale} | **Source locale**: ${article.source_locale}`,
     `- **Section**: ${article.section_id} | **Draft**: ${article.draft}`,
+    typeof article.position === 'number' ? `- **Position**: ${article.position}` : '',
     article.label_names.length > 0 ? `- **Labels**: ${article.label_names.join(', ')}` : '',
     `- **Created**: ${article.created_at} | **Updated**: ${article.updated_at}`,
   ]

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -339,7 +339,13 @@ export const handlers = [
   http.post(`${HC_BASE}/sections/:sid/articles`, () =>
     HttpResponse.json({ article: MOCK_ARTICLE }),
   ),
-  http.put(`${HC_BASE}/articles/:id`, () => HttpResponse.json({ article: MOCK_ARTICLE })),
+  http.put(`${HC_BASE}/articles/:id`, async ({ request, params }) => {
+    const reqBody = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const update = (reqBody['article'] as Record<string, unknown> | undefined) ?? {};
+    return HttpResponse.json({
+      article: { ...MOCK_ARTICLE, id: Number(params['id']), ...update },
+    });
+  }),
 
   // Guide - Permission Groups
   http.get(`${BASE}/guide/permission_groups`, () =>

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -247,7 +247,9 @@ describe('help center tools', () => {
 
     it('documents how to move an article to the end of its section', () => {
       const tool = findTool('update_article');
-      expect(tool.description.toLowerCase()).toContain('position');
+      const field = (tool.inputSchema as { shape: { position: { description?: string } } }).shape
+        .position;
+      expect(field.description).toContain('P + 1');
       expect(tool.inputSchema.parse({ article_id: 5000, position: 3 })).toMatchObject({
         position: 3,
       });

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -238,6 +238,20 @@ describe('help center tools', () => {
       const result = await tool.handler({ article_id: 5000, draft: false });
       expect(result.content[0]?.text).toContain('Article #5000 updated');
     });
+
+    it('forwards position to reposition the article within its section', async () => {
+      const tool = findTool('update_article');
+      const result = await tool.handler({ article_id: 5000, position: 7 });
+      expect(result.content[0]?.text).toContain('**Position**: 7');
+    });
+
+    it('documents how to move an article to the end of its section', () => {
+      const tool = findTool('update_article');
+      expect(tool.description.toLowerCase()).toContain('position');
+      expect(tool.inputSchema.parse({ article_id: 5000, position: 3 })).toMatchObject({
+        position: 3,
+      });
+    });
   });
 
   describe('list_content_tags', () => {

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -164,6 +164,19 @@ describe('formatArticleSummary', () => {
     const result = formatArticleSummary({ ...MOCK_ARTICLE, label_names: [] });
     expect(result).not.toContain('Labels');
   });
+
+  it('includes the sort position', () => {
+    const result = formatArticleSummary({ ...MOCK_ARTICLE, position: 7 });
+    expect(result).toContain('**Position**: 7');
+  });
+
+  it('omits position when not a number', () => {
+    const result = formatArticleSummary({
+      ...MOCK_ARTICLE,
+      position: undefined as unknown as number,
+    });
+    expect(result).not.toContain('Position');
+  });
 });
 
 describe('formatTranslation', () => {


### PR DESCRIPTION
## Why

The Zendesk `PUT /help_center/articles/{id}` endpoint accepts a `position` field, but `update_article` did not expose it — so callers could not reorder an article within its section. New articles default to `position` 0 (top of the section), with no way to move them to the bottom.

This unblocks the Fruggr convention of publishing new articles at the **end** of their section (driven from the `fruggr-zendesk-documentation` skill on the consumer side).

## What changed

- **`update_article`**: add an optional `position` field to the input schema, with guidance to read the section's current max position from `list_articles` (`sort_by="position"`, `sort_order="desc"`) and set `position = P + 1` to append. The handler already forwards `updates` verbatim — no endpoint change.
- **`formatArticleSummary`**: surface `Position` (guarded on `typeof === 'number'`) so `list_articles` / `get_article` / `search_articles` show the current order.
- **Docs**: README row for `update_article` mentions sort position.
- **Tests**: MSW `PUT /articles/:id` now echoes the request body so the forwarding is testable; +4 tests (position forwarded, shown in formatting, omitted when absent, schema accepts it).

No tool added/removed — tool counts unchanged.

## Test plan

- `pnpm typecheck` ✓
- `pnpm check` ✓ (pre-existing warning in `article-sections.ts` only)
- `pnpm test` ✓ (219 passed)
- `pnpm build` ✓

## Release

`feat:` → semantic-release minor bump on merge to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to update and view article sort positions within Help Center sections, enabling better control over article ordering.
  * Articles now display position information in their summaries.

* **Documentation**
  * Updated Help Center tool documentation to reflect the new article position management capability.

* **Tests**
  * Added unit and handler tests to verify position handling and summary display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->