### PR TITLE
feat(auth): add structured logging to diagnose the OAuth browser flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,6 @@ jobs:
       - name: Verify tarball runs on Node 20
         run: |
           set -euo pipefail
-          OUT=$(timeout 5 zendesk-mcp-server smoke-test 2>&1 || true)
+          OUT=$(env LOG_LEVEL=info timeout 5 zendesk-mcp-server smoke-test 2>&1 || true)
           echo "$OUT"
           echo "$OUT" | grep -q "stdio_transport_ready"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,4 @@ jobs:
           set -euo pipefail
           OUT=$(timeout 5 zendesk-mcp-server smoke-test 2>&1 || true)
           echo "$OUT"
-          echo "$OUT" | grep -q "running via stdio"
+          echo "$OUT" | grep -q "stdio_transport_ready"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ src/
 │   └── stdio.ts          # Stdio transport
 └── utils/
     ├── formatting.ts     # Markdown formatters per entity type
+    ├── logger.ts         # Structured logger (stderr + MCP logging notifications)
     └── pagination.ts     # Cursor-based pagination helpers
 ```
 

--- a/README.md
+++ b/README.md
@@ -291,9 +291,37 @@ zendesk-mcp-server acme --tool get_ticket --tool search_tickets --tool get_curre
 | `ZENDESK_OAUTH_CLIENT_ID` | no | `<subdomain>_zendesk` | OAuth client identifier |
 | `ZENDESK_EMAIL` | for API token auth | — | Agent email for Basic auth |
 | `ZENDESK_API_TOKEN` | for API token auth | — | Zendesk API token |
-| `LOG_LEVEL` | no | `info` | Log verbosity |
+| `LOG_LEVEL` | no | `info` | Log verbosity (`debug` surfaces the full OAuth flow trace) |
 
 If both `ZENDESK_EMAIL` and `ZENDESK_API_TOKEN` are set, the server uses API token auth. Otherwise, it uses OAuth 2.1 PKCE.
+
+## Troubleshooting
+
+### The browser doesn't open during OAuth login
+
+The OAuth flow opens your default browser on the first tool call. If it doesn't
+open (common in sandboxed or remote desktop environments), the authorization URL
+is still printed to the server's stderr — open it manually.
+
+To collect diagnostics, restart with `LOG_LEVEL=debug`. The server then emits
+structured logs through **two channels**, so they're reachable on any MCP client:
+
+- **stderr** — captured to a log file by every mainstream client.
+- **MCP logging notifications** (`notifications/message`) — surfaced by clients
+  that support the `logging` capability.
+
+When the browser fails to open, look for the `oauth_browser_open_failed` event:
+it reports the underlying error, the platform, and which environment markers are
+present (no secrets, tokens, or env values are ever logged).
+
+Where each client writes the server's stderr:
+
+| Client | Log location |
+|--------|--------------|
+| Claude Desktop (macOS) | `~/Library/Logs/Claude/mcp-server-*.log` |
+| Claude Desktop (Windows) | `%APPDATA%\Claude\logs\mcp-server-*.log` |
+| Claude Code | `claude --debug`, or the session logs |
+| Cursor / VS Code / Cline | the extension's MCP output/log panel |
 
 ## Development
 

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -5,6 +5,9 @@ const TIMEOUT_MS = 5000;
 
 const proc = spawn('node', ['dist/index.js', 'smoke-test'], {
   stdio: ['ignore', 'pipe', 'pipe'],
+  // The readiness marker is emitted at info level; force it so an inherited
+  // LOG_LEVEL=warn/error can't suppress the marker and false-fail the smoke test.
+  env: { ...process.env, LOG_LEVEL: 'info' },
 });
 
 let output = '';

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 
-const MARKER = 'running via stdio';
+const MARKER = 'stdio_transport_ready';
 const TIMEOUT_MS = 5000;
 
 const proc = spawn('node', ['dist/index.js', 'smoke-test'], {

--- a/src/auth/browser-oauth.ts
+++ b/src/auth/browser-oauth.ts
@@ -52,6 +52,7 @@ export const authenticateViaBrowser = (
 
   return new Promise((resolve, reject) => {
     let callbackServer: Server;
+    let authTimeout: ReturnType<typeof setTimeout> | undefined;
 
     callbackServer = createServer(async (req, res) => {
       const url = new URL(req.url ?? '/', `http://localhost`);
@@ -74,6 +75,7 @@ export const authenticateViaBrowser = (
         const desc = url.searchParams.get('error_description') ?? error;
         res.writeHead(400, { 'Content-Type': 'text/html' });
         res.end(`<html><body><h1>Authentication failed</h1><p>${desc}</p></body></html>`);
+        clearTimeout(authTimeout);
         callbackServer.close();
         reject(new Error(`OAuth error: ${desc}`));
         return;
@@ -82,6 +84,7 @@ export const authenticateViaBrowser = (
       if (!code) {
         res.writeHead(400, { 'Content-Type': 'text/html' });
         res.end('<html><body><h1>Missing authorization code</h1></body></html>');
+        clearTimeout(authTimeout);
         callbackServer.close();
         reject(new Error('Missing authorization code in callback'));
         return;
@@ -121,6 +124,7 @@ export const authenticateViaBrowser = (
             '<script>window.close()</script></body></html>',
         );
 
+        clearTimeout(authTimeout);
         callbackServer.close();
         resolve(tokenData);
       } catch (err) {
@@ -128,6 +132,7 @@ export const authenticateViaBrowser = (
         res.end(
           `<html><body><h1>Token exchange failed</h1><p>${err instanceof Error ? err.message : String(err)}</p></body></html>`,
         );
+        clearTimeout(authTimeout);
         callbackServer.close();
         reject(err);
       }
@@ -178,14 +183,16 @@ export const authenticateViaBrowser = (
         });
     });
 
-    // Timeout after 5 minutes
-    setTimeout(
+    // Timeout after 5 minutes. Cleared on every completion path above so a
+    // successful auth can't emit a spurious `oauth_timeout` error later.
+    authTimeout = setTimeout(
       () => {
         logger.error('oauth_timeout', { timeoutMs: 5 * 60 * 1000 });
         callbackServer.close();
         reject(new Error('OAuth authentication timed out (5 min). Please try again.'));
       },
       5 * 60 * 1000,
-    ).unref();
+    );
+    authTimeout.unref();
   });
 };

--- a/src/auth/browser-oauth.ts
+++ b/src/auth/browser-oauth.ts
@@ -1,9 +1,22 @@
 import { createHash, randomBytes } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { createServer, type Server } from 'node:http';
+import { release } from 'node:os';
 import open from 'open';
 import { getOAuthUrls } from '../constants';
+import { type Logger, silentLogger } from '../utils/logger';
 
 const DEFAULT_CALLBACK_PORT = 3000;
+
+/** Best-effort WSL detection: WSL kernels carry "microsoft" in /proc/version. */
+const detectWsl = (): boolean => {
+  if (process.platform !== 'linux') return false;
+  try {
+    return readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft');
+  } catch {
+    return false;
+  }
+};
 
 interface BrowserOAuthConfig {
   subdomain: string;
@@ -28,7 +41,10 @@ const generateCodeChallenge = (verifier: string): string =>
  * Starts a temporary HTTP server to receive the callback.
  * Returns the access token on success.
  */
-export const authenticateViaBrowser = (config: BrowserOAuthConfig): Promise<TokenResult> => {
+export const authenticateViaBrowser = (
+  config: BrowserOAuthConfig,
+  logger: Logger = silentLogger,
+): Promise<TokenResult> => {
   const { subdomain, oauthClientId } = config;
   const { authorizeUrl, tokenUrl } = getOAuthUrls(subdomain);
   const codeVerifier = generateCodeVerifier();
@@ -48,6 +64,11 @@ export const authenticateViaBrowser = (config: BrowserOAuthConfig): Promise<Toke
 
       const code = url.searchParams.get('code');
       const error = url.searchParams.get('error');
+
+      logger.debug('oauth_callback_received', {
+        hasCode: Boolean(code),
+        hasError: Boolean(error),
+      });
 
       if (error) {
         const desc = url.searchParams.get('error_description') ?? error;
@@ -83,12 +104,15 @@ export const authenticateViaBrowser = (config: BrowserOAuthConfig): Promise<Toke
           body: tokenBody.toString(),
         });
 
+        logger.debug('oauth_token_exchange', { status: tokenResponse.status });
+
         if (!tokenResponse.ok) {
           const errorBody = await tokenResponse.text();
           throw new Error(`Token exchange failed (${tokenResponse.status}): ${errorBody}`);
         }
 
         const tokenData = (await tokenResponse.json()) as TokenResult;
+        logger.info('oauth_authenticated');
 
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(
@@ -124,17 +148,40 @@ export const authenticateViaBrowser = (config: BrowserOAuthConfig): Promise<Toke
       });
 
       const authUrl = `${authorizeUrl}?${params.toString()}`;
+      logger.debug('oauth_callback_listening', { port, redirectUri });
+      logger.info('oauth_browser_opening');
+      // Full authorize URL is debug-only: it carries the (public) client_id and
+      // PKCE challenge — no secret — but stays out of default-level logs.
+      logger.debug('oauth_authorize_url', { url: authUrl });
       console.error(`Opening browser for Zendesk authentication...`);
       console.error(`If the browser doesn't open, visit: ${authUrl}`);
 
-      open(authUrl).catch(() => {
-        // Browser open failed — the URL is already logged
-      });
+      open(authUrl)
+        .then(() => {
+          logger.debug('oauth_browser_opened');
+        })
+        .catch((err: unknown) => {
+          // Do NOT swallow: this is the #60 signal. Capture why `open` failed
+          // plus environment markers (presence only, never values).
+          logger.error('oauth_browser_open_failed', {
+            error: err instanceof Error ? err.message : String(err),
+            errorCode: (err as NodeJS.ErrnoException | undefined)?.code,
+            platform: process.platform,
+            release: release(),
+            isWsl: detectWsl(),
+            hasSystemRoot: Boolean(process.env['SYSTEMROOT']),
+            hasWindir: Boolean(process.env['WINDIR']),
+            hasComSpec: Boolean(process.env['ComSpec']),
+            hasPath: Boolean(process.env['PATH']),
+            hasDisplay: Boolean(process.env['DISPLAY']),
+          });
+        });
     });
 
     // Timeout after 5 minutes
     setTimeout(
       () => {
+        logger.error('oauth_timeout', { timeoutMs: 5 * 60 * 1000 });
         callbackServer.close();
         reject(new Error('OAuth authentication timed out (5 min). Please try again.'));
       },

--- a/src/auth/browser-oauth.ts
+++ b/src/auth/browser-oauth.ts
@@ -7,6 +7,7 @@ import { getOAuthUrls } from '../constants';
 import { type Logger, silentLogger } from '../utils/logger';
 
 const DEFAULT_CALLBACK_PORT = 3000;
+const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Best-effort WSL detection: WSL kernels carry "microsoft" in /proc/version. */
 const detectWsl = (): boolean => {
@@ -185,14 +186,11 @@ export const authenticateViaBrowser = (
 
     // Timeout after 5 minutes. Cleared on every completion path above so a
     // successful auth can't emit a spurious `oauth_timeout` error later.
-    authTimeout = setTimeout(
-      () => {
-        logger.error('oauth_timeout', { timeoutMs: 5 * 60 * 1000 });
-        callbackServer.close();
-        reject(new Error('OAuth authentication timed out (5 min). Please try again.'));
-      },
-      5 * 60 * 1000,
-    );
+    authTimeout = setTimeout(() => {
+      logger.error('oauth_timeout', { timeoutMs: AUTH_TIMEOUT_MS });
+      callbackServer.close();
+      reject(new Error('OAuth authentication timed out (5 min). Please try again.'));
+    }, AUTH_TIMEOUT_MS);
     authTimeout.unref();
   });
 };

--- a/src/auth/browser-oauth.ts
+++ b/src/auth/browser-oauth.ts
@@ -159,6 +159,9 @@ export const authenticateViaBrowser = (
       // Full authorize URL is debug-only: it carries the (public) client_id and
       // PKCE challenge — no secret — but stays out of default-level logs.
       logger.debug('oauth_authorize_url', { url: authUrl });
+      // Always-on, ungated user-facing fallback: if the browser can't open, the
+      // user must see this URL regardless of LOG_LEVEL — do NOT route it through
+      // the (level-gated) logger.
       console.error(`Opening browser for Zendesk authentication...`);
       console.error(`If the browser doesn't open, visit: ${authUrl}`);
 

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,3 +1,4 @@
+import { type Logger, silentLogger } from '../utils/logger';
 import { authenticateViaBrowser } from './browser-oauth';
 
 interface StoredToken {
@@ -5,7 +6,10 @@ interface StoredToken {
   refreshToken?: string | undefined;
 }
 
-export const createTokenStore = (config: { subdomain: string; oauthClientId: string }) => {
+export const createTokenStore = (
+  config: { subdomain: string; oauthClientId: string },
+  logger: Logger = silentLogger,
+) => {
   let token: StoredToken | undefined;
   let authPromise: Promise<StoredToken> | undefined;
 
@@ -14,13 +18,20 @@ export const createTokenStore = (config: { subdomain: string; oauthClientId: str
   };
 
   const ensureToken = async (): Promise<StoredToken> => {
-    if (token) return token;
+    if (token) {
+      logger.debug('oauth_token_cache_hit');
+      return token;
+    }
 
     if (!authPromise) {
-      authPromise = authenticateViaBrowser({
-        subdomain: config.subdomain,
-        oauthClientId: config.oauthClientId,
-      })
+      logger.info('oauth_auth_start');
+      authPromise = authenticateViaBrowser(
+        {
+          subdomain: config.subdomain,
+          oauthClientId: config.oauthClientId,
+        },
+        logger,
+      )
         .then((result) => {
           const stored: StoredToken = {
             accessToken: result.access_token,
@@ -32,6 +43,9 @@ export const createTokenStore = (config: { subdomain: string; oauthClientId: str
         })
         .catch((err) => {
           authPromise = undefined;
+          logger.warn('oauth_auth_failed', {
+            error: err instanceof Error ? err.message : String(err),
+          });
           throw err;
         });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,24 +3,29 @@ import { createTokenStore } from './auth/token-store';
 import { loadConfig } from './config';
 import { createMcpServer } from './server';
 import { startStdioTransport } from './transports/stdio';
+import { createLogger } from './utils/logger';
 
 const main = async (): Promise<void> => {
   const config = loadConfig();
+  const logger = createLogger(config.logLevel);
 
   if (config.zendeskEmail && config.zendeskApiToken) {
     // API token mode — static Basic auth
     const staticToken = buildBasicAuthHeader(config.zendeskEmail, config.zendeskApiToken);
     const getToken = () => staticToken;
-    const server = createMcpServer(config, getToken);
-    await startStdioTransport(server);
+    const server = createMcpServer(config, getToken, logger);
+    await startStdioTransport(server, logger);
   } else {
     // OAuth mode — browser-based auth on first tool call
-    const tokenStore = createTokenStore({
-      subdomain: config.subdomain,
-      oauthClientId: config.oauthClientId,
-    });
-    const server = createMcpServer(config, tokenStore.getToken);
-    await startStdioTransport(server);
+    const tokenStore = createTokenStore(
+      {
+        subdomain: config.subdomain,
+        oauthClientId: config.oauthClientId,
+      },
+      logger,
+    );
+    const server = createMcpServer(config, tokenStore.getToken, logger);
+    await startStdioTransport(server, logger);
   }
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import type { Config } from './config';
 import { filterTools, groupByNamespace } from './routing/registry';
 import { createAllTools, type ToolDefinition } from './tools/index';
 import { type Logger, silentLogger } from './utils/logger';
+import { readPackageInfo } from './utils/package-info';
 
 const NAMESPACE_LABELS: Record<string, { toolName: string; title: string }> = {
   tickets: { toolName: 'zendesk_tickets', title: 'Zendesk Tickets' },
@@ -74,10 +75,13 @@ export const createMcpServer = (
   getToken: () => string | Promise<string>,
   logger: Logger = silentLogger,
 ): McpServer => {
+  // Read name/version from package.json at runtime rather than hardcoding them
+  // (the old literals were stale and even carried the wrong package name).
+  const pkg = readPackageInfo();
   const server = new McpServer(
     {
-      name: '@digital4better/zendesk-mcp-server',
-      version: '0.1.0',
+      name: pkg.name,
+      version: pkg.version,
     },
     // Advertise the logging capability so structured diagnostics (notably the
     // OAuth browser flow) reach clients that support it. Clients that don't

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import * as z from 'zod/v4';
 import type { Config } from './config';
 import { filterTools, groupByNamespace } from './routing/registry';
 import { createAllTools, type ToolDefinition } from './tools/index';
+import { type Logger, silentLogger } from './utils/logger';
 
 const NAMESPACE_LABELS: Record<string, { toolName: string; title: string }> = {
   tickets: { toolName: 'zendesk_tickets', title: 'Zendesk Tickets' },
@@ -71,11 +72,22 @@ const registerProxyTool = (
 export const createMcpServer = (
   config: Config,
   getToken: () => string | Promise<string>,
+  logger: Logger = silentLogger,
 ): McpServer => {
-  const server = new McpServer({
-    name: '@digital4better/zendesk-mcp-server',
-    version: '0.1.0',
-  });
+  const server = new McpServer(
+    {
+      name: '@digital4better/zendesk-mcp-server',
+      version: '0.1.0',
+    },
+    // Advertise the logging capability so structured diagnostics (notably the
+    // OAuth browser flow) reach clients that support it. Clients that don't
+    // simply ignore the notifications.
+    { capabilities: { logging: {} } },
+  );
+
+  // Route the logger's MCP sink through this server. Auth runs lazily on the
+  // first tool call (after connect), so notifications can flow by then.
+  logger.attachServer(server);
 
   const allTools = createAllTools({ subdomain: config.subdomain, getToken });
 
@@ -125,6 +137,6 @@ export const createMcpServer = (
     }
   }
 
-  console.error(`Registered ${filteredTools.length} tools in ${config.mode} mode`);
+  logger.info('tools_registered', { count: filteredTools.length, mode: config.mode });
   return server;
 };

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -1,8 +1,12 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { type Logger, silentLogger } from '../utils/logger';
 
-export const startStdioTransport = async (server: McpServer): Promise<void> => {
+export const startStdioTransport = async (
+  server: McpServer,
+  logger: Logger = silentLogger,
+): Promise<void> => {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error('Zendesk MCP server running via stdio');
+  logger.info('stdio_transport_ready');
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -68,14 +68,6 @@ const redactValue = (value: unknown): unknown => {
   return value;
 };
 
-const redact = (fields: Fields): Fields => {
-  const out: Fields = {};
-  for (const [key, value] of Object.entries(fields)) {
-    out[key] = isSensitive(key) ? '[REDACTED]' : redactValue(value);
-  }
-  return out;
-};
-
 const renderValue = (value: unknown): string => {
   if (typeof value === 'string') return value;
   if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
@@ -110,7 +102,7 @@ export const createLogger = (level: LogLevel): Logger => {
   const emit = (lvl: LogLevel, event: string, fields?: Fields): void => {
     if (SEVERITY[lvl] < min) return;
 
-    const safe = fields ? redact(fields) : {};
+    const safe = fields ? (redactValue(fields) as Fields) : {};
     console.error(formatLine(lvl, event, safe));
 
     if (server) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,126 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { LogLevel } from '../config';
+
+type Fields = Record<string, unknown>;
+
+/**
+ * Minimal structured logger with two sinks:
+ *  - stderr (always, gated by the configured level) — the universal floor that
+ *    every mainstream MCP client captures to a log file;
+ *  - MCP `notifications/message` (when a server is attached and advertises the
+ *    `logging` capability) — surfaced by clients that support it, ignored
+ *    gracefully by those that don't.
+ *
+ * Both sinks share a single level gate (`LOG_LEVEL`); MCP clients may further
+ * raise the floor via `logging/setLevel`, which the SDK filters on its own.
+ */
+export interface Logger {
+  debug(event: string, fields?: Fields): void;
+  info(event: string, fields?: Fields): void;
+  warn(event: string, fields?: Fields): void;
+  error(event: string, fields?: Fields): void;
+  /** Attach an McpServer so logs are also emitted as MCP notifications. */
+  attachServer(server: Pick<McpServer, 'sendLoggingMessage'>): void;
+}
+
+const SEVERITY: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+// Our 4 levels mapped onto the MCP logging levels (note: `warning`, not `warn`).
+const MCP_LEVEL: Record<LogLevel, 'debug' | 'info' | 'warning' | 'error'> = {
+  debug: 'debug',
+  info: 'info',
+  warn: 'warning',
+  error: 'error',
+};
+
+// Field keys whose values must never reach a sink, matched after normalising
+// (lowercase, separators stripped) so `access_token`, `accessToken` and
+// `ACCESS-TOKEN` all collapse to the same key. Diagnostic fields such as
+// `errorCode`, `status` or `error` (a message) are intentionally NOT listed.
+const REDACTED_KEYS = new Set([
+  'token',
+  'accesstoken',
+  'refreshtoken',
+  'code',
+  'codeverifier',
+  'authorization',
+  'password',
+  'secret',
+  'apitoken',
+  'bearer',
+]);
+
+const isSensitive = (key: string): boolean =>
+  REDACTED_KEYS.has(key.toLowerCase().replace(/[_-]/g, ''));
+
+const redact = (fields: Fields): Fields => {
+  const out: Fields = {};
+  for (const [key, value] of Object.entries(fields)) {
+    out[key] = isSensitive(key) ? '[REDACTED]' : value;
+  }
+  return out;
+};
+
+const renderValue = (value: unknown): string => {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '[unserializable]';
+  }
+};
+
+const formatLine = (level: LogLevel, event: string, fields: Fields): string => {
+  const parts = Object.entries(fields).map(([key, value]) => `${key}=${renderValue(value)}`);
+  return `[zendesk-mcp] [${level}] ${event}${parts.length ? ` ${parts.join(' ')}` : ''}`;
+};
+
+const noop = (): void => {};
+
+export const silentLogger: Logger = {
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  attachServer: noop,
+};
+
+export const createLogger = (level: LogLevel): Logger => {
+  const min = SEVERITY[level];
+  let server: Pick<McpServer, 'sendLoggingMessage'> | undefined;
+
+  const emit = (lvl: LogLevel, event: string, fields?: Fields): void => {
+    if (SEVERITY[lvl] < min) return;
+
+    const safe = fields ? redact(fields) : {};
+    console.error(formatLine(lvl, event, safe));
+
+    if (server) {
+      try {
+        void server
+          .sendLoggingMessage({
+            level: MCP_LEVEL[lvl],
+            logger: 'zendesk-mcp-server',
+            data: { event, ...safe },
+          })
+          .catch(noop);
+      } catch {
+        // Forwarding is best-effort (e.g. transport not connected yet);
+        // it must never break the flow that emitted the log.
+      }
+    }
+  };
+
+  return {
+    debug: (event, fields) => emit('debug', event, fields),
+    info: (event, fields) => emit('info', event, fields),
+    warn: (event, fields) => emit('warn', event, fields),
+    error: (event, fields) => emit('error', event, fields),
+    attachServer: (s) => {
+      server = s;
+    },
+  };
+};

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -53,10 +53,25 @@ const REDACTED_KEYS = new Set([
 const isSensitive = (key: string): boolean =>
   REDACTED_KEYS.has(key.toLowerCase().replace(/[_-]/g, ''));
 
+// Recursively redact: a sensitive *key* anywhere in the tree (top-level or
+// nested in objects/arrays) has its value replaced, so `{ oauth: { token } }`
+// can't leak. Primitives are returned as-is.
+const redactValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = isSensitive(key) ? '[REDACTED]' : redactValue(val);
+    }
+    return out;
+  }
+  return value;
+};
+
 const redact = (fields: Fields): Fields => {
   const out: Fields = {};
   for (const [key, value] of Object.entries(fields)) {
-    out[key] = isSensitive(key) ? '[REDACTED]' : value;
+    out[key] = isSensitive(key) ? '[REDACTED]' : redactValue(value);
   }
   return out;
 };
@@ -104,7 +119,9 @@ export const createLogger = (level: LogLevel): Logger => {
           .sendLoggingMessage({
             level: MCP_LEVEL[lvl],
             logger: 'zendesk-mcp-server',
-            data: { event, ...safe },
+            // `event` last so a caller-supplied `fields.event` can't shadow the
+            // canonical event name.
+            data: { ...safe, event },
           })
           .catch(noop);
       } catch {

--- a/src/utils/package-info.ts
+++ b/src/utils/package-info.ts
@@ -22,17 +22,27 @@ const FALLBACK: PackageInfo = {
  * at runtime (not inlining at build) matters because semantic-release bumps the
  * version into package.json before publishing, after the build step.
  */
+// package.json can't change during the process lifetime, and createMcpServer
+// (hence this) may run several times (notably across tests) — cache the result.
+let cached: PackageInfo | undefined;
+
 export const readPackageInfo = (): PackageInfo => {
+  if (cached) return cached;
   try {
     let dir = dirname(fileURLToPath(import.meta.url));
     for (let depth = 0; depth < 8; depth++) {
       try {
-        const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as
-          | Partial<PackageInfo>
-          | undefined;
-        if (pkg?.name && pkg.version) return { name: pkg.name, version: pkg.version };
+        // JSON.parse yields `unknown`; validate at runtime rather than asserting.
+        const raw: unknown = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+        if (raw && typeof raw === 'object') {
+          const pkg = raw as Partial<PackageInfo>;
+          if (typeof pkg.name === 'string' && typeof pkg.version === 'string') {
+            cached = { name: pkg.name, version: pkg.version };
+            return cached;
+          }
+        }
       } catch {
-        // No readable package.json here — keep walking up.
+        // No readable/valid package.json here — keep walking up.
       }
       const parent = dirname(dir);
       if (parent === dir) break;
@@ -41,5 +51,6 @@ export const readPackageInfo = (): PackageInfo => {
   } catch {
     // import.meta / fs unavailable — fall back below.
   }
-  return FALLBACK;
+  cached = FALLBACK;
+  return cached;
 };

--- a/src/utils/package-info.ts
+++ b/src/utils/package-info.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface PackageInfo {
+  name: string;
+  version: string;
+}
+
+// Used only if package.json can't be located/parsed (should not happen in a
+// published install). Keeps the server bootable rather than throwing.
+const FALLBACK: PackageInfo = {
+  name: '@fruggr/zendesk-mcp-server',
+  version: '0.0.0',
+};
+
+/**
+ * Read `name`/`version` from the package's own package.json at runtime instead
+ * of hardcoding them. Walks up from this module to the nearest package.json,
+ * which resolves correctly both when bundled (`dist/index.js` → repo root) and
+ * from source/tests (`src/` has no package.json, so the root is found). Reading
+ * at runtime (not inlining at build) matters because semantic-release bumps the
+ * version into package.json before publishing, after the build step.
+ */
+export const readPackageInfo = (): PackageInfo => {
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < 8; depth++) {
+      try {
+        const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as
+          | Partial<PackageInfo>
+          | undefined;
+        if (pkg?.name && pkg.version) return { name: pkg.name, version: pkg.version };
+      } catch {
+        // No readable package.json here — keep walking up.
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // import.meta / fs unavailable — fall back below.
+  }
+  return FALLBACK;
+};

--- a/src/utils/package-info.ts
+++ b/src/utils/package-info.ts
@@ -28,28 +28,26 @@ let cached: PackageInfo | undefined;
 
 export const readPackageInfo = (): PackageInfo => {
   if (cached) return cached;
-  try {
-    let dir = dirname(fileURLToPath(import.meta.url));
-    for (let depth = 0; depth < 8; depth++) {
-      try {
-        // JSON.parse yields `unknown`; validate at runtime rather than asserting.
-        const raw: unknown = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
-        if (raw && typeof raw === 'object') {
-          const pkg = raw as Partial<PackageInfo>;
-          if (typeof pkg.name === 'string' && typeof pkg.version === 'string') {
-            cached = { name: pkg.name, version: pkg.version };
-            return cached;
-          }
+  // Only readFileSync/JSON.parse can throw here (caught per-iteration below);
+  // fileURLToPath/dirname/join don't, so no outer guard is needed.
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let depth = 0; depth < 8; depth++) {
+    try {
+      // JSON.parse yields `unknown`; validate at runtime rather than asserting.
+      const raw: unknown = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+      if (raw && typeof raw === 'object') {
+        const pkg = raw as Partial<PackageInfo>;
+        if (typeof pkg.name === 'string' && typeof pkg.version === 'string') {
+          cached = { name: pkg.name, version: pkg.version };
+          return cached;
         }
-      } catch {
-        // No readable/valid package.json here — keep walking up.
       }
-      const parent = dirname(dir);
-      if (parent === dir) break;
-      dir = parent;
+    } catch {
+      // No readable/valid package.json here — keep walking up.
     }
-  } catch {
-    // import.meta / fs unavailable — fall back below.
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
   cached = FALLBACK;
   return cached;

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -27,6 +27,13 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
       connected = undefined;
     });
 
+    describe('capabilities', () => {
+      it('advertises the logging capability over the wire', async () => {
+        connected = await harness.connect(makeConfig());
+        expect(connected.client.getServerCapabilities()?.logging).toBeDefined();
+      });
+    });
+
     describe('tools/list', () => {
       it('exposes individual tools in "all" mode', async () => {
         connected = await harness.connect(makeConfig({ mode: 'all' }));

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -172,6 +172,12 @@ export const MOCK_COMMENT = {
   ],
 };
 
+// OAuth token endpoint used by the browser PKCE flow. Opt-in per test via
+// mswServer.use() so the OAuth roundtrip mock stays centralized here too.
+export const oauthTokenHandler = http.post('https://testsubdomain.zendesk.com/oauth/tokens', () =>
+  HttpResponse.json({ access_token: 'token-abc', token_type: 'bearer', scope: 'read write' }),
+);
+
 // Opt-in error handlers for tests that exercise failure paths. Kept here so all
 // Zendesk mocking stays centralized; activate one per test via mswServer.use().
 export const errorHandlers = {

--- a/tests/unit/auth/browser-oauth.test.ts
+++ b/tests/unit/auth/browser-oauth.test.ts
@@ -72,4 +72,48 @@ describe('authenticateViaBrowser', () => {
       /^http:\/\/localhost:\d+\/callback$/,
     );
   });
+
+  it('logs the failure (with platform diagnostics) instead of swallowing it when open rejects', async () => {
+    mswServer.use(
+      http.post(`https://${SUB}.zendesk.com/oauth/tokens`, async () =>
+        HttpResponse.json({ access_token: 'token-abc', token_type: 'bearer', scope: 'read' }),
+      ),
+    );
+
+    const errorEvents: Array<{ event: string; fields?: Record<string, unknown> }> = [];
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((event: string, fields?: Record<string, unknown>) => {
+        errorEvents.push({ event, fields });
+      }),
+      attachServer: vi.fn(),
+    };
+
+    // The browser fails to open (the #60 symptom). The flow must NOT crash: the
+    // user can still complete auth by visiting the URL, so we drive the callback
+    // ourselves to let the promise resolve.
+    openMock.mockImplementation(async (url: string) => {
+      const redirectUri = new URL(url).searchParams.get('redirect_uri');
+      setImmediate(() => {
+        fetch(`${redirectUri}?code=the-auth-code`).catch(() => {});
+      });
+      throw Object.assign(new Error('spawn failed'), { code: 'ENOENT' });
+    });
+
+    const result = await authenticateViaBrowser(
+      { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 },
+      logger,
+    );
+
+    expect(result.access_token).toBe('token-abc');
+    const failure = errorEvents.find((e) => e.event === 'oauth_browser_open_failed');
+    expect(failure).toBeDefined();
+    expect(failure?.fields?.['error']).toBe('spawn failed');
+    expect(failure?.fields?.['errorCode']).toBe('ENOENT');
+    expect(failure?.fields?.['platform']).toBe(process.platform);
+    // Environment presence is reported as booleans (never values).
+    expect(typeof failure?.fields?.['hasSystemRoot']).toBe('boolean');
+  });
 });

--- a/tests/unit/auth/browser-oauth.test.ts
+++ b/tests/unit/auth/browser-oauth.test.ts
@@ -1,5 +1,6 @@
 import { HttpResponse, http } from 'msw';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { oauthTokenHandler } from '../../msw-handlers';
 import { mswServer } from '../../setup';
 
 const openMock = vi.fn<(url: string) => Promise<unknown>>();
@@ -74,11 +75,7 @@ describe('authenticateViaBrowser', () => {
   });
 
   it('logs the failure (with platform diagnostics) instead of swallowing it when open rejects', async () => {
-    mswServer.use(
-      http.post(`https://${SUB}.zendesk.com/oauth/tokens`, async () =>
-        HttpResponse.json({ access_token: 'token-abc', token_type: 'bearer', scope: 'read' }),
-      ),
-    );
+    mswServer.use(oauthTokenHandler);
 
     const errorEvents: Array<{ event: string; fields?: Record<string, unknown> }> = [];
     const logger = {

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -62,6 +62,31 @@ describe('createLogger', () => {
     expect(line).toContain('status=401');
   });
 
+  it('redacts sensitive values nested in objects and arrays', () => {
+    const log = createLogger('debug');
+    log.error('nested', {
+      oauth: { access_token: 'deep-secret' },
+      items: [{ token: 'arr-secret', label: 'keep-me' }],
+    });
+
+    const line = errSpy.mock.calls[0]?.[0] as string;
+    expect(line).not.toContain('deep-secret');
+    expect(line).not.toContain('arr-secret');
+    expect(line).toContain('[REDACTED]');
+    expect(line).toContain('keep-me');
+  });
+
+  it('keeps the canonical event name even if a field named "event" is passed', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const log = createLogger('debug');
+    log.attachServer({ sendLoggingMessage: send } as never);
+
+    log.info('real_event', { event: 'spoofed' });
+
+    const arg = send.mock.calls[0]?.[0] as { data: { event: string } };
+    expect(arg.data.event).toBe('real_event');
+  });
+
   it('forwards to the MCP server when attached, mapping warn -> warning', () => {
     const send = vi.fn().mockResolvedValue(undefined);
     const log = createLogger('debug');

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLogger, silentLogger } from '../../../src/utils/logger';
+
+describe('createLogger', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it('writes to stderr at or above the configured level', () => {
+    const log = createLogger('info');
+    log.debug('skipped_event');
+    log.info('kept_event');
+
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(errSpy.mock.calls[0]?.[0]).toContain('kept_event');
+  });
+
+  it('suppresses everything below the configured level', () => {
+    const log = createLogger('error');
+    log.debug('a');
+    log.info('b');
+    log.warn('c');
+    expect(errSpy).not.toHaveBeenCalled();
+
+    log.error('boom');
+    expect(errSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes structured fields in the output', () => {
+    const log = createLogger('debug');
+    log.info('evt', { platform: 'win32', port: 3000 });
+
+    const line = errSpy.mock.calls[0]?.[0] as string;
+    expect(line).toContain('evt');
+    expect(line).toContain('platform=win32');
+    expect(line).toContain('port=3000');
+  });
+
+  it('redacts sensitive field values but keeps technical fields', () => {
+    const log = createLogger('debug');
+    log.error('oauth_failed', {
+      token: 'super-secret',
+      access_token: 'aaa',
+      code: 'the-code',
+      errorCode: 'ENOENT',
+      status: 401,
+    });
+
+    const line = errSpy.mock.calls[0]?.[0] as string;
+    expect(line).not.toContain('super-secret');
+    expect(line).not.toContain('aaa');
+    expect(line).not.toContain('the-code');
+    expect(line).toContain('[REDACTED]');
+    // Diagnostic, non-sensitive fields must survive.
+    expect(line).toContain('ENOENT');
+    expect(line).toContain('status=401');
+  });
+
+  it('forwards to the MCP server when attached, mapping warn -> warning', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const log = createLogger('debug');
+    log.attachServer({ sendLoggingMessage: send } as never);
+
+    log.warn('w', { a: 1, token: 'x' });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const arg = send.mock.calls[0]?.[0] as {
+      level: string;
+      data: { event: string; token: string };
+    };
+    expect(arg.level).toBe('warning');
+    expect(arg.data.event).toBe('w');
+    // Redaction applies to the MCP sink too.
+    expect(arg.data.token).toBe('[REDACTED]');
+  });
+
+  it('does not throw when the MCP forward rejects', () => {
+    const send = vi.fn().mockRejectedValue(new Error('not connected'));
+    const log = createLogger('debug');
+    log.attachServer({ sendLoggingMessage: send } as never);
+
+    expect(() => log.info('x')).not.toThrow();
+  });
+
+  it('exposes a silent logger that never writes', () => {
+    silentLogger.debug('a');
+    silentLogger.info('b');
+    silentLogger.warn('c');
+    silentLogger.error('d');
+    silentLogger.attachServer({ sendLoggingMessage: vi.fn() } as never);
+
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/utils/package-info.test.ts
+++ b/tests/unit/utils/package-info.test.ts
@@ -1,16 +1,37 @@
 import { readFileSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
-import { readPackageInfo } from '../../../src/utils/package-info';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const REAL_PKG = JSON.parse(
+  readFileSync(new URL('../../../package.json', import.meta.url), 'utf8'),
+) as { name: string; version: string };
 
 describe('readPackageInfo', () => {
-  it('returns the name and version from the package own package.json', () => {
-    const pkg = JSON.parse(
-      readFileSync(new URL('../../../package.json', import.meta.url), 'utf8'),
-    ) as { name: string; version: string };
+  afterEach(() => {
+    vi.doUnmock('node:fs');
+    vi.resetModules();
+  });
+
+  it('returns the name and version from the package own package.json', async () => {
+    vi.resetModules();
+    const { readPackageInfo } = await import('../../../src/utils/package-info');
 
     const info = readPackageInfo();
 
-    expect(info.name).toBe(pkg.name);
-    expect(info.version).toBe(pkg.version);
+    expect(info.name).toBe(REAL_PKG.name);
+    expect(info.version).toBe(REAL_PKG.version);
+  });
+
+  it('falls back to safe defaults when no package.json can be read', async () => {
+    vi.resetModules();
+    vi.doMock('node:fs', () => ({
+      readFileSync: () => {
+        throw new Error('ENOENT');
+      },
+    }));
+    const { readPackageInfo } = await import('../../../src/utils/package-info');
+
+    const info = readPackageInfo();
+
+    expect(info).toEqual({ name: '@fruggr/zendesk-mcp-server', version: '0.0.0' });
   });
 });

--- a/tests/unit/utils/package-info.test.ts
+++ b/tests/unit/utils/package-info.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { readPackageInfo } from '../../../src/utils/package-info';
+
+describe('readPackageInfo', () => {
+  it('returns the name and version from the package own package.json', () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../../../package.json', import.meta.url), 'utf8'),
+    ) as { name: string; version: string };
+
+    const info = readPackageInfo();
+
+    expect(info.name).toBe(pkg.name);
+    expect(info.version).toBe(pkg.version);
+  });
+});


### PR DESCRIPTION
## Context

On Claude Cowork Windows the OAuth login fails — the browser never opens
(works on Mac). See #60.

Root cause for the lack of a diagnosis (confirmed in code, not the failure
itself):
- `open(authUrl).catch(() => {})` **swallowed** any browser-launch error, so we
  could never see *why* it failed on Windows.
- The fallback authorization URL only went to **stderr**, invisible in most MCP
  client UIs.
- `config.logLevel` / `--log-level` was parsed but **wired to nothing**.

This PR is **iteration 1 = observability only**. It does not change the auth
UX or the 5-min timeout (those are tracked for later iterations).

## What changed

New `src/utils/logger.ts` — a small structured logger with two sinks, designed
to be useful on **every** MCP client (not just Cowork):

| Sink | Mechanism | Reach |
|------|-----------|-------|
| stderr (floor) | gated by `LOG_LEVEL` | every mainstream client captures it to a log file |
| MCP logging | `notifications/message` via the newly advertised `logging` capability | clients that support it; ignored gracefully otherwise |

- **A1** — the browser-open failure is now logged as `oauth_browser_open_failed`
  with the error message, `errorCode`, `platform`, `os.release()`, WSL
  detection, and the **presence** (booleans, never values) of `SYSTEMROOT` /
  `WINDIR` / `ComSpec` / `PATH` / `DISPLAY`.
- **A2** — step traces at `debug` (callback listening, authorize URL, callback
  received, token-exchange HTTP status, timeout) + `LOG_LEVEL` finally wired.
- **A3** — `{ capabilities: { logging: {} } }` declared; the SDK auto-handles
  `logging/setLevel` and client-side level filtering.
- **Redaction** — a key denylist guarantees no token / code / verifier / secret
  / env value can ever reach a sink (covered by a dedicated test).

## Out of scope (next iterations)

- **B1**: surface the auth URL in the tool response (visible to the user).
- **B2**: non-blocking / fail-fast timeout.
- No API-token workaround (Zendesk's token model is too broad).

## Tests & gate

- New `tests/unit/utils/logger.test.ts` (level filtering, fields, redaction,
  MCP forward, silent logger).
- `browser-oauth.test.ts`: asserts the failure is **logged with diagnostics**
  instead of swallowed.
- `core-scenarios.ts`: asserts the `logging` capability is advertised over the
  wire (transport-agnostic).
- `pnpm check` / `typecheck` / `test` (224 passing) / `test:coverage`
  (thresholds met) / `build` — all green locally.

## Notes for the reviewer

- `docs/mcp-metadata.md` is referenced by `CLAUDE.md` but is **absent** from the
  repo (pre-existing, out of scope here).
- Verified against `@modelcontextprotocol/sdk@1.29.0`: `sendLoggingMessage` is a
  no-op when the capability isn't declared, and filters by the client-set level.

## How to verify

1. `pnpm install && pnpm test`.
2. Force `open` to reject (or run without a usable browser) in OAuth mode with
   `LOG_LEVEL=debug` → an `oauth_browser_open_failed` line appears on stderr
   with `platform`/`errorCode`/env presence, and the authorize URL is traced at
   `debug`.
3. Confirm no token/secret appears in any log line.

https://claude.ai/code/session_014vwKKn5MYrTJiEKUycXswf

---
_Generated by [Claude Code](https://claude.ai/code/session_014vwKKn5MYrTJiEKUycXswf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured, configurable logger with silent mode and optional forwarding; server now advertises logging and reports name/version dynamically

* **Documentation**
  * LOG_LEVEL documented; new Troubleshooting section for OAuth browser-login with platform log locations

* **Improvements**
  * OAuth browser flow emits richer diagnostics (environment, browser-open failures, timeouts)
  * Smoke-test readiness check made more robust

* **Tests**
  * Added unit and integration tests covering logging, OAuth browser behavior, token exchange mocks, and capabilities reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->