### PR TITLE
fix(auth): escape reflected values in OAuth callback HTML responses

### DIFF
--- a/src/auth/browser-oauth.ts
+++ b/src/auth/browser-oauth.ts
@@ -32,6 +32,20 @@ interface TokenResult {
   scope: string;
 }
 
+/**
+ * Escape a string for safe interpolation into HTML text/attribute context.
+ * The local callback server echoes attacker-controllable values (the OAuth
+ * `error_description` query param, token-exchange error bodies) back into the
+ * browser response; without escaping these are a reflected-XSS sink.
+ */
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
 const generateCodeVerifier = (): string => randomBytes(32).toString('base64url');
 
 const generateCodeChallenge = (verifier: string): string =>
@@ -75,7 +89,9 @@ export const authenticateViaBrowser = (
       if (error) {
         const desc = url.searchParams.get('error_description') ?? error;
         res.writeHead(400, { 'Content-Type': 'text/html' });
-        res.end(`<html><body><h1>Authentication failed</h1><p>${desc}</p></body></html>`);
+        res.end(
+          `<html><body><h1>Authentication failed</h1><p>${escapeHtml(desc)}</p></body></html>`,
+        );
         clearTimeout(authTimeout);
         callbackServer.close();
         reject(new Error(`OAuth error: ${desc}`));
@@ -131,7 +147,7 @@ export const authenticateViaBrowser = (
       } catch (err) {
         res.writeHead(500, { 'Content-Type': 'text/html' });
         res.end(
-          `<html><body><h1>Token exchange failed</h1><p>${err instanceof Error ? err.message : String(err)}</p></body></html>`,
+          `<html><body><h1>Token exchange failed</h1><p>${escapeHtml(err instanceof Error ? err.message : String(err))}</p></body></html>`,
         );
         clearTimeout(authTimeout);
         callbackServer.close();

--- a/tests/unit/auth/browser-oauth.test.ts
+++ b/tests/unit/auth/browser-oauth.test.ts
@@ -101,6 +101,41 @@ describe('authenticateViaBrowser', () => {
     expect(body).toContain('&lt;script&gt;');
   });
 
+  it('HTML-escapes the token-exchange error body in the callback response (no reflected XSS)', async () => {
+    const xss = '<script>alert(1)</script>';
+    // The token endpoint fails with an attacker-controllable body, which the
+    // error message echoes back into the "Token exchange failed" HTML response.
+    mswServer.use(
+      http.post(`https://${SUB}.zendesk.com/oauth/tokens`, () =>
+        HttpResponse.text(xss, { status: 500 }),
+      ),
+    );
+
+    let resolveBody: (body: string) => void;
+    const bodyPromise = new Promise<string>((r) => {
+      resolveBody = r;
+    });
+
+    openMock.mockImplementation(async (url: string) => {
+      const redirectUri = new URL(url).searchParams.get('redirect_uri');
+      setImmediate(() => {
+        fetch(`${redirectUri}?code=the-auth-code`)
+          .then((res) => res.text())
+          .then((text) => resolveBody(text))
+          .catch(() => resolveBody(''));
+      });
+      return {};
+    });
+
+    await expect(
+      authenticateViaBrowser({ subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 }),
+    ).rejects.toThrow(/Token exchange failed/);
+
+    const body = await bodyPromise;
+    expect(body).not.toContain(xss);
+    expect(body).toContain('&lt;script&gt;');
+  });
+
   it('logs the failure (with platform diagnostics) instead of swallowing it when open rejects', async () => {
     mswServer.use(oauthTokenHandler);
 

--- a/tests/unit/auth/browser-oauth.test.ts
+++ b/tests/unit/auth/browser-oauth.test.ts
@@ -74,6 +74,33 @@ describe('authenticateViaBrowser', () => {
     );
   });
 
+  it('HTML-escapes the OAuth error_description in the callback response (no reflected XSS)', async () => {
+    const xss = '<script>alert(1)</script>';
+    let resolveBody: (body: string) => void;
+    const bodyPromise = new Promise<string>((r) => {
+      resolveBody = r;
+    });
+
+    openMock.mockImplementation(async (url: string) => {
+      const redirectUri = new URL(url).searchParams.get('redirect_uri');
+      setImmediate(() => {
+        fetch(`${redirectUri}?error=access_denied&error_description=${encodeURIComponent(xss)}`)
+          .then((res) => res.text())
+          .then((text) => resolveBody(text))
+          .catch(() => resolveBody(''));
+      });
+      return {};
+    });
+
+    await expect(
+      authenticateViaBrowser({ subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 }),
+    ).rejects.toThrow(/OAuth error/);
+
+    const body = await bodyPromise;
+    expect(body).not.toContain(xss);
+    expect(body).toContain('&lt;script&gt;');
+  });
+
   it('logs the failure (with platform diagnostics) instead of swallowing it when open rejects', async () => {
     mswServer.use(oauthTokenHandler);
 


### PR DESCRIPTION
## Vulnerability (CodeQL `js/reflected-xss`)

The local OAuth callback HTTP server (`src/auth/browser-oauth.ts`) echoed **attacker-controllable** values straight into its HTML response without escaping:

- the `error_description` query parameter (`desc`) → interpolated into `<p>${desc}</p>`;
- the token-exchange error message (`err.message`) → interpolated into the failure page.

An attacker can lure a victim into visiting a URL such as
`http://localhost:3000/callback?error=x&error_description=<script>…</script>`
and run JavaScript in the context of the locally served page → **reflected XSS**.

## Fix

- Added an `escapeHtml` helper (escapes `& < > " '`).
- Applied it to **every** reflected value in the callback responses.
- Regression test: a `<script>alert(1)</script>` payload comes back escaped (`&lt;script&gt;`) and never appears verbatim.

`pnpm check`, `pnpm typecheck` and the test suite all pass (233 tests).

## Why this slipped through the original PR without blocking

The file was introduced in `65ca70f` and instrumented in #62. CodeQL runs here in **default setup** — there is no `codeql.yml` in `.github/workflows/` (only `ci.yml` and `release.yml`). Code scanning is therefore **not a required check** on `pull_request`: CI (lint, typecheck, tests, build) was green while the CodeQL analysis ran outside the merge gate, so the alert was raised after the fact without ever blocking the merge.

### Suggestion (separate from this fix)
To block this in the future: enable branch protection requiring the Code Scanning check, or add a CodeQL workflow triggered on `pull_request` and mark it as required.

https://claude.ai/code/session_01R9ezGJu7sfDgD9GBB6S7mT

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9ezGJu7sfDgD9GBB6S7mT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability in OAuth authentication callbacks where error messages and descriptions were not properly escaped before display, potentially allowing malicious script injection. Error responses are now HTML-escaped.

* **Tests**
  * Added unit tests to verify that authentication error messages are properly escaped in OAuth callbacks and protected from reflected XSS attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->