### PR TITLE
chore: resolve Biome warnings and harden lint setup

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev": "tsx watch src/index.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build",
-    "check": "biome check src/ tests/ scripts/",
+    "check": "biome check --error-on-warnings src/ tests/ scripts/",
     "check:fix": "biome check --write src/ tests/ scripts/",
     "test": "vitest run",
     "test:watch": "vitest watch",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "dev": "tsx watch src/index.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build",
-    "check": "biome check src/",
-    "check:fix": "biome check --write src/",
+    "check": "biome check src/ tests/ scripts/",
+    "check:fix": "biome check --write src/ tests/ scripts/",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage",
@@ -69,7 +69,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.7",
+    "@biomejs/biome": "2.4.16",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 4.4.3
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.4.7
+        specifier: 2.4.16
         version: 2.4.16
       '@semantic-release/changelog':
         specifier: ^6.0.3

--- a/src/utils/article-sections.ts
+++ b/src/utils/article-sections.ts
@@ -36,7 +36,7 @@ const textOf = (html: string): string => {
 };
 
 export const parseSections = (html: string): Section[] => {
-  if (!html || !html.trim()) return [];
+  if (!html?.trim()) return [];
 
   const $ = cheerio.load(html, null, false);
   const children = $.root().contents().toArray();

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -15,6 +15,7 @@ describe('loadConfig', () => {
     expect(config.subdomain).toBe('mycompany');
   });
 
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: documents the literal default value ${subdomain}_zendesk
   it('defaults oauthClientId to ${subdomain}_zendesk', () => {
     const config = loadConfig(['mycompany']);
     expect(config.oauthClientId).toBe('mycompany_zendesk');

--- a/tests/unit/tools/search.test.ts
+++ b/tests/unit/tools/search.test.ts
@@ -10,8 +10,10 @@ describe('search tools', () => {
   });
 
   describe('search', () => {
+    const [tool] = createSearchTools(ctx);
+    if (!tool) throw new Error('search tool not registered');
+
     it('performs unified search with total count', async () => {
-      const tool = createSearchTools(ctx)[0]!;
       const result = await tool.handler({ query: 'test', per_page: 100, page: 1 });
       expect(result.content[0]?.text).toContain('Total: 2');
       expect(result.content[0]?.text).toContain('ticket');
@@ -19,7 +21,6 @@ describe('search tools', () => {
     });
 
     it('is readOnly', () => {
-      const tool = createSearchTools(ctx)[0]!;
       expect(tool.readOnly).toBe(true);
       expect(tool.annotations.readOnlyHint).toBe(true);
     });


### PR DESCRIPTION
## Context

Biome reports warnings on `main`. They are **non-blocking today**: CI runs `pnpm check` (= `biome check src/`), which exits `0` because Biome only fails on *errors*, not *warnings*. This PR clears the real findings, tightens the setup, and adds guardrails so they cannot silently recur.

## Root cause — how the warnings appeared

A common amplifier plus three independent causes:

- **Amplifier:** a Biome *warning* does not fail `biome check` (exit `0`), so CI stayed green and the warnings were invisible.
1. `src/utils/article-sections.ts` — `useOptionalChain` (`!html || !html.trim()`) introduced in the unified-pipeline rewrite (`4a8ea31`); stayed a warning.
2. `biome.json` — schema/CLI drift: Biome was added (`8bba517`) with dependency `^2.4.7` (caret, floats up) **and** `$schema` pinned to `2.4.8`. Patches `2.4.9 → 2.4.16` shipped, the CLI floated to `2.4.16`, the schema stayed at `2.4.8`.
3. `tests/` — CI only scanned `src/`, so the test tree was never analysed (`noTemplateCurlyInString`, `noNonNullAssertion`).

## Changes

**Fix the findings**
- `article-sections.ts`: `!html || !html.trim()` → `!html?.trim()` (equivalent, `html` is typed `string`).
- `config.test.ts`: targeted `biome-ignore` for the intentional `${subdomain}` literal in a test name.
- `search.test.ts`: destructure + runtime guard instead of `[0]!` non-null assertions.

**Guardrails so it cannot recur**
- `check` script now runs with **`--error-on-warnings`** → any future Biome warning fails CI instead of passing silently (kills the amplifier).
- `check` / `check:fix` scope widened to `src/ tests/ scripts/` → no blind spots.
- `@biomejs/biome` **pinned** to exact `2.4.16` (no more caret float).
- `biome.json` `$schema` points to the **locally installed** `./node_modules/@biomejs/biome/configuration_schema.json` → always matches the installed CLI, even across Renovate bumps; drift becomes structurally impossible.
- `vcs.useIgnoreFile` enabled → `dist/` and `coverage/` excluded from `biome check .`.

## Local gate

- `pnpm check` ✅ clean & strict (`--error-on-warnings`, src + tests + scripts)
- `pnpm typecheck` ✅
- `pnpm test` ✅ 232 passing
- `pnpm build` ✅

No release expected (`chore:` only).

https://claude.ai/code/session_01N2VNaAauP9zJrmSxrqMYa4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Biome config and tooling to v2.4.16 and expanded automated checks to include source, tests, and scripts.

* **Refactor**
  * Simplified input validation for more maintainable behavior without changing outcomes.

* **Tests**
  * Improved test structure and reliability; added a lint-suppression note for a specific assertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->