### PR TITLE
chore(renovate): clear lockFileMaintenance minimumReleaseAge dashboard warning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,7 @@
     "enabled": true,
     "automerge": true,
     "schedule": ["before 8am on friday"],
-    "timezone": "Europe/Paris",
-    "minimumReleaseAgeBehaviour": "timestamp-optional"
+    "timezone": "Europe/Paris"
   },
   "vulnerabilityAlerts": {
     "description": "Security fixes surface immediately (a PR is opened as soon as the alert is detected) but are held by the same inherited 7-day minimumReleaseAge as every other update. internalChecksFilter 'flexible' keeps that PR visible with a pending renovate/stability-days check instead of suppressing it, so a freshly published fix is not auto-merged until it has aged past the supply-chain delay. A critical, actively-exploited CVE landing inside that window is merged manually.",
@@ -36,6 +35,11 @@
     ]
   },
   "packageRules": [
+    {
+      "description": "lockFileMaintenance updates are synthetic lockfile refreshes with no releaseTimestamp, so the inherited 7-day minimumReleaseAge can never be evaluated and Renovate raises a dashboard warning (and, from Renovate 42 on, would stop running lockfile maintenance entirely). Opt them out of the age gate, mirroring Renovate's own security:minimumReleaseAgeNpm preset. The supply-chain delay for the packages bumped here is still enforced natively by pnpm via minimumReleaseAge in pnpm-workspace.yaml.",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "minimumReleaseAge": null
+    },
     {
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true


### PR DESCRIPTION
## Context

Closes the persistent "Repository Problems" warning on the Dependency Dashboard (#21):

> ⚠️ WARN: Some upgrade(s) did not have a releaseTimestamp, but as we're running with `minimumReleaseAgeBehaviour=timestamp-optional`, proceeding. See debug logs for more information

## Root cause (verified against the Mend debug logs)

The warning fires **exclusively** on `branch: renovate/lock-file-maintenance`, with `updates:[{updateType:lockFileMaintenance},{updateType:lockFileMaintenance}]`. The `renovate/node-24.x` and `renovate/pnpm-11.x` branches emit **no** warning — their `releaseTimestamp`s resolve fine, so they are not the cause.

`lockFileMaintenance` entries are synthetic lockfile refreshes that have **no `releaseTimestamp` by nature** (they are not package releases). The top-level `minimumReleaseAge: "7 days"` is inherited into that block but can never be evaluated against them, which is what triggers the warning.

The previous workaround — `minimumReleaseAgeBehaviour: "timestamp-optional"` inside the `lockFileMaintenance` block (#55) — let the update proceed but kept emitting the warning, and would not survive the **Renovate 42** default flip to `timestamp-required` (lockfile maintenance would then stop running entirely, cf. renovatebot/renovate discussion #39352).

## Change

Replace the band-aid with the canonical opt-out shipped by Renovate's own `security:minimumReleaseAgeNpm` preset:

```json
{ "matchUpdateTypes": ["lockFileMaintenance"], "minimumReleaseAge": null }
```

This removes the age check at the root (no timestamp lookup → no warning) and is the Renovate-42-safe form. The supply-chain delay for the packages actually bumped during a lockfile refresh remains enforced **natively by pnpm** via `minimumReleaseAge: 10080` in `pnpm-workspace.yaml`, so the security posture is unchanged.

## Verification

- `renovate.json` validated as JSON.
- Approach matches Renovate's documented `security:minimumReleaseAgeNpm` preset (not invented behavior).
- No tool-surface or doc changes — confined to `renovate.json`.

https://claude.ai/code/session_015H6sAEewKbBabvm1SCQHTs

---
_Generated by [Claude Code](https://claude.ai/code/session_015H6sAEewKbBabvm1SCQHTs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to ensure lockfile maintenance updates process more efficiently without unnecessary delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->