### PR TITLE
chore: add glama.json to claim MCP server maintainership

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["dlecan"]
+}


### PR DESCRIPTION
Adds `glama.json` so the Glama MCP directory recognizes `dlecan` as the maintainer of this server, without waiting on the larger #40 (currently blocked) to land.

The file is an exact copy of the one introduced in #40:

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["dlecan"]
}
```

Metadata only — no code or tool-surface changes, so no README sync required.

https://claude.ai/code/session_01TZKd729AHg4FwxTQ7dECNb

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZKd729AHg4FwxTQ7dECNb)_