### PR TITLE
feat(auth): persist OAuth token to disk, refresh, and make callback port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ No API key needed. Each user authenticates via their browser on the first tool c
 1. Go to **Admin Center > Apps and integrations > APIs > OAuth Clients**
 2. Create a public client:
    - **Identifier**: `<your-subdomain>_zendesk` (or set `ZENDESK_OAUTH_CLIENT_ID`)
-   - **Redirect URL**: `http://localhost:3000/callback`
+   - **Redirect URL**: `http://localhost:27439/callback` (change the port to match
+     `ZENDESK_OAUTH_CALLBACK_PORT` / `--callback-port` if you override it; Zendesk
+     accepts several redirect URLs, one per line)
 
 **Run:**
 
@@ -201,8 +203,22 @@ zendesk-mcp-server <your-subdomain>
 On the first tool call, the server starts the sign-in flow: it opens a browser
 window **and** returns a tool message containing the authorize URL. The call
 does not block waiting for sign-in — authenticate in the browser (or open the
-URL manually if it didn't open), then retry the request. Once authenticated, the
-token is cached in memory and subsequent calls succeed for the session.
+URL manually if it didn't open), then retry the request.
+
+Once authenticated, the token is **persisted to disk** (one owner-only `0600`
+file per subdomain in your OS config dir —
+`%APPDATA%\fruggr\zendesk-mcp-server\<subdomain>.json` on Windows,
+`${XDG_CONFIG_HOME:-~/.config}/fruggr/zendesk-mcp-server/<subdomain>.json`
+elsewhere; override the path with `ZENDESK_TOKEN_FILE`). It is reused across restarts, so you don't
+re-authenticate every time the MCP client respawns the server. If the Zendesk
+OAuth client has token expiration enabled, the stored refresh token is used to
+renew access silently; only an expired/invalid refresh token triggers a new
+browser sign-in.
+
+> **Port conflict?** If port `27439` is already in use the first tool call returns
+> a clear error telling you to set `ZENDESK_OAUTH_CALLBACK_PORT` (or
+> `--callback-port`) to a free port — remember to register the matching
+> `http://localhost:<port>/callback` redirect URL in your Zendesk OAuth client.
 
 ### Option B: API token
 
@@ -290,6 +306,7 @@ Options:
   --tool <name>           Filter by tool name (repeatable, forces --mode all)
   --read-only             Only expose read operations
   --log-level <level>     debug | info (default) | warn | error
+  --callback-port <port>  Local OAuth callback port (default 27439)
 ```
 
 `--namespace` and `--read-only` are applied before the proxies are registered, so they narrow the surface in every mode — in the default `namespace` mode, `--namespace help_center` registers a single proxy (`zendesk_help_center`) instead of three.
@@ -313,6 +330,8 @@ zendesk-mcp-server acme --tool get_ticket --tool search_tickets --tool get_curre
 |----------|----------|---------|-------------|
 | `ZENDESK_SUBDOMAIN` | yes (or CLI arg) | — | Zendesk subdomain (e.g., `acme` for acme.zendesk.com) |
 | `ZENDESK_OAUTH_CLIENT_ID` | no | `<subdomain>_zendesk` | OAuth client identifier |
+| `ZENDESK_OAUTH_CALLBACK_PORT` | no | `27439` | Local port for the OAuth browser callback (also `--callback-port`). Must match the redirect URL registered in Zendesk. |
+| `ZENDESK_TOKEN_FILE` | no | OS config dir | Path to the persisted OAuth token file (`0600`). |
 | `ZENDESK_EMAIL` | for API token auth | — | Agent email for Basic auth |
 | `ZENDESK_API_TOKEN` | for API token auth | — | Zendesk API token |
 | `LOG_LEVEL` | no | `info` | Log verbosity (`debug` surfaces the full OAuth flow trace) |
@@ -339,6 +358,22 @@ structured logs through **two channels**, so they're reachable on any MCP client
 When the browser fails to open, look for the `oauth_browser_open_failed` event:
 it reports the underlying error, the platform, and which environment markers are
 present (no secrets, tokens, or env values are ever logged).
+
+### The OAuth callback port is already in use
+
+The sign-in flow runs a short-lived local server on port `27439` to receive the
+callback. If that port is taken, the first tool call fails with a message saying
+so (and logs `oauth_callback_listen_failed`). Pick a free port with
+`ZENDESK_OAUTH_CALLBACK_PORT=<port>` (or `--callback-port <port>`), and register
+the matching `http://localhost:<port>/callback` redirect URL in your Zendesk
+OAuth client.
+
+### I have to re-authenticate every time
+
+The OAuth token is persisted to an owner-only file in your OS config dir and
+reused across restarts, so this shouldn't happen. If it does, check that the file
+is writable (`ZENDESK_TOKEN_FILE` to relocate it) and look for
+`token_persist_failed` in the logs.
 
 Where each client writes the server's stderr:
 

--- a/src/auth/browser-oauth.ts
+++ b/src/auth/browser-oauth.ts
@@ -3,10 +3,9 @@ import { readFileSync } from 'node:fs';
 import { createServer, type Server } from 'node:http';
 import { release } from 'node:os';
 import open from 'open';
-import { getOAuthUrls } from '../constants';
+import { DEFAULT_CALLBACK_PORT, getOAuthUrls } from '../constants';
 import { type Logger, silentLogger } from '../utils/logger';
 
-const DEFAULT_CALLBACK_PORT = 3000;
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Best-effort WSL detection: WSL kernels carry "microsoft" in /proc/version. */
@@ -30,7 +29,28 @@ interface TokenResult {
   refresh_token?: string;
   token_type: string;
   scope: string;
+  // Present only when the Zendesk OAuth client has token expiration enabled.
+  // Seconds until the access/refresh token expires.
+  expires_in?: number;
+  refresh_token_expires_in?: number;
 }
+
+/**
+ * Build an actionable error for a callback port that's already taken. The raw
+ * Node `EADDRINUSE` is opaque to both the user and the LLM; this spells out the
+ * fix (set a free port + register the matching redirect URL in Zendesk). The
+ * `(EADDRINUSE)` marker and `code` are kept for diagnostics/tests.
+ */
+const callbackPortInUseError = (port: number, cause: Error): Error =>
+  Object.assign(
+    new Error(
+      `Cannot start the Zendesk OAuth sign-in: local callback port ${port} is already in use ` +
+        `by another process. Set ZENDESK_OAUTH_CALLBACK_PORT (or --callback-port) to a free port, ` +
+        `then register http://localhost:<port>/callback as a redirect URL in your Zendesk OAuth ` +
+        `client. (EADDRINUSE)`,
+    ),
+    { code: 'EADDRINUSE', cause },
+  );
 
 /**
  * Escape a string for safe interpolation into HTML text/attribute context.
@@ -185,16 +205,21 @@ export const startBrowserAuth = (
       }
     });
 
+    const requestedPort = config.callbackPort ?? DEFAULT_CALLBACK_PORT;
+
     // Listen failure (e.g. port already in use) before we ever get a URL: the
-    // whole start fails so the caller can surface/retry.
+    // whole start fails so the caller can surface/retry. EADDRINUSE is rewrapped
+    // into an actionable message (user *and* LLM can act on it).
     const onStartError = (err: Error) => {
       clearTimeout(authTimeout);
-      rejectStarted(err);
+      const code = (err as NodeJS.ErrnoException).code;
+      logger.error('oauth_callback_listen_failed', { port: requestedPort, errorCode: code });
+      rejectStarted(code === 'EADDRINUSE' ? callbackPortInUseError(requestedPort, err) : err);
     };
     callbackServer.once('error', onStartError);
 
     // Start on fixed port (must match redirect_uri registered in Zendesk OAuth client)
-    callbackServer.listen(config.callbackPort ?? DEFAULT_CALLBACK_PORT, () => {
+    callbackServer.listen(requestedPort, () => {
       // Now that we're listening, a later server error must settle the *token*
       // flow (the started promise is already resolved) and tear the server down,
       // so the token store doesn't wedge waiting on a promise that never settles.
@@ -275,4 +300,41 @@ export const authenticateViaBrowser = async (
 ): Promise<TokenResult> => {
   const { tokenPromise } = await startBrowserAuth(config, logger);
   return tokenPromise;
+};
+
+/**
+ * Exchange a refresh token for a fresh access token (and a rotated refresh token)
+ * without any browser interaction. Public PKCE clients send no `client_secret`.
+ * Zendesk refresh tokens are single-use: the caller MUST persist the new
+ * `refresh_token` from the response. Throws on a non-2xx (expired/invalid
+ * refresh token) so the caller can fall back to the full browser flow.
+ */
+export const refreshAccessToken = async (
+  config: { subdomain: string; oauthClientId: string; refreshToken: string },
+  logger: Logger = silentLogger,
+): Promise<TokenResult> => {
+  const { tokenUrl } = getOAuthUrls(config.subdomain);
+
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: config.refreshToken,
+    client_id: config.oauthClientId,
+  });
+
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  logger.debug('oauth_token_refresh', { status: response.status });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Token refresh failed (${response.status}): ${errorBody}`);
+  }
+
+  const tokenData = (await response.json()) as TokenResult;
+  logger.info('oauth_token_refreshed');
+  return tokenData;
 };

--- a/src/auth/token-persistence.ts
+++ b/src/auth/token-persistence.ts
@@ -1,0 +1,117 @@
+import { chmodSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { type Logger, silentLogger } from '../utils/logger';
+import { readPackageInfo } from '../utils/package-info';
+
+/**
+ * On-disk OAuth token record. `expiresAt` is an absolute epoch-ms timestamp
+ * (derived from the OAuth `expires_in`) so expiry survives restarts; `undefined`
+ * means a non-expiring token (Zendesk's default until expiration is enabled).
+ */
+export interface PersistedToken {
+  accessToken: string;
+  refreshToken?: string | undefined;
+  expiresAt?: number | undefined;
+}
+
+const isWindows = process.platform === 'win32';
+
+/**
+ * Config-dir segments derived from the *scoped* package name
+ * (`@fruggr/zendesk-mcp-server` → `fruggr` + `zendesk-mcp-server`) so the path is
+ * vendor-namespaced and can't collide with another `zendesk-mcp-server`.
+ */
+const appDirSegments = (): string[] => {
+  const { name } = readPackageInfo();
+  const scoped = /^@([^/]+)\/(.+)$/.exec(name);
+  return scoped?.[1] && scoped[2] ? [scoped[1], scoped[2]] : [name];
+};
+
+// OS config dir holding the per-subdomain token files: `%APPDATA%` on Windows,
+// `$XDG_CONFIG_HOME` (falling back to `~/.config`) elsewhere.
+const configDir = (): string => {
+  const segments = appDirSegments();
+  if (isWindows) {
+    const base = process.env['APPDATA'] ?? join(homedir(), 'AppData', 'Roaming');
+    return join(base, ...segments);
+  }
+  const base = process.env['XDG_CONFIG_HOME'] ?? join(homedir(), '.config');
+  return join(base, ...segments);
+};
+
+// Zendesk subdomains are [a-z0-9-]; sanitize defensively so a crafted value
+// can neither escape the config dir nor smuggle a path separator.
+const safeName = (subdomain: string): string => subdomain.replace(/[^a-z0-9-]/gi, '_');
+
+/**
+ * Path to the token file for a subdomain. Each subdomain gets its **own** file
+ * (`<subdomain>.json`, a single record) so concurrent processes for different
+ * subdomains never read-modify-write a shared file — no merge, no clobber.
+ * `ZENDESK_TOKEN_FILE` overrides with an explicit path (a single file; use the
+ * default layout for multi-subdomain installs).
+ */
+export const resolveTokenPath = (subdomain: string): string => {
+  const override = process.env['ZENDESK_TOKEN_FILE'];
+  if (override) return override;
+  return join(configDir(), `${safeName(subdomain)}.json`);
+};
+
+// Atomic write (tmp + rename) so a crash mid-write can't leave a truncated file,
+// with owner-only perms on the file and its dir where the OS supports it.
+const writeFileAtomic = (path: string, record: PersistedToken): void => {
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(record, null, 2), 'utf8');
+  if (!isWindows) chmodSync(tmp, 0o600);
+  renameSync(tmp, path);
+  if (!isWindows) {
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Best-effort: tightening the dir is a bonus, not a requirement.
+    }
+  }
+};
+
+// A missing file or unparseable/garbage content is treated as "no token yet"
+// rather than an error: persistence must never wedge the auth flow.
+export const loadToken = (path: string): PersistedToken | undefined => {
+  try {
+    const raw: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    if (raw && typeof raw === 'object' && typeof (raw as PersistedToken).accessToken === 'string') {
+      return raw as PersistedToken;
+    }
+  } catch {
+    // absent or corrupt → no token
+  }
+  return undefined;
+};
+
+export const saveToken = (
+  path: string,
+  record: PersistedToken,
+  logger: Logger = silentLogger,
+): void => {
+  try {
+    writeFileAtomic(path, record);
+    logger.debug('token_persisted');
+  } catch (err) {
+    // Never fail the auth flow because the token couldn't be cached to disk.
+    logger.warn('token_persist_failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
+
+export const clearToken = (path: string, logger: Logger = silentLogger): void => {
+  try {
+    rmSync(path, { force: true });
+    logger.debug('token_cleared');
+  } catch (err) {
+    logger.warn('token_clear_failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+};

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,10 +1,18 @@
 import { type Logger, silentLogger } from '../utils/logger';
-import { startBrowserAuth } from './browser-oauth';
+import { refreshAccessToken, startBrowserAuth } from './browser-oauth';
+import {
+  clearToken as clearPersistedToken,
+  loadToken,
+  type PersistedToken,
+  resolveTokenPath,
+  saveToken,
+} from './token-persistence';
 
-interface StoredToken {
-  accessToken: string;
-  refreshToken?: string | undefined;
-}
+type StoredToken = PersistedToken;
+
+// Refresh slightly before the real expiry so a request never races a token that
+// dies in flight.
+const EXPIRY_SKEW_MS = 60_000;
 
 /**
  * Signals that interactive sign-in is required. The message is user-facing: MCP
@@ -29,33 +37,96 @@ export const isAuthRequiredError = (err: unknown): err is AuthRequiredError =>
   err.name === 'AuthRequiredError' &&
   typeof (err as AuthRequiredError).authorizeUrl === 'string';
 
+// Compute the absolute expiry (epoch ms) from an OAuth `expires_in` (seconds),
+// or `undefined` for a non-expiring token.
+const expiryFrom = (expiresIn: number | undefined): number | undefined =>
+  typeof expiresIn === 'number' ? Date.now() + expiresIn * 1000 : undefined;
+
 export const createTokenStore = (
-  config: { subdomain: string; oauthClientId: string },
+  config: { subdomain: string; oauthClientId: string; callbackPort?: number | undefined },
   logger: Logger = silentLogger,
 ) => {
-  let token: StoredToken | undefined;
+  const tokenPath = resolveTokenPath(config.subdomain);
+  // Seed the in-memory cache from disk so a restart (notably the Cowork-on-Windows
+  // process churn) reuses the existing token instead of re-prompting.
+  let token: StoredToken | undefined = loadToken(tokenPath);
+  if (token) logger.debug('oauth_token_loaded_from_disk');
+
   // The authorize URL of the in-flight flow (set once the callback server is
   // listening); `undefined` means no flow is currently pending.
   let authorizeUrl: string | undefined;
   // Resolves to the authorize URL while a flow is being started; guards against
   // launching multiple browser flows for concurrent first calls.
   let starting: Promise<string> | undefined;
+  // De-dupes concurrent refresh attempts so a burst of expired-token calls
+  // triggers a single network round-trip.
+  let refreshing: Promise<string | undefined> | undefined;
+
+  const persist = (t: StoredToken): void => saveToken(tokenPath, t, logger);
 
   const setToken = (accessToken: string, refreshToken?: string | undefined) => {
     token = { accessToken, refreshToken };
+    persist(token);
+  };
+
+  const isExpired = (t: StoredToken): boolean =>
+    typeof t.expiresAt === 'number' && Date.now() >= t.expiresAt - EXPIRY_SKEW_MS;
+
+  // Try to silently mint a fresh access token from the stored refresh token.
+  // Resolves to the new access token, or `undefined` if there's nothing to
+  // refresh / the refresh failed (in which case the dead token is dropped).
+  const tryRefresh = async (current: StoredToken): Promise<string | undefined> => {
+    if (!current.refreshToken) return undefined;
+    try {
+      const result = await refreshAccessToken(
+        {
+          subdomain: config.subdomain,
+          oauthClientId: config.oauthClientId,
+          refreshToken: current.refreshToken,
+        },
+        logger,
+      );
+      // Zendesk rotates the refresh token on every use — persist the new one (or
+      // keep the current one if the response omitted it).
+      token = {
+        accessToken: result.access_token,
+        refreshToken: result.refresh_token ?? current.refreshToken,
+        expiresAt: expiryFrom(result.expires_in),
+      };
+      persist(token);
+      logger.info('oauth_token_refreshed_cached');
+      return token.accessToken;
+    } catch (err) {
+      logger.warn('oauth_token_refresh_failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Refresh token expired/invalid → drop it so we fall back to a fresh flow.
+      token = undefined;
+      clearPersistedToken(tokenPath, logger);
+      return undefined;
+    }
   };
 
   const beginAuth = (): Promise<string> => {
     logger.info('oauth_auth_start');
     return startBrowserAuth(
-      { subdomain: config.subdomain, oauthClientId: config.oauthClientId },
+      {
+        subdomain: config.subdomain,
+        oauthClientId: config.oauthClientId,
+        callbackPort: config.callbackPort,
+      },
       logger,
     )
       .then((started) => {
         authorizeUrl = started.authorizeUrl;
         started.tokenPromise
           .then((result) => {
-            token = { accessToken: result.access_token, refreshToken: result.refresh_token };
+            token = {
+              accessToken: result.access_token,
+              refreshToken: result.refresh_token,
+              expiresAt: expiryFrom(result.expires_in),
+            };
+            persist(token);
             logger.info('oauth_token_cached');
           })
           .catch((err) => {
@@ -80,9 +151,21 @@ export const createTokenStore = (
   };
 
   const getToken = async (): Promise<string> => {
-    if (token) {
+    if (token && !isExpired(token)) {
       logger.debug('oauth_token_cache_hit');
       return token.accessToken;
+    }
+
+    // Expired (or near-expiry) but refreshable → refresh silently before falling
+    // back to a browser prompt. Concurrent callers share the one attempt.
+    if (token?.refreshToken) {
+      if (!refreshing) {
+        refreshing = tryRefresh(token).finally(() => {
+          refreshing = undefined;
+        });
+      }
+      const refreshed = await refreshing;
+      if (refreshed) return refreshed;
     }
 
     if (!starting) {
@@ -97,5 +180,21 @@ export const createTokenStore = (
     throw createAuthRequiredError(url);
   };
 
-  return { getToken, setToken };
+  // Backstop for an access token the server rejected mid-life (e.g. revoked).
+  // A 401 invalidates the *access* token, not necessarily the refresh token —
+  // so keep the latter and just mark the access token expired, letting the next
+  // getToken attempt a silent refresh before falling back to the browser. Only
+  // when there's no refresh token do we wipe the record entirely.
+  const invalidate = (): void => {
+    if (token?.refreshToken) {
+      token = { accessToken: token.accessToken, refreshToken: token.refreshToken, expiresAt: 0 };
+      persist(token);
+    } else {
+      token = undefined;
+      clearPersistedToken(tokenPath, logger);
+    }
+    logger.info('oauth_token_invalidated');
+  };
+
+  return { getToken, setToken, invalidate };
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export const ConfigSchema = z.object({
   readOnly: z.boolean(),
   namespaces: z.array(Namespace).optional(),
   tools: z.array(z.string()).optional(),
+  callbackPort: z.number().int().min(1).max(65535).optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -30,6 +31,7 @@ interface CliResult {
   namespaces?: string[];
   tools?: string[];
   logLevel?: string;
+  callbackPort?: number;
 }
 
 const parseCliArgs = (args: string[]): CliResult => {
@@ -57,6 +59,9 @@ const parseCliArgs = (args: string[]): CliResult => {
     } else if (arg === '--log-level' && next) {
       result.logLevel = next;
       i++;
+    } else if (arg === '--callback-port' && next) {
+      result.callbackPort = Number(next);
+      i++;
     } else if (!arg.startsWith('-') && positionalIndex === 0) {
       result.subdomain = arg;
       positionalIndex++;
@@ -75,6 +80,9 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
 
   const mode = cli.tools?.length ? 'all' : (cli.mode ?? 'namespace');
 
+  const envCallbackPort = process.env['ZENDESK_OAUTH_CALLBACK_PORT'];
+  const callbackPort = cli.callbackPort ?? (envCallbackPort ? Number(envCallbackPort) : undefined);
+
   return ConfigSchema.parse({
     subdomain,
     oauthClientId,
@@ -85,5 +93,6 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
     readOnly: cli.readOnly ?? false,
     namespaces: cli.namespaces,
     tools: cli.tools,
+    callbackPort,
   });
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,14 @@ export const DEFAULT_PAGE_SIZE = 100;
 export const MAX_PAGE_SIZE = 100;
 export const TOKEN_CACHE_TTL_MS = 5 * 60 * 1000;
 
+// Local port the OAuth PKCE flow listens on for the browser callback. Must match
+// the redirect URL registered in the Zendesk OAuth client. Deliberately picked
+// outside the usual dev range (3000/5000/8080…) and below the OS ephemeral
+// ranges (Linux ≥ 32768, Windows ≥ 49152) so it is neither commonly taken nor
+// grabbed by a transient socket. Override via ZENDESK_OAUTH_CALLBACK_PORT /
+// --callback-port (and register the matching redirect URL in Zendesk).
+export const DEFAULT_CALLBACK_PORT = 27439;
+
 // Per-attachment cap for inline image content. Images larger than this are
 // returned as text references instead of base64 image content blocks.
 // Aligned with the Anthropic vision API per-image limit.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,11 @@ const main = async (): Promise<void> => {
       {
         subdomain: config.subdomain,
         oauthClientId: config.oauthClientId,
+        callbackPort: config.callbackPort,
       },
       logger,
     );
-    const server = createMcpServer(config, tokenStore.getToken, logger);
+    const server = createMcpServer(config, tokenStore.getToken, logger, tokenStore.invalidate);
     await startStdioTransport(server, logger);
   }
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,33 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as z from 'zod/v4';
+import { ZendeskApiError } from './client/zendesk-api';
 import type { Config } from './config';
 import { filterTools, groupByNamespace } from './routing/registry';
-import type { ToolAnnotations } from './tools/definitions';
+import type { ToolAnnotations, ToolResult } from './tools/definitions';
 import { createAllTools, type ToolDefinition } from './tools/index';
 import { type Logger, silentLogger } from './utils/logger';
 import { readPackageInfo } from './utils/package-info';
+
+/**
+ * Invoke a tool handler, notifying `onUnauthorized` when Zendesk rejects the
+ * token (401). This lets the OAuth store drop the dead token so the next call
+ * refreshes/re-authenticates instead of replaying a revoked token. A no-op
+ * callback (API-token mode) leaves behavior unchanged.
+ */
+const runHandler = async (
+  def: ToolDefinition,
+  params: Record<string, unknown>,
+  onUnauthorized: (() => void) | undefined,
+): Promise<ToolResult> => {
+  try {
+    return await def.handler(params);
+  } catch (err) {
+    if (onUnauthorized && err instanceof ZendeskApiError && err.status === 401) {
+      onUnauthorized();
+    }
+    throw err;
+  }
+};
 
 const NAMESPACE_LABELS: Record<string, { toolName: string; title: string }> = {
   tickets: { toolName: 'zendesk_tickets', title: 'Zendesk Tickets' },
@@ -52,6 +74,7 @@ const registerProxyTool = (
   tools: ToolDefinition[],
   handlerMap: Map<string, ToolDefinition>,
   readOnlyMode: boolean,
+  onUnauthorized: (() => void) | undefined,
 ): void => {
   const operationNames = tools.map((t) => t.name);
   const operationList = buildOperationList(tools);
@@ -83,7 +106,7 @@ const registerProxyTool = (
       }
       // Validate params through the tool's own schema
       const validated = def.inputSchema.parse(params);
-      return def.handler(validated);
+      return runHandler(def, validated, onUnauthorized);
     },
   );
 };
@@ -92,6 +115,9 @@ export const createMcpServer = (
   config: Config,
   getToken: () => string | Promise<string>,
   logger: Logger = silentLogger,
+  // Called when a tool handler hits a 401 from Zendesk (OAuth mode only). Lets
+  // the token store invalidate the rejected token. Omitted in API-token mode.
+  onUnauthorized?: () => void,
 ): McpServer => {
   // Read name/version from package.json at runtime rather than hardcoding them
   // (the old literals were stale and even carried the wrong package name).
@@ -138,7 +164,7 @@ export const createMcpServer = (
             inputSchema: tool.inputSchema,
             annotations: tool.annotations,
           },
-          async (params) => tool.handler(params as Record<string, unknown>),
+          async (params) => runHandler(tool, params as Record<string, unknown>, onUnauthorized),
         );
       }
       break;
@@ -155,13 +181,22 @@ export const createMcpServer = (
             tools,
             handlerMap,
             config.readOnly,
+            onUnauthorized,
           );
         }
       }
       break;
     }
     case 'single': {
-      registerProxyTool(server, 'zendesk', 'Zendesk', filteredTools, handlerMap, config.readOnly);
+      registerProxyTool(
+        server,
+        'zendesk',
+        'Zendesk',
+        filteredTools,
+        handlerMap,
+        config.readOnly,
+        onUnauthorized,
+      );
       break;
     }
   }

--- a/tests/integration/unauthorized-backstop.test.ts
+++ b/tests/integration/unauthorized-backstop.test.ts
@@ -1,0 +1,45 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMcpServer } from '../../src/server';
+import { errorHandlers } from '../msw-handlers';
+import { mswServer } from '../setup';
+import { makeConfig } from './harness';
+
+// End-to-end proof of the 401 backstop: when Zendesk rejects the token mid-call,
+// the server invokes `onUnauthorized` (so the OAuth store can drop the dead
+// token) and still surfaces the error to the client.
+describe('[stdio] unauthorized backstop', () => {
+  let close: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await close?.();
+    close = undefined;
+  });
+
+  it('calls onUnauthorized when a tool hits a 401 from Zendesk', async () => {
+    mswServer.use(errorHandlers.usersMeUnauthorized);
+    const onUnauthorized = vi.fn();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createMcpServer(
+      makeConfig({ mode: 'all' }),
+      () => 'test-token',
+      undefined,
+      onUnauthorized,
+    );
+    await server.connect(serverTransport);
+
+    const client = new Client({ name: 'unauthorized-backstop-test', version: '0.0.0' });
+    await client.connect(clientTransport);
+    close = async () => {
+      await client.close();
+      await server.close();
+    };
+
+    const result = await client.callTool({ name: 'get_current_user', arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/auth/browser-oauth.test.ts
+++ b/tests/unit/auth/browser-oauth.test.ts
@@ -11,9 +11,17 @@ vi.mock('open', () => ({
 }));
 
 // Imported after vi.mock so the mocked `open` is bound.
-const { authenticateViaBrowser, startBrowserAuth } = await import(
+const { authenticateViaBrowser, refreshAccessToken, startBrowserAuth } = await import(
   '../../../src/auth/browser-oauth'
 );
+
+const makeLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  attachServer: vi.fn(),
+});
 
 const SUB = 'testsubdomain';
 const CLIENT_ID = 'test_client';
@@ -211,15 +219,28 @@ describe('startBrowserAuth', () => {
     openMock.mockReset();
   });
 
-  it('rejects the start (without opening a browser) when the callback port is in use', async () => {
+  it('rejects with an actionable message (and logs it) when the callback port is in use', async () => {
     const blocker = createServer();
     await new Promise<void>((resolve) => blocker.listen(0, resolve));
     const port = (blocker.address() as { port: number }).port;
+    const logger = makeLogger();
 
     try {
-      await expect(
-        startBrowserAuth({ subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: port }),
-      ).rejects.toThrow(/EADDRINUSE/);
+      const err = await startBrowserAuth(
+        { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: port },
+        logger,
+      ).catch((e) => e as Error);
+
+      // The raw EADDRINUSE is rewrapped into guidance both the user and the LLM
+      // can act on: which port, which env var, and the Zendesk redirect URL.
+      expect(err.message).toMatch(/EADDRINUSE/);
+      expect(err.message).toContain(String(port));
+      expect(err.message).toContain('ZENDESK_OAUTH_CALLBACK_PORT');
+      expect(err.message).toContain('/callback');
+      expect(logger.error).toHaveBeenCalledWith(
+        'oauth_callback_listen_failed',
+        expect.objectContaining({ port, errorCode: 'EADDRINUSE' }),
+      );
       expect(openMock).not.toHaveBeenCalled();
     } finally {
       await new Promise<void>((resolve) => blocker.close(() => resolve()));
@@ -250,5 +271,49 @@ describe('startBrowserAuth', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('refreshAccessToken', () => {
+  it('exchanges a refresh token for a rotated access/refresh token pair', async () => {
+    mswServer.use(
+      http.post(`https://${SUB}.zendesk.com/oauth/tokens`, async ({ request }) => {
+        const params = new URLSearchParams(await request.text());
+        expect(params.get('grant_type')).toBe('refresh_token');
+        expect(params.get('refresh_token')).toBe('old-refresh');
+        expect(params.get('client_id')).toBe(CLIENT_ID);
+        // Public PKCE client → no client secret.
+        expect(params.get('client_secret')).toBeNull();
+        return HttpResponse.json({
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          token_type: 'bearer',
+          scope: 'read write',
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const result = await refreshAccessToken({
+      subdomain: SUB,
+      oauthClientId: CLIENT_ID,
+      refreshToken: 'old-refresh',
+    });
+
+    expect(result.access_token).toBe('new-access');
+    expect(result.refresh_token).toBe('new-refresh');
+    expect(result.expires_in).toBe(3600);
+  });
+
+  it('throws when the refresh token is rejected', async () => {
+    mswServer.use(
+      http.post(`https://${SUB}.zendesk.com/oauth/tokens`, () =>
+        HttpResponse.text('invalid_grant', { status: 400 }),
+      ),
+    );
+
+    await expect(
+      refreshAccessToken({ subdomain: SUB, oauthClientId: CLIENT_ID, refreshToken: 'dead' }),
+    ).rejects.toThrow(/Token refresh failed \(400\)/);
   });
 });

--- a/tests/unit/auth/token-persistence.test.ts
+++ b/tests/unit/auth/token-persistence.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// In-memory filesystem backing the mocked `node:fs`, so these tests never touch
+// the real disk. `node:fs` is also used by readPackageInfo (imported indirectly),
+// which then falls back to the default scoped package name — giving a
+// deterministic `fruggr/zendesk-mcp-server` config segment.
+const files = new Map<string, string>();
+const chmodCalls: Array<{ path: string; mode: number }> = [];
+let failWrite = false;
+
+vi.mock('node:fs', () => ({
+  readFileSync: (p: string) => {
+    const v = files.get(p);
+    if (v === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    return v;
+  },
+  writeFileSync: (p: string, data: string) => {
+    if (failWrite) throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+    files.set(p, String(data));
+  },
+  renameSync: (from: string, to: string) => {
+    const v = files.get(from);
+    if (v === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    files.set(to, v);
+    files.delete(from);
+  },
+  rmSync: (p: string) => {
+    files.delete(p);
+  },
+  mkdirSync: () => undefined,
+  chmodSync: (p: string, mode: number) => {
+    chmodCalls.push({ path: p, mode });
+  },
+}));
+
+const realPlatform = process.platform;
+const setPlatform = (p: NodeJS.Platform) =>
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+
+const importFresh = async () => {
+  vi.resetModules();
+  return import('../../../src/auth/token-persistence');
+};
+
+describe('token-persistence', () => {
+  beforeEach(() => {
+    files.clear();
+    chmodCalls.length = 0;
+    failWrite = false;
+    delete process.env['ZENDESK_TOKEN_FILE'];
+    delete process.env['XDG_CONFIG_HOME'];
+    delete process.env['APPDATA'];
+  });
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+    vi.resetModules();
+  });
+
+  it('resolves the path from ZENDESK_TOKEN_FILE when set', async () => {
+    process.env['ZENDESK_TOKEN_FILE'] = '/custom/token.json';
+    const { resolveTokenPath } = await importFresh();
+    expect(resolveTokenPath('acme')).toBe('/custom/token.json');
+  });
+
+  it('gives each subdomain its own file under the config dir on non-Windows', async () => {
+    setPlatform('linux');
+    process.env['XDG_CONFIG_HOME'] = '/home/u/.config';
+    const { resolveTokenPath } = await importFresh();
+    expect(resolveTokenPath('acme')).toBe('/home/u/.config/fruggr/zendesk-mcp-server/acme.json');
+    expect(resolveTokenPath('other')).toBe('/home/u/.config/fruggr/zendesk-mcp-server/other.json');
+  });
+
+  it('sanitizes unsafe characters in the subdomain filename', async () => {
+    setPlatform('linux');
+    process.env['XDG_CONFIG_HOME'] = '/home/u/.config';
+    const { resolveTokenPath } = await importFresh();
+    expect(resolveTokenPath('../evil')).toBe(
+      '/home/u/.config/fruggr/zendesk-mcp-server/___evil.json',
+    );
+  });
+
+  it('uses %APPDATA% and the namespaced segments on Windows', async () => {
+    setPlatform('win32');
+    process.env['APPDATA'] = 'C:\\Users\\u\\AppData\\Roaming';
+    const { resolveTokenPath } = await importFresh();
+    const path = resolveTokenPath('acme');
+    expect(path).toContain('fruggr');
+    expect(path).toContain('zendesk-mcp-server');
+    expect(path).toContain('acme.json');
+  });
+
+  it('saves then loads a single token record, writing atomically with 0600 perms', async () => {
+    setPlatform('linux');
+    const path = '/cfg/acme.json';
+    const { saveToken, loadToken } = await importFresh();
+
+    saveToken(path, { accessToken: 'a', refreshToken: 'r', expiresAt: 123 });
+
+    expect(loadToken(path)).toEqual({ accessToken: 'a', refreshToken: 'r', expiresAt: 123 });
+    // Written to a temp file (chmod 0600) then renamed onto the final path.
+    expect(chmodCalls.some((c) => c.path.endsWith('.tmp') && c.mode === 0o600)).toBe(true);
+  });
+
+  it('keeps subdomains isolated in separate files (no shared read-modify-write)', async () => {
+    const { saveToken, loadToken } = await importFresh();
+
+    saveToken('/cfg/a.json', { accessToken: 'ta' });
+    saveToken('/cfg/b.json', { accessToken: 'tb' });
+
+    expect(loadToken('/cfg/a.json')?.accessToken).toBe('ta');
+    expect(loadToken('/cfg/b.json')?.accessToken).toBe('tb');
+  });
+
+  it('clear removes the token file', async () => {
+    const path = '/cfg/acme.json';
+    const { saveToken, clearToken, loadToken } = await importFresh();
+    saveToken(path, { accessToken: 'x' });
+
+    clearToken(path);
+    expect(loadToken(path)).toBeUndefined();
+  });
+
+  it('returns undefined for a missing file', async () => {
+    const { loadToken } = await importFresh();
+    expect(loadToken('/cfg/missing.json')).toBeUndefined();
+  });
+
+  it('treats corrupt JSON as no token', async () => {
+    files.set('/cfg/bad.json', '{not json');
+    const { loadToken } = await importFresh();
+    expect(loadToken('/cfg/bad.json')).toBeUndefined();
+  });
+
+  it('never throws when the write fails', async () => {
+    failWrite = true;
+    const { saveToken } = await importFresh();
+    expect(() => saveToken('/cfg/acme.json', { accessToken: 'x' })).not.toThrow();
+  });
+
+  it('does not chmod on Windows', async () => {
+    setPlatform('win32');
+    const { saveToken } = await importFresh();
+    saveToken('C:\\cfg\\acme.json', { accessToken: 'x' });
+    expect(chmodCalls.length).toBe(0);
+  });
+});

--- a/tests/unit/auth/token-store.test.ts
+++ b/tests/unit/auth/token-store.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-type TokenResult = { access_token: string; refresh_token?: string };
+type TokenResult = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+};
 
 const startBrowserAuthMock =
   vi.fn<
@@ -10,12 +14,39 @@ const startBrowserAuthMock =
     }>
   >();
 
+const refreshAccessTokenMock =
+  vi.fn<
+    (config: {
+      subdomain: string;
+      oauthClientId: string;
+      refreshToken: string;
+    }) => Promise<TokenResult>
+  >();
+
 vi.mock('../../../src/auth/browser-oauth', () => ({
   startBrowserAuth: (config: { subdomain: string; oauthClientId: string }) =>
     startBrowserAuthMock(config),
+  refreshAccessToken: (config: {
+    subdomain: string;
+    oauthClientId: string;
+    refreshToken: string;
+  }) => refreshAccessTokenMock(config),
 }));
 
-// Imported after vi.mock so the mocked browser flow is bound.
+// Persistence is mocked so the unit tests never touch the real filesystem; the
+// store's disk interactions are asserted through these spies.
+const loadTokenMock = vi.fn<() => unknown>();
+const saveTokenMock = vi.fn();
+const clearTokenMock = vi.fn();
+
+vi.mock('../../../src/auth/token-persistence', () => ({
+  resolveTokenPath: () => '/tmp/fake-token.json',
+  loadToken: (...args: unknown[]) => loadTokenMock(...(args as [])),
+  saveToken: (...args: unknown[]) => saveTokenMock(...args),
+  clearToken: (...args: unknown[]) => clearTokenMock(...args),
+}));
+
+// Imported after vi.mock so the mocked deps are bound.
 const { createTokenStore, isAuthRequiredError } = await import('../../../src/auth/token-store');
 
 const CONFIG = { subdomain: 'testsubdomain', oauthClientId: 'test_client' };
@@ -38,6 +69,11 @@ const flush = () => new Promise((resolve) => setImmediate(resolve));
 describe('createTokenStore', () => {
   beforeEach(() => {
     startBrowserAuthMock.mockReset();
+    refreshAccessTokenMock.mockReset();
+    loadTokenMock.mockReset();
+    loadTokenMock.mockReturnValue(undefined);
+    saveTokenMock.mockReset();
+    clearTokenMock.mockReset();
   });
 
   it('returns a token set via setToken without triggering the browser flow', async () => {
@@ -46,6 +82,7 @@ describe('createTokenStore', () => {
 
     await expect(store.getToken()).resolves.toBe('preset-token');
     expect(startBrowserAuthMock).not.toHaveBeenCalled();
+    expect(saveTokenMock).toHaveBeenCalled();
   });
 
   it('fails fast with the authorize URL when no token is present', async () => {
@@ -56,7 +93,9 @@ describe('createTokenStore', () => {
     expect(isAuthRequiredError(err)).toBe(true);
     expect((err as { authorizeUrl: string }).authorizeUrl).toBe(AUTH_URL);
     expect((err as Error).message).toContain(AUTH_URL);
-    expect(startBrowserAuthMock).toHaveBeenCalledWith(CONFIG);
+    expect(startBrowserAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({ subdomain: CONFIG.subdomain, oauthClientId: CONFIG.oauthClientId }),
+    );
   });
 
   it('returns the cached token once the background flow completes, then retry succeeds', async () => {
@@ -71,6 +110,22 @@ describe('createTokenStore', () => {
 
     await expect(store.getToken()).resolves.toBe('fresh-token');
     expect(startBrowserAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists the token to disk after the background flow completes', async () => {
+    const { started, resolveToken } = deferredStarted();
+    startBrowserAuthMock.mockResolvedValue(started);
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).rejects.toThrow('authentication required');
+    resolveToken({ access_token: 'fresh-token', refresh_token: 'refresh-abc' });
+    await flush();
+
+    expect(saveTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ accessToken: 'fresh-token', refreshToken: 'refresh-abc' }),
+      expect.anything(),
+    );
   });
 
   it('starts only one browser flow for concurrent first calls', async () => {
@@ -110,5 +165,101 @@ describe('createTokenStore', () => {
     await expect(store.getToken()).rejects.toThrow('EADDRINUSE');
     await expect(store.getToken()).rejects.toThrow('authentication required');
     expect(startBrowserAuthMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses a token loaded from disk without starting a browser flow', async () => {
+    loadTokenMock.mockReturnValue({ accessToken: 'disk-token' });
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('disk-token');
+    expect(startBrowserAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards the configured callback port to the browser flow', async () => {
+    startBrowserAuthMock.mockResolvedValue(deferredStarted().started);
+    const store = createTokenStore({ ...CONFIG, callbackPort: 51000 });
+
+    await store.getToken().catch(() => {});
+    expect(startBrowserAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({ callbackPort: 51000 }),
+    );
+  });
+
+  it('refreshes silently when the cached token is expired, persisting the rotated refresh token', async () => {
+    loadTokenMock.mockReturnValue({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      expiresAt: Date.now() - 1000,
+    });
+    refreshAccessTokenMock.mockResolvedValue({
+      access_token: 'new',
+      refresh_token: 'r2',
+      expires_in: 3600,
+    });
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('new');
+    expect(refreshAccessTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshToken: 'r1' }),
+    );
+    expect(saveTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ accessToken: 'new', refreshToken: 'r2' }),
+      expect.anything(),
+    );
+    expect(startBrowserAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the browser flow when the refresh token is rejected', async () => {
+    loadTokenMock.mockReturnValue({
+      accessToken: 'old',
+      refreshToken: 'bad',
+      expiresAt: Date.now() - 1000,
+    });
+    refreshAccessTokenMock.mockRejectedValue(
+      new Error('Token refresh failed (400): invalid_grant'),
+    );
+    startBrowserAuthMock.mockResolvedValue(deferredStarted().started);
+    const store = createTokenStore(CONFIG);
+
+    const err = await store.getToken().catch((e) => e);
+    expect(isAuthRequiredError(err)).toBe(true);
+    expect(clearTokenMock).toHaveBeenCalledWith(expect.any(String), expect.anything());
+    expect(startBrowserAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidate drops the in-memory and persisted token when there is no refresh token', async () => {
+    loadTokenMock.mockReturnValue({ accessToken: 'live' });
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('live');
+
+    store.invalidate();
+    expect(clearTokenMock).toHaveBeenCalledWith(expect.any(String), expect.anything());
+
+    startBrowserAuthMock.mockResolvedValue(deferredStarted().started);
+    await expect(store.getToken()).rejects.toThrow('authentication required');
+  });
+
+  it('invalidate keeps the refresh token so the next call can refresh silently', async () => {
+    loadTokenMock.mockReturnValue({ accessToken: 'old', refreshToken: 'r1' });
+    refreshAccessTokenMock.mockResolvedValue({ access_token: 'new', refresh_token: 'r2' });
+    const store = createTokenStore(CONFIG);
+
+    store.invalidate();
+    // The record is preserved (persisted), not cleared.
+    expect(clearTokenMock).not.toHaveBeenCalled();
+    expect(saveTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ refreshToken: 'r1', expiresAt: 0 }),
+      expect.anything(),
+    );
+
+    // The next call recovers via silent refresh rather than a browser prompt.
+    await expect(store.getToken()).resolves.toBe('new');
+    expect(refreshAccessTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshToken: 'r1' }),
+    );
+    expect(startBrowserAuthMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -8,6 +8,7 @@ describe('loadConfig', () => {
     delete process.env['ZENDESK_EMAIL'];
     delete process.env['ZENDESK_API_TOKEN'];
     delete process.env['LOG_LEVEL'];
+    delete process.env['ZENDESK_OAUTH_CALLBACK_PORT'];
   });
 
   it('parses subdomain from CLI positional arg', () => {
@@ -74,5 +75,31 @@ describe('loadConfig', () => {
     const config = loadConfig(['mycompany']);
     expect(config.zendeskEmail).toBe('a@b.com');
     expect(config.zendeskApiToken).toBe('tok');
+  });
+
+  it('leaves callbackPort undefined by default', () => {
+    const config = loadConfig(['mycompany']);
+    expect(config.callbackPort).toBeUndefined();
+  });
+
+  it('parses --callback-port flag', () => {
+    const config = loadConfig(['mycompany', '--callback-port', '51000']);
+    expect(config.callbackPort).toBe(51000);
+  });
+
+  it('reads ZENDESK_OAUTH_CALLBACK_PORT from env', () => {
+    process.env['ZENDESK_OAUTH_CALLBACK_PORT'] = '52000';
+    const config = loadConfig(['mycompany']);
+    expect(config.callbackPort).toBe(52000);
+  });
+
+  it('prefers --callback-port over the env var', () => {
+    process.env['ZENDESK_OAUTH_CALLBACK_PORT'] = '52000';
+    const config = loadConfig(['mycompany', '--callback-port', '51000']);
+    expect(config.callbackPort).toBe(51000);
+  });
+
+  it('rejects a callback port outside the TCP range', () => {
+    expect(() => loadConfig(['mycompany', '--callback-port', '70000'])).toThrow();
   });
 });


### PR DESCRIPTION
## Context

Stdio OAuth kept the token in memory only (`token-store.ts`), so any restart of the server process wiped it. On Claude Desktop Cowork (Windows) the plugin respawns the process frequently, the cache is lost, and `getToken` restarts the browser flow with a new PKCE `code_challenge` every time. On Linux (Claude Code) and Mac the process stays alive for the whole session, so the in-memory cache survived and the bug stayed invisible -- hence "works on Mac/Linux, broken on Windows".

Two issues reported by the tester:
- port 3000 conflict with another local tool (the callback port was hardcoded and not overridable);
- token not persisted (the structural issue above).

Forward-looking: Zendesk tokens are currently long-lived but will be shortened, at which point the `authorization_code` flow returns a rotating refresh token and the access token expires, so refresh support is needed too.

Relation to #40 (HTTP transport): complementary. In HTTP mode the MCP client stores tokens; this PR targets the stdio path where the server does the OAuth and must persist. Branched from `main`.

## What changed

- Disk persistence (`src/auth/token-persistence.ts`): token (access/refresh/`expiresAt`) written to an owner-only `0600` file in the OS config dir, namespaced from the scoped package name (`fruggr/zendesk-mcp-server`) to avoid collisions; override with `ZENDESK_TOKEN_FILE`. Atomic write (tmp + rename), tolerant load (missing/corrupt becomes empty). Seeded into the in-memory cache at startup, so it survives restarts.
- Silent refresh (`refreshAccessToken` + `token-store`): when the access token is near or at expiry and a refresh token is present, refresh silently and persist the rotated refresh token; only an expired/invalid refresh token falls back to the browser flow. No-op today (long-lived tokens), active as soon as expiration is enabled in Zendesk.
- Configurable callback port: `ZENDESK_OAUTH_CALLBACK_PORT` / `--callback-port`, default changed from 3000 to 27439 (outside the usual dev range and OS ephemeral ranges). Wired `config` to `createTokenStore` to `startBrowserAuth` (the field existed but was never passed through).
- Actionable port-conflict error: `EADDRINUSE` on the callback server is rewrapped into a message telling the user and the LLM which port, which env var, and which redirect URL to register, plus an `oauth_callback_listen_failed` log.
- 401 backstop: a 401 from Zendesk in a tool handler invalidates the persisted token (`onUnauthorized` to `invalidate`) so the next call refreshes or re-authenticates.

## Migration note (not a SemVer-major)

The default callback port changes from 3000 to 27439. This is shipped as a `feat:` (minor), not a breaking major: the only known consumer controls its own Zendesk config, and the change is fully opt-out. The release notes spell it out. To keep the old behavior, register `http://localhost:27439/callback` in the Zendesk OAuth client, or pin the previous port with `ZENDESK_OAUTH_CALLBACK_PORT=3000` (`--callback-port 3000`).

## Tests and gate

- New `tests/unit/auth/token-persistence.test.ts` (path resolution including Windows, atomic 0600 write, multi-subdomain, corrupt-file tolerance, write-failure swallowed).
- Extended `token-store.test.ts` (disk seeding, persistence after flow, proactive refresh and rotation, refresh-failure fallback, `invalidate`, callback-port forwarding).
- Extended `browser-oauth.test.ts` (actionable EADDRINUSE message and log; `refreshAccessToken` success/failure via MSW).
- New `tests/integration/unauthorized-backstop.test.ts` (401 triggers `onUnauthorized`).
- `config.test.ts` (port flag/env precedence).
- Local gate green: `pnpm typecheck` / `check` / `test:coverage` (274 tests, 96.5 / 81.3 / 99.4 / 97.4 vs ratchet 94/77/98/95) / `build`.

## Docs

`README.md` updated: redirect URL (`:27439`), disk persistence and location, `ZENDESK_OAUTH_CALLBACK_PORT` / `ZENDESK_TOKEN_FILE`, `--callback-port`, and two new troubleshooting entries (port conflict, re-auth).

https://claude.ai/code/session_01N6X2JADLe8rvbUM3wqbJSm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth tokens are now persisted on disk; you no longer need to re-authenticate on restart.
  * Silent token refresh automatically keeps you signed in when refresh tokens are enabled.
  * Configurable OAuth callback port via `--callback-port` option or environment variable.

* **Bug Fixes**
  * Improved error messages when the OAuth callback port is already in use.

* **Documentation**
  * Updated OAuth setup and troubleshooting guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->