### PR TITLE
fix(http): address code-review findings on the HTTP transport (PR #40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,25 +28,7 @@ jobs:
 
       - run: pnpm typecheck
 
-      # TEMPORARY DIAGNOSTIC (revert before merge): test:coverage hangs
-      # intermittently on GitHub runners only, and only when vitest writes to
-      # the runner's stdout pipe (file-redirected runs are consistently
-      # green). Keep the pipe condition via `tee`, capture everything to a
-      # file, and kill the whole process group at the bound so the step always
-      # exits with readable logs (the last running test + open handles).
-      - run: |
-          set +e
-          setsid bash -o pipefail -c 'pnpm test:coverage --reporter=verbose --reporter=hanging-process 2>&1 | tee vitest-diag.log' &
-          pgid=$!
-          ( sleep 240 && kill -TERM -- "-$pgid" 2>/dev/null; sleep 15 && kill -KILL -- "-$pgid" 2>/dev/null ) &
-          watcher=$!
-          wait "$pgid"
-          code=$?
-          kill "$watcher" 2>/dev/null
-          echo "=== exit code: $code ==="
-          echo "=== last 120 lines of vitest output ==="
-          tail -n 120 vitest-diag.log
-          exit $code
+      - run: pnpm test:coverage
 
       - name: Coverage summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,20 @@ jobs:
       - run: pnpm typecheck
 
       # TEMPORARY DIAGNOSTIC (revert before merge): the test step hangs on CI
-      # but not locally. Bound it so the job completes and logs become
-      # readable; `hanging-process` dumps the open handles keeping the worker
-      # alive, `--reporter=verbose` shows the last test that ran.
-      - run: timeout -k 15 300 pnpm test:coverage --reporter=verbose --reporter=hanging-process
+      # but not locally. Bound it and write output to a FILE: orphaned vitest
+      # workers survive `timeout` (it only signals the direct child) and would
+      # hold the runner's stdout pipe open forever — a file redirect lets the
+      # step exit anyway. The tail shows the last running test; `ps` shows the
+      # survivors.
+      - run: |
+          set +e
+          timeout -k 15 240 pnpm test:coverage --reporter=verbose --reporter=hanging-process > vitest-diag.log 2>&1 < /dev/null
+          code=$?
+          echo "=== exit code: $code ==="
+          tail -n 150 vitest-diag.log
+          echo "=== surviving node processes ==="
+          ps -ef | grep -E "node|vitest" | grep -v grep || true
+          exit $code
 
       - name: Coverage summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ permissions:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    # The suite finishes in well under a minute; a wedged test or runner
+    # should fail fast instead of holding the job for the 6-hour default.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -25,21 +28,7 @@ jobs:
 
       - run: pnpm typecheck
 
-      # TEMPORARY DIAGNOSTIC (revert before merge): the test step hangs on CI
-      # but not locally. Bound it and write output to a FILE: orphaned vitest
-      # workers survive `timeout` (it only signals the direct child) and would
-      # hold the runner's stdout pipe open forever — a file redirect lets the
-      # step exit anyway. The tail shows the last running test; `ps` shows the
-      # survivors.
-      - run: |
-          set +e
-          timeout -k 15 240 pnpm test:coverage --reporter=verbose --reporter=hanging-process > vitest-diag.log 2>&1 < /dev/null
-          code=$?
-          echo "=== exit code: $code ==="
-          tail -n 150 vitest-diag.log
-          echo "=== surviving node processes ==="
-          ps -ef | grep -E "node|vitest" | grep -v grep || true
-          exit $code
+      - run: pnpm test:coverage
 
       - name: Coverage summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,25 @@ jobs:
 
       - run: pnpm typecheck
 
-      - run: pnpm test:coverage
+      # TEMPORARY DIAGNOSTIC (revert before merge): test:coverage hangs
+      # intermittently on GitHub runners only, and only when vitest writes to
+      # the runner's stdout pipe (file-redirected runs are consistently
+      # green). Keep the pipe condition via `tee`, capture everything to a
+      # file, and kill the whole process group at the bound so the step always
+      # exits with readable logs (the last running test + open handles).
+      - run: |
+          set +e
+          setsid bash -o pipefail -c 'pnpm test:coverage --reporter=verbose --reporter=hanging-process 2>&1 | tee vitest-diag.log' &
+          pgid=$!
+          ( sleep 240 && kill -TERM -- "-$pgid" 2>/dev/null; sleep 15 && kill -KILL -- "-$pgid" 2>/dev/null ) &
+          watcher=$!
+          wait "$pgid"
+          code=$?
+          kill "$watcher" 2>/dev/null
+          echo "=== exit code: $code ==="
+          echo "=== last 120 lines of vitest output ==="
+          tail -n 120 vitest-diag.log
+          exit $code
 
       - name: Coverage summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,11 @@ jobs:
 
       - run: pnpm typecheck
 
-      - run: pnpm test:coverage
+      # TEMPORARY DIAGNOSTIC (revert before merge): the test step hangs on CI
+      # but not locally. Bound it so the job completes and logs become
+      # readable; `hanging-process` dumps the open handles keeping the worker
+      # alive, `--reporter=verbose` shows the last test that ran.
+      - run: timeout -k 15 300 pnpm test:coverage --reporter=verbose --reporter=hanging-process
 
       - name: Coverage summary
         if: always()

--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ zendesk-mcp-server <your-subdomain> --transport http --port 3000 \
 | **Caddy / nginx / Traefik in front of a VM** | `PUBLIC_URL=https://mcp.example.com` |
 | **Local dev (no proxy)** | `--host 127.0.0.1 --port 3000` — the resource URL is derived automatically (the wildcard `0.0.0.0` is what triggers the warning) |
 
+### Sessions & request limits
+
+- `Authorization: Bearer …` is required on **every** `/mcp` request — a session id alone is never accepted as a credential. The most recent bearer presented on a session is the one used for Zendesk calls, so a client refreshing its token mid-session just works.
+- Request bodies are capped at 4 MB (`413` beyond that).
+- Sessions idle for more than 30 minutes are evicted server-side; clients re-initialize transparently on their next request.
+
 ### Verify discovery endpoints
 
 Served by the HTTP transport in `src/transports/http.ts`:

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,21 @@ export const ConfigSchema = z.object({
    * Desktop, Claude Code CLI, Cursor, VS Code, Zed…) are unaffected
    * because they send no Origin header.
    */
-  corsOrigins: z.array(z.string().url()).default([]),
+  corsOrigins: z
+    .array(
+      z
+        .string()
+        .url()
+        // Browsers send `Origin` with no trailing slash or path, and the CORS
+        // allowlist matches by strict equality. Normalize the configured value
+        // to its origin so `https://app.example.com/` (natural when
+        // copy-pasting a URL) still matches at runtime.
+        .transform((value) => new URL(value).origin)
+        .refine((origin) => origin !== 'null', {
+          message: 'CORS origin must be an http(s) URL with a host',
+        }),
+    )
+    .default([]),
   callbackPort: z.number().int().min(1).max(65535).optional(),
 });
 
@@ -53,6 +67,19 @@ interface CliResult {
   corsOrigins?: string[];
   callbackPort?: number;
 }
+
+// Number.parseInt('8080abc', 10) === 8080 — silently accepts a numeric
+// prefix. Validate strictly so malformed values fail loudly instead. Range
+// checks (0 vs 1 minimum etc.) stay in ConfigSchema, the single authority.
+const parsePort = (raw: string, label: string): number => {
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Invalid ${label} value: "${raw}". Expected an integer 0-65535.`);
+  }
+  return Number(raw);
+};
+
+const parsePortEnv = (raw: string | undefined, label: string): number | undefined =>
+  raw === undefined || raw === '' ? undefined : parsePort(raw, label);
 
 const parseCliArgs = (args: string[]): CliResult => {
   const result: CliResult = {};
@@ -86,12 +113,7 @@ const parseCliArgs = (args: string[]): CliResult => {
       result.host = next;
       i++;
     } else if (arg === '--port' && next) {
-      // Number.parseInt('8080abc', 10) === 8080 — silently accepts a numeric
-      // prefix. Validate strictly so malformed values fail loudly instead.
-      if (!/^\d+$/.test(next)) {
-        throw new Error(`Invalid --port value: "${next}". Expected an integer 0-65535.`);
-      }
-      result.port = Number(next);
+      result.port = parsePort(next, '--port');
       i++;
     } else if (arg === '--public-url' && next) {
       result.publicUrl = next;
@@ -101,7 +123,7 @@ const parseCliArgs = (args: string[]): CliResult => {
       result.corsOrigins.push(next);
       i++;
     } else if (arg === '--callback-port' && next) {
-      result.callbackPort = Number(next);
+      result.callbackPort = parsePort(next, '--callback-port');
       i++;
     } else if (!arg.startsWith('-') && positionalIndex === 0) {
       result.subdomain = arg;
@@ -110,14 +132,6 @@ const parseCliArgs = (args: string[]): CliResult => {
   }
 
   return result;
-};
-
-const parsePortEnv = (raw: string | undefined): number | undefined => {
-  if (raw === undefined || raw === '') return undefined;
-  if (!/^\d+$/.test(raw)) {
-    throw new Error(`Invalid PORT value: "${raw}". Expected an integer 0-65535.`);
-  }
-  return Number(raw);
 };
 
 export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
@@ -131,7 +145,7 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
 
   const transport = cli.transport ?? process.env['TRANSPORT'] ?? 'stdio';
   const host = cli.host ?? process.env['HOST'] ?? '0.0.0.0';
-  const port = cli.port ?? parsePortEnv(process.env['PORT']) ?? 3000;
+  const port = cli.port ?? parsePortEnv(process.env['PORT'], 'PORT') ?? 3000;
   const publicUrl = cli.publicUrl ?? process.env['PUBLIC_URL'];
 
   // CORS allowlist extension: CLI flags first, then comma-separated env var.
@@ -143,8 +157,9 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
     .filter((s) => s.length > 0);
   const corsOrigins = [...(cli.corsOrigins ?? []), ...corsFromEnv];
 
-  const envCallbackPort = process.env['ZENDESK_OAUTH_CALLBACK_PORT'];
-  const callbackPort = cli.callbackPort ?? (envCallbackPort ? Number(envCallbackPort) : undefined);
+  const callbackPort =
+    cli.callbackPort ??
+    parsePortEnv(process.env['ZENDESK_OAUTH_CALLBACK_PORT'], 'ZENDESK_OAUTH_CALLBACK_PORT');
 
   const zendeskEmail = process.env['ZENDESK_EMAIL'];
   const zendeskApiToken = process.env['ZENDESK_API_TOKEN'];

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -258,7 +258,7 @@ type BodyResult =
 // Read and parse the request body. The SDK transport could parse the stream
 // itself, but it neither caps the body size nor maps parse failures to the
 // right HTTP status — buffering here keeps both concerns in one place.
-const readJsonBody = (req: IncomingMessage): Promise<BodyResult> =>
+const readJsonBody = (req: IncomingMessage, maxBodyBytes: number): Promise<BodyResult> =>
   new Promise((resolve) => {
     const chunks: Buffer[] = [];
     let total = 0;
@@ -270,13 +270,13 @@ const readJsonBody = (req: IncomingMessage): Promise<BodyResult> =>
     };
     req.on('data', (chunk: Buffer) => {
       total += chunk.length;
-      if (total > MAX_BODY_BYTES) {
+      if (total > maxBodyBytes) {
         req.removeAllListeners('data');
         settle({
           ok: false,
           status: 413,
           rpcCode: -32600,
-          message: `Request body exceeds ${MAX_BODY_BYTES} bytes.`,
+          message: `Request body exceeds ${maxBodyBytes} bytes.`,
         });
         return;
       }
@@ -346,6 +346,8 @@ export interface HttpTransportOptions {
   sessionIdleTimeoutMs?: number;
   /** Idle-session sweep interval override (tests). */
   sweepIntervalMs?: number;
+  /** Request body cap override (tests use a small cap to stay cheap). */
+  maxBodyBytes?: number;
 }
 
 export const startHttpTransport = async (
@@ -356,6 +358,7 @@ export const startHttpTransport = async (
   const metadata = buildOAuthMetadata(config, logger);
   const sessions = new Map<string, Session>();
   const idleTimeoutMs = options.sessionIdleTimeoutMs ?? SESSION_IDLE_TIMEOUT_MS;
+  const maxBodyBytes = options.maxBodyBytes ?? MAX_BODY_BYTES;
 
   const handleMcpRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     // MCP 2025-06-18: the Authorization header is validated on EVERY request,
@@ -381,7 +384,7 @@ export const startHttpTransport = async (
         session.lastActivityAt = Date.now();
         const body =
           req.method === 'POST'
-            ? await readJsonBody(req)
+            ? await readJsonBody(req, maxBodyBytes)
             : ({ ok: true, value: undefined } as const);
         if (!body.ok) {
           respondBodyError(req, res, body);
@@ -398,7 +401,7 @@ export const startHttpTransport = async (
       return;
     }
 
-    const body = await readJsonBody(req);
+    const body = await readJsonBody(req, maxBodyBytes);
     if (!body.ok) {
       respondBodyError(req, res, body);
       return;

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -79,12 +79,6 @@ export const resolveAllowedOrigin = (
   }
 };
 
-/** Boolean view of `resolveAllowedOrigin`, kept for the existing tests. */
-export const isOriginAllowed = (
-  origin: string,
-  extraOrigins: ReadonlyArray<string> | undefined,
-): boolean => resolveAllowedOrigin(origin, extraOrigins) !== undefined;
-
 const applyCorsHeaders = (
   req: IncomingMessage,
   res: ServerResponse,
@@ -136,19 +130,19 @@ const handleCorsPreflight = (
 //   3. Fallback to host:port + warning. Clients following RFC 8707 strictly
 //      will reject this resource identifier, so log a clear warning so the
 //      operator knows to set PUBLIC_URL.
-export const resolveResourceUrl = (config: Config): string => {
+export const resolveResourceUrl = (config: Config, logger: Logger = silentLogger): string => {
   if (config.publicUrl) return config.publicUrl.replace(/\/+$/, '');
   if (!WILDCARD_HOSTS.has(config.host)) {
     return `http://${config.host}:${config.port}`;
   }
-  console.error(
-    `[zendesk-mcp-server] WARNING: HOST=${config.host} but PUBLIC_URL is unset. ` +
-      `OAuth discovery will advertise http://${config.host}:${config.port} as the ` +
-      `resource identifier, which is not routable from external clients and may ` +
-      `cause spec-compliant MCP clients to refuse the connection. Set PUBLIC_URL ` +
-      `(or --public-url) to the URL clients use to reach this server (e.g. ` +
-      `https://your-host.example.com).`,
-  );
+  logger.warn('public_url_unset', {
+    host: config.host,
+    advertised: `http://${config.host}:${config.port}`,
+    hint:
+      'OAuth discovery will advertise a non-routable resource identifier and spec-compliant ' +
+      'MCP clients may refuse the connection. Set PUBLIC_URL (or --public-url) to the URL ' +
+      'clients use to reach this server (e.g. https://your-host.example.com).',
+  });
   return `http://${config.host}:${config.port}`;
 };
 
@@ -186,10 +180,13 @@ interface OAuthMetadata {
   };
 }
 
-export const buildOAuthMetadata = (config: Config): OAuthMetadata => {
+export const buildOAuthMetadata = (
+  config: Config,
+  logger: Logger = silentLogger,
+): OAuthMetadata => {
   const { authorizeUrl, tokenUrl } = getOAuthUrls(config.subdomain);
   const issuer = `https://${config.subdomain}.zendesk.com`;
-  const resource = resolveResourceUrl(config);
+  const resource = resolveResourceUrl(config, logger);
   return {
     protectedResource: {
       authorization_servers: [issuer],
@@ -215,38 +212,109 @@ const sendJson = (res: ServerResponse, status: number, body: unknown): void => {
   res.end(JSON.stringify(body));
 };
 
+// Single construction point for JSON-RPC-shaped HTTP errors so the envelope
+// ({ error, id: null, jsonrpc }) can't drift between the 4xx/5xx paths.
+const sendJsonRpcError = (
+  res: ServerResponse,
+  status: number,
+  code: number,
+  message: string,
+  headers: Record<string, string> = {},
+): void => {
+  res.writeHead(status, { 'Content-Type': 'application/json', ...headers });
+  res.end(JSON.stringify({ error: { code, message }, id: null, jsonrpc: '2.0' }));
+};
+
 const sendUnauthorized = (res: ServerResponse, resource: string): void => {
   // RFC 6750 + MCP 2025-06-18: the WWW-Authenticate header points the client
   // at the resource metadata that bootstraps the OAuth discovery flow.
   const wwwAuthenticate = `Bearer resource_metadata="${resource}/.well-known/oauth-protected-resource", error="invalid_token", error_description="${MISSING_BEARER_MESSAGE}"`;
-  res.writeHead(401, {
-    'Content-Type': 'application/json',
+  sendJsonRpcError(res, 401, -32000, MISSING_BEARER_MESSAGE, {
     'WWW-Authenticate': wwwAuthenticate,
   });
-  res.end(
-    JSON.stringify({
-      error: { code: -32000, message: MISSING_BEARER_MESSAGE },
-      id: null,
-      jsonrpc: '2.0',
-    }),
-  );
 };
 
 interface Session {
   transport: StreamableHTTPServerTransport;
+  /**
+   * Latest bearer presented for this session. Tool calls read through this
+   * object so a client that refreshes its Zendesk token mid-session has the
+   * fresh token used on the next call.
+   */
+  auth: { bearer: string };
+  /** Epoch ms of the last request routed to this session (idle eviction). */
+  lastActivityAt: number;
   close(): Promise<void>;
 }
 
-// Read the request body into a string. The SDK transport expects a parsed
-// body or will parse from the stream itself; we go through a buffer to keep
-// the JSON-RPC dispatch deterministic.
-const readBody = (req: IncomingMessage): Promise<string> =>
-  new Promise((resolve, reject) => {
+// JSON-RPC tool calls are small; this is a generous ceiling that exists only
+// so a client can't stream an unbounded body into server memory.
+export const MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+type BodyResult =
+  | { ok: true; value: unknown }
+  | { ok: false; status: number; rpcCode: number; message: string };
+
+// Read and parse the request body. The SDK transport could parse the stream
+// itself, but it neither caps the body size nor maps parse failures to the
+// right HTTP status — buffering here keeps both concerns in one place.
+const readJsonBody = (req: IncomingMessage): Promise<BodyResult> =>
+  new Promise((resolve) => {
     const chunks: Buffer[] = [];
-    req.on('data', (chunk) => chunks.push(chunk));
-    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
-    req.on('error', reject);
+    let total = 0;
+    let settled = false;
+    const settle = (result: BodyResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > MAX_BODY_BYTES) {
+        req.removeAllListeners('data');
+        settle({
+          ok: false,
+          status: 413,
+          rpcCode: -32600,
+          message: `Request body exceeds ${MAX_BODY_BYTES} bytes.`,
+        });
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) {
+        settle({ ok: true, value: undefined });
+        return;
+      }
+      try {
+        settle({ ok: true, value: JSON.parse(raw) });
+      } catch {
+        settle({
+          ok: false,
+          status: 400,
+          rpcCode: -32700,
+          message: 'Parse error: request body is not valid JSON.',
+        });
+      }
+    });
+    req.on('error', () =>
+      settle({
+        ok: false,
+        status: 400,
+        rpcCode: -32600,
+        message: 'Request body could not be read.',
+      }),
+    );
   });
+
+// A client that vanishes without DELETEing its session would otherwise leak a
+// McpServer + bearer forever (the SDK only fires onclose on an explicit
+// DELETE). A periodic sweep closes sessions with no traffic for this long;
+// well-behaved clients simply re-initialize on their next request.
+const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const SESSION_SWEEP_INTERVAL_MS = 60 * 1000;
 
 export interface HttpServerHandle {
   /** Actual bound port (resolved when listen completes — useful for port:0 tests). */
@@ -255,58 +323,81 @@ export interface HttpServerHandle {
   close(): Promise<void>;
 }
 
+export interface HttpTransportOptions {
+  /** Idle-session eviction timeout override (tests). */
+  sessionIdleTimeoutMs?: number;
+  /** Idle-session sweep interval override (tests). */
+  sweepIntervalMs?: number;
+}
+
 export const startHttpTransport = async (
   config: Config,
   logger: Logger = silentLogger,
+  options: HttpTransportOptions = {},
 ): Promise<HttpServerHandle> => {
-  const metadata = buildOAuthMetadata(config);
+  const metadata = buildOAuthMetadata(config, logger);
   const sessions = new Map<string, Session>();
+  const idleTimeoutMs = options.sessionIdleTimeoutMs ?? SESSION_IDLE_TIMEOUT_MS;
 
   const handleMcpRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
-    const sessionId =
-      typeof req.headers['mcp-session-id'] === 'string' ? req.headers['mcp-session-id'] : undefined;
-
-    // Existing session: route the request to its transport.
-    if (sessionId) {
-      const session = sessions.get(sessionId);
-      if (session) {
-        const body = req.method === 'POST' ? await readBody(req) : undefined;
-        const parsed = body ? JSON.parse(body) : undefined;
-        await session.transport.handleRequest(req, res, parsed);
-        return;
-      }
-    }
-
-    // New session: an unauthenticated request gets a 401 + WWW-Authenticate
-    // that bootstraps the OAuth flow on the client side. The bearer is
-    // captured here and passed to the per-session McpServer as the token
-    // source for every tool call on that session — no async-local storage
-    // needed because each session has its own server instance.
+    // MCP 2025-06-18: the Authorization header is validated on EVERY request,
+    // not only at session initialization — a session id alone is not a
+    // credential. An unauthenticated request gets a 401 + WWW-Authenticate
+    // that bootstraps the OAuth flow on the client side.
     const bearer = extractBearer(req);
     if (!bearer) {
       sendUnauthorized(res, metadata.protectedResource.resource);
       return;
     }
 
+    const sessionId =
+      typeof req.headers['mcp-session-id'] === 'string' ? req.headers['mcp-session-id'] : undefined;
+
+    // Existing session: adopt the presented bearer (clients may have
+    // refreshed their Zendesk token mid-session) and route the request to
+    // the session's transport.
+    if (sessionId) {
+      const session = sessions.get(sessionId);
+      if (session) {
+        session.auth.bearer = bearer;
+        session.lastActivityAt = Date.now();
+        const body =
+          req.method === 'POST'
+            ? await readJsonBody(req)
+            : ({ ok: true, value: undefined } as const);
+        if (!body.ok) {
+          sendJsonRpcError(res, body.status, body.rpcCode, body.message);
+          return;
+        }
+        await session.transport.handleRequest(req, res, body.value);
+        return;
+      }
+    }
+
     if (req.method !== 'POST') {
       // Non-POST without a session ID can't initialize a new session.
-      sendJson(res, 400, {
-        error: { code: -32000, message: 'No active session; initialize via POST first.' },
-        id: null,
-        jsonrpc: '2.0',
-      });
+      sendJsonRpcError(res, 400, -32000, 'No active session; initialize via POST first.');
       return;
     }
 
-    const body = await readBody(req);
-    const parsed = body ? JSON.parse(body) : undefined;
+    const body = await readJsonBody(req);
+    if (!body.ok) {
+      sendJsonRpcError(res, body.status, body.rpcCode, body.message);
+      return;
+    }
 
-    const server = createMcpServer(config, () => bearer, logger);
+    // New session: the bearer is held in a per-session mutable cell read by
+    // the per-session McpServer's token source — no async-local storage
+    // needed because each session has its own server instance.
+    const auth = { bearer };
+    const server = createMcpServer(config, () => auth.bearer, logger);
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (newId) => {
         sessions.set(newId, {
           transport,
+          auth,
+          lastActivityAt: Date.now(),
           close: async () => {
             await transport.close();
             await server.close();
@@ -323,7 +414,7 @@ export const startHttpTransport = async (
     // purely a type-system seam.
     // biome-ignore lint/suspicious/noExplicitAny: SDK type seam, see above
     await server.connect(transport as any);
-    await transport.handleRequest(req, res, parsed);
+    await transport.handleRequest(req, res, body.value);
   };
 
   const requestListener = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
@@ -356,20 +447,13 @@ export const startHttpTransport = async (
       res.writeHead(404, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Not found', path: url.pathname }));
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Internal Server Error';
       if (!res.headersSent) {
-        res.writeHead(500, { 'Content-Type': 'application/json' });
-      }
-      if (!res.writableEnded) {
-        res.end(
-          JSON.stringify({
-            error: {
-              code: -32603,
-              message: err instanceof Error ? err.message : 'Internal Server Error',
-            },
-            id: null,
-            jsonrpc: '2.0',
-          }),
-        );
+        sendJsonRpcError(res, 500, -32603, message);
+      } else if (!res.writableEnded) {
+        // Headers already on the wire: appending a JSON error mid-stream would
+        // corrupt the body; just terminate the response.
+        res.end();
       }
     }
   };
@@ -390,10 +474,33 @@ export const startHttpTransport = async (
   const boundPort = typeof addr === 'object' && addr !== null ? addr.port : config.port;
   logger.info('http_transport_ready', { host: config.host, port: boundPort });
 
+  const sweepIdleSessions = async (): Promise<void> => {
+    const cutoff = Date.now() - idleTimeoutMs;
+    for (const [id, session] of sessions) {
+      if (session.lastActivityAt > cutoff) continue;
+      sessions.delete(id);
+      try {
+        await session.close();
+      } catch (err) {
+        logger.warn('session_close_failed', {
+          sessionId: id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  };
+  const sweeper = setInterval(
+    () => void sweepIdleSessions(),
+    options.sweepIntervalMs ?? SESSION_SWEEP_INTERVAL_MS,
+  );
+  // The sweeper must never keep the process alive on its own.
+  sweeper.unref();
+
   return {
     port: boundPort,
     close: async () => {
-      for (const session of sessions.values()) await session.close();
+      clearInterval(sweeper);
+      await Promise.all([...sessions.values()].map((session) => session.close()));
       sessions.clear();
       await new Promise<void>((resolve, reject) => {
         httpServer.close((err) => (err ? reject(err) : resolve()));

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -309,6 +309,24 @@ const readJsonBody = (req: IncomingMessage): Promise<BodyResult> =>
     );
   });
 
+const respondBodyError = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  failure: Extract<BodyResult, { ok: false }>,
+): void => {
+  const headers = failure.status === 413 ? { Connection: 'close' } : {};
+  sendJsonRpcError(res, failure.status, failure.rpcCode, failure.message, headers);
+  if (failure.status === 413) {
+    // The client may still be mid-upload with the request stream paused
+    // (readJsonBody dropped its listeners at the cap). Left alone, the
+    // connection wedges: the client blocks on backpressure and
+    // httpServer.close() waits on the socket forever. Drop it as soon as the
+    // 413 has flushed.
+    if (res.writableFinished) req.destroy();
+    else res.once('finish', () => req.destroy());
+  }
+};
+
 // A client that vanishes without DELETEing its session would otherwise leak a
 // McpServer + bearer forever (the SDK only fires onclose on an explicit
 // DELETE). A periodic sweep closes sessions with no traffic for this long;
@@ -366,7 +384,7 @@ export const startHttpTransport = async (
             ? await readJsonBody(req)
             : ({ ok: true, value: undefined } as const);
         if (!body.ok) {
-          sendJsonRpcError(res, body.status, body.rpcCode, body.message);
+          respondBodyError(req, res, body);
           return;
         }
         await session.transport.handleRequest(req, res, body.value);
@@ -382,7 +400,7 @@ export const startHttpTransport = async (
 
     const body = await readJsonBody(req);
     if (!body.ok) {
-      sendJsonRpcError(res, body.status, body.rpcCode, body.message);
+      respondBodyError(req, res, body);
       return;
     }
 
@@ -502,6 +520,10 @@ export const startHttpTransport = async (
       clearInterval(sweeper);
       await Promise.all([...sessions.values()].map((session) => session.close()));
       sessions.clear();
+      // server.close() waits for every connection to drain; a wedged or
+      // keep-alive socket would stall shutdown forever. Sessions are already
+      // closed at this point, so dropping the remaining sockets is safe.
+      httpServer.closeAllConnections();
       await new Promise<void>((resolve, reject) => {
         httpServer.close((err) => (err ? reject(err) : resolve()));
       });

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -191,6 +191,32 @@ describe('loadConfig', () => {
     });
   });
 
+  describe('corsOrigins', () => {
+    beforeEach(() => {
+      delete process.env['CORS_ORIGIN'];
+    });
+
+    it('normalizes a trailing slash to the bare origin (browsers send no slash in Origin)', () => {
+      const config = loadConfig(['mycompany', '--cors-origin', 'https://my-app.example.com/']);
+      expect(config.corsOrigins).toEqual(['https://my-app.example.com']);
+    });
+
+    it('normalizes a URL with a path down to its origin', () => {
+      process.env['CORS_ORIGIN'] = 'https://my-app.example.com/some/page';
+      const config = loadConfig(['mycompany']);
+      expect(config.corsOrigins).toEqual(['https://my-app.example.com']);
+    });
+
+    it('keeps an already-normalized origin untouched', () => {
+      const config = loadConfig(['mycompany', '--cors-origin', 'https://my-app.example.com']);
+      expect(config.corsOrigins).toEqual(['https://my-app.example.com']);
+    });
+
+    it('rejects values that are not URLs', () => {
+      expect(() => loadConfig(['mycompany', '--cors-origin', 'not-a-url'])).toThrow();
+    });
+  });
+
   describe('callbackPort', () => {
     it('leaves callbackPort undefined by default', () => {
       const config = loadConfig(['mycompany']);
@@ -216,6 +242,18 @@ describe('loadConfig', () => {
 
     it('rejects a callback port outside the TCP range', () => {
       expect(() => loadConfig(['mycompany', '--callback-port', '70000'])).toThrow();
+    });
+
+    it('rejects --callback-port values that are not strictly numeric', () => {
+      // Same strictness as --port: Number.parseInt would accept '51000abc'.
+      expect(() => loadConfig(['mycompany', '--callback-port', '51000abc'])).toThrow(
+        /Invalid --callback-port value/,
+      );
+    });
+
+    it('rejects ZENDESK_OAUTH_CALLBACK_PORT env values that are not strictly numeric', () => {
+      process.env['ZENDESK_OAUTH_CALLBACK_PORT'] = '52000abc';
+      expect(() => loadConfig(['mycompany'])).toThrow(/Invalid ZENDESK_OAUTH_CALLBACK_PORT value/);
     });
   });
 });

--- a/tests/unit/transports/http.test.ts
+++ b/tests/unit/transports/http.test.ts
@@ -312,8 +312,14 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
     expect(seenAuth).toEqual(['Bearer rotated-token']);
   });
 
-  it('rejects a body over MAX_BODY_BYTES with 413', async () => {
-    handle = await startHttpTransport(baseConfig);
+  // Both 413 tests inject a small cap: the production default is 4 MB, and
+  // pushing megabytes through the test stack means MSW's interceptor clones
+  // and buffers the body — slow, and a source of timing-dependent hangs on
+  // constrained CI runners. The cap value is irrelevant to the behavior.
+  const SMALL_CAP = 64 * 1024;
+
+  it('rejects a body over the configured cap with 413', async () => {
+    handle = await startHttpTransport(baseConfig, undefined, { maxBodyBytes: SMALL_CAP });
     const res = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
       method: 'POST',
       headers: {
@@ -321,10 +327,14 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
         'Content-Type': 'application/json',
         Accept: 'application/json, text/event-stream',
       },
-      body: `{"pad":"${'x'.repeat(MAX_BODY_BYTES + 1)}"}`,
+      body: `{"pad":"${'x'.repeat(SMALL_CAP + 1)}"}`,
     });
     expect(res.status).toBe(413);
     await res.text();
+  });
+
+  it('defaults the body cap to MAX_BODY_BYTES (sanity)', () => {
+    expect(MAX_BODY_BYTES).toBe(4 * 1024 * 1024);
   });
 
   it('responds 413 mid-upload and drops the connection (no deadlock on slow clients)', async () => {
@@ -333,7 +343,7 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
     // destroys the socket after the 413, the connection wedges and
     // handle.close() (in afterEach) hangs forever. Reproduced here with a
     // request that announces more than it ever sends.
-    handle = await startHttpTransport(baseConfig);
+    handle = await startHttpTransport(baseConfig, undefined, { maxBodyBytes: SMALL_CAP });
     const status = await new Promise<number>((resolve, reject) => {
       const req = httpRequest({
         host: '127.0.0.1',
@@ -343,7 +353,7 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
         headers: {
           Authorization: 'Bearer test-token',
           'Content-Type': 'application/json',
-          'Content-Length': String(MAX_BODY_BYTES * 2),
+          'Content-Length': String(SMALL_CAP * 2),
         },
       });
       req.on('response', (res) => {
@@ -355,7 +365,7 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
       // ever arrived.
       req.on('error', (err) => reject(err));
       // Send just past the cap, then keep the request open forever.
-      req.write(Buffer.alloc(MAX_BODY_BYTES + 1024, 120));
+      req.write(Buffer.alloc(SMALL_CAP + 1024, 120));
     });
     expect(status).toBe(413);
     // afterEach's handle.close() locks the "shutdown never hangs" half.

--- a/tests/unit/transports/http.test.ts
+++ b/tests/unit/transports/http.test.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from 'node:http';
+import { request as httpRequest, type IncomingMessage } from 'node:http';
 import { HttpResponse, http } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Config } from '../../../src/config';
@@ -325,6 +325,40 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
     });
     expect(res.status).toBe(413);
     await res.text();
+  });
+
+  it('responds 413 mid-upload and drops the connection (no deadlock on slow clients)', async () => {
+    // Regression for a CI-only deadlock: when the cap is hit while the client
+    // is still uploading, the request stream is paused; unless the server
+    // destroys the socket after the 413, the connection wedges and
+    // handle.close() (in afterEach) hangs forever. Reproduced here with a
+    // request that announces more than it ever sends.
+    handle = await startHttpTransport(baseConfig);
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = httpRequest({
+        host: '127.0.0.1',
+        port: handle?.port,
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+          'Content-Length': String(MAX_BODY_BYTES * 2),
+        },
+      });
+      req.on('response', (res) => {
+        res.resume();
+        resolve(res.statusCode ?? 0);
+      });
+      // The server destroys the socket right after the 413 — an ECONNRESET
+      // here is the expected teardown, not a failure, unless no response
+      // ever arrived.
+      req.on('error', (err) => reject(err));
+      // Send just past the cap, then keep the request open forever.
+      req.write(Buffer.alloc(MAX_BODY_BYTES + 1024, 120));
+    });
+    expect(status).toBe(413);
+    // afterEach's handle.close() locks the "shutdown never hangs" half.
   });
 
   it('rejects malformed JSON with 400 and JSON-RPC -32700 Parse Error', async () => {

--- a/tests/unit/transports/http.test.ts
+++ b/tests/unit/transports/http.test.ts
@@ -1,15 +1,18 @@
 import type { IncomingMessage } from 'node:http';
+import { HttpResponse, http } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Config } from '../../../src/config';
 import {
   buildOAuthMetadata,
   DEFAULT_BROWSER_MCP_CLIENT_ORIGINS,
   extractBearer,
-  isOriginAllowed,
+  MAX_BODY_BYTES,
+  resolveAllowedOrigin,
   resolveResourceUrl,
   startHttpTransport,
 } from '../../../src/transports/http';
-import { errorHandlers } from '../../msw-handlers';
+import { type Logger, silentLogger } from '../../../src/utils/logger';
+import { errorHandlers, MOCK_USER } from '../../msw-handlers';
 import { mswServer } from '../../setup';
 
 const baseConfig: Config = {
@@ -26,6 +29,33 @@ const baseConfig: Config = {
 
 const mockRequest = (headers: Record<string, string | string[] | undefined>): IncomingMessage =>
   ({ headers }) as unknown as IncomingMessage;
+
+// Initialize an MCP session over HTTP and return its mcp-session-id.
+const initializeSession = async (port: number, authorization: string): Promise<string> => {
+  const init = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      id: 1,
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'test', version: '0.0.0' },
+      },
+    }),
+  });
+  expect(init.status).toBe(200);
+  const sessionId = init.headers.get('mcp-session-id');
+  await init.text();
+  if (!sessionId) throw new Error('initialize did not return a session id');
+  return sessionId;
+};
 
 describe('extractBearer', () => {
   it('returns the token from a well-formed Bearer header', () => {
@@ -68,29 +98,19 @@ describe('resolveResourceUrl', () => {
     );
   });
 
-  it('warns and returns the wildcard URL when host is 0.0.0.0 and publicUrl is unset', () => {
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    try {
-      const url = resolveResourceUrl({ ...baseConfig, host: '0.0.0.0', port: 3000 });
-      expect(url).toBe('http://0.0.0.0:3000');
-      const warned = errSpy.mock.calls.some((args) =>
-        args.some(
-          (a) => typeof a === 'string' && a.includes('WARNING') && a.includes('PUBLIC_URL'),
-        ),
-      );
-      expect(warned).toBe(true);
-    } finally {
-      errSpy.mockRestore();
-    }
+  it('warns via the structured logger when host is 0.0.0.0 and publicUrl is unset', () => {
+    const warnSpy = vi.fn();
+    const logger: Logger = { ...silentLogger, warn: warnSpy };
+    const url = resolveResourceUrl({ ...baseConfig, host: '0.0.0.0', port: 3000 }, logger);
+    expect(url).toBe('http://0.0.0.0:3000');
+    expect(warnSpy).toHaveBeenCalledWith(
+      'public_url_unset',
+      expect.objectContaining({ host: '0.0.0.0', advertised: 'http://0.0.0.0:3000' }),
+    );
   });
 
   it('also recognizes :: as the wildcard host', () => {
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    try {
-      expect(resolveResourceUrl({ ...baseConfig, host: '::', port: 3000 })).toBe('http://:::3000');
-    } finally {
-      errSpy.mockRestore();
-    }
+    expect(resolveResourceUrl({ ...baseConfig, host: '::', port: 3000 })).toBe('http://:::3000');
   });
 });
 
@@ -217,33 +237,34 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
   it('routes a follow-up request to its existing session via mcp-session-id', async () => {
     // Regression coverage for the existing-session branch in handleMcpRequest:
     // initialize once → capture the session id → POST again with that id and
-    // assert the request is routed to the same session (no re-init, no 401).
+    // assert the request is routed to the same session (no re-init).
     handle = await startHttpTransport(baseConfig);
-    const init = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
+    const sessionId = await initializeSession(handle.port, 'Bearer test-token');
+
+    // Follow-up: tools/list on the same session. The handler should route via
+    // sessions.get(sessionId).transport.handleRequest. The bearer stays
+    // mandatory: Authorization is validated on every request, not only at
+    // session initialization.
+    const followUp = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
       method: 'POST',
       headers: {
         Authorization: 'Bearer test-token',
         'Content-Type': 'application/json',
         Accept: 'application/json, text/event-stream',
+        'mcp-session-id': sessionId,
       },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        method: 'initialize',
-        id: 1,
-        params: {
-          protocolVersion: '2025-06-18',
-          capabilities: {},
-          clientInfo: { name: 'test', version: '0.0.0' },
-        },
-      }),
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 2 }),
     });
-    const sessionId = init.headers.get('mcp-session-id');
-    if (!sessionId) throw new Error('initialize did not return a session id');
-    await init.text();
+    expect(followUp.status).toBe(200);
+    await followUp.text();
+  });
 
-    // Follow-up: tools/list on the same session. The handler should route via
-    // sessions.get(sessionId).transport.handleRequest — no bearer needed at
-    // this point because the session is already authenticated.
+  it('rejects a sessionful request without Authorization with 401 (session id is not a credential)', async () => {
+    // Security regression lock: a leaked mcp-session-id alone must NOT grant
+    // access to the session's Zendesk token.
+    handle = await startHttpTransport(baseConfig);
+    const sessionId = await initializeSession(handle.port, 'Bearer test-token');
+
     const followUp = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
       method: 'POST',
       headers: {
@@ -253,7 +274,98 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
       },
       body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 2 }),
     });
-    expect(followUp.status).toBe(200);
+    expect(followUp.status).toBe(401);
+    expect(followUp.headers.get('www-authenticate')).toMatch(/^Bearer\b/i);
+    await followUp.text();
+  });
+
+  it('uses the freshest bearer presented on an existing session (token rotation)', async () => {
+    // Clients refresh their Zendesk access token mid-session; the next tool
+    // call must go out with the new token, not the one captured at init.
+    const seenAuth: Array<string | null> = [];
+    mswServer.use(
+      http.get('https://testsubdomain.zendesk.com/api/v2/users/me', ({ request }) => {
+        seenAuth.push(request.headers.get('authorization'));
+        return HttpResponse.json({ user: MOCK_USER });
+      }),
+    );
+    handle = await startHttpTransport(baseConfig);
+    const sessionId = await initializeSession(handle.port, 'Bearer first-token');
+
+    const call = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer rotated-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'mcp-session-id': sessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        id: 2,
+        params: { name: 'get_current_user', arguments: {} },
+      }),
+    });
+    expect(call.status).toBe(200);
+    await call.text();
+    expect(seenAuth).toEqual(['Bearer rotated-token']);
+  });
+
+  it('rejects a body over MAX_BODY_BYTES with 413', async () => {
+    handle = await startHttpTransport(baseConfig);
+    const res = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: `{"pad":"${'x'.repeat(MAX_BODY_BYTES + 1)}"}`,
+    });
+    expect(res.status).toBe(413);
+    await res.text();
+  });
+
+  it('rejects malformed JSON with 400 and JSON-RPC -32700 Parse Error', async () => {
+    handle = await startHttpTransport(baseConfig);
+    const res = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: '{this is not json',
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: number } };
+    expect(body.error.code).toBe(-32700);
+  });
+
+  it('evicts idle sessions after the configured timeout', async () => {
+    handle = await startHttpTransport(baseConfig, undefined, {
+      sessionIdleTimeoutMs: 50,
+      sweepIntervalMs: 20,
+    });
+    const sessionId = await initializeSession(handle.port, 'Bearer test-token');
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // The session is gone: the request falls through to the new-session path,
+    // where a non-initialize POST on a fresh transport is rejected by the SDK
+    // (anything but 200 proves the old session no longer exists).
+    const followUp = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'mcp-session-id': sessionId,
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 2 }),
+    });
+    expect(followUp.status).not.toBe(200);
     await followUp.text();
   });
 
@@ -280,31 +392,40 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
   });
 });
 
-describe('isOriginAllowed', () => {
+describe('resolveAllowedOrigin', () => {
   it('always allows the default browser MCP client origins', () => {
     for (const origin of DEFAULT_BROWSER_MCP_CLIENT_ORIGINS) {
-      expect(isOriginAllowed(origin, [])).toBe(true);
+      expect(resolveAllowedOrigin(origin, [])).toBe(origin);
     }
   });
 
   it('always allows localhost on any port (dev tooling)', () => {
-    expect(isOriginAllowed('http://localhost:6274', [])).toBe(true);
-    expect(isOriginAllowed('http://127.0.0.1:9999', [])).toBe(true);
-    expect(isOriginAllowed('http://[::1]:3000', [])).toBe(true);
+    expect(resolveAllowedOrigin('http://localhost:6274', [])).toBe('http://localhost:6274');
+    expect(resolveAllowedOrigin('http://127.0.0.1:9999', [])).toBe('http://127.0.0.1:9999');
+    expect(resolveAllowedOrigin('http://[::1]:3000', [])).toBe('http://[::1]:3000');
   });
 
   it('rejects an unknown origin not in defaults nor extras', () => {
-    expect(isOriginAllowed('https://evil.example.com', [])).toBe(false);
+    expect(resolveAllowedOrigin('https://evil.example.com', [])).toBeUndefined();
   });
 
   it('accepts an extra origin passed by the operator', () => {
-    expect(isOriginAllowed('https://my-app.example.com', ['https://my-app.example.com'])).toBe(
-      true,
+    expect(resolveAllowedOrigin('https://my-app.example.com', ['https://my-app.example.com'])).toBe(
+      'https://my-app.example.com',
     );
   });
 
+  it('matches extras by strict equality — config normalization is what makes trailing slashes work', () => {
+    // Browsers never send a trailing slash in Origin; an un-normalized entry
+    // can't match. loadConfig normalizes entries to their URL origin, which is
+    // covered in tests/unit/config.test.ts.
+    expect(
+      resolveAllowedOrigin('https://my-app.example.com', ['https://my-app.example.com/']),
+    ).toBeUndefined();
+  });
+
   it('rejects malformed origin strings without throwing', () => {
-    expect(isOriginAllowed('not-a-url', [])).toBe(false);
+    expect(resolveAllowedOrigin('not-a-url', [])).toBeUndefined();
   });
 
   it('lists ChatGPT first in the default allowlist (largest user base)', () => {
@@ -420,37 +541,16 @@ describe('startHttpTransport (Zendesk 401 backstop)', () => {
   //   3. NO `onUnauthorized` callback to be invoked server-side — there is
   //      nothing to invalidate (this is asserted indirectly by point 2 and
   //      explicitly in the http.ts construction `createMcpServer(config, () =>
-  //      bearer, logger)` which omits the fourth argument).
+  //      auth.bearer, logger)` which omits the fourth argument).
   it('surfaces a Zendesk 401 as an MCP tool error and keeps the session open', async () => {
     mswServer.use(errorHandlers.usersMeUnauthorized);
     handle = await startHttpTransport(baseConfig);
-
-    const initRes = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
-      method: 'POST',
-      headers: {
-        Authorization: 'Bearer client-issued-bearer',
-        'Content-Type': 'application/json',
-        Accept: 'application/json, text/event-stream',
-      },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        method: 'initialize',
-        id: 1,
-        params: {
-          protocolVersion: '2025-06-18',
-          capabilities: {},
-          clientInfo: { name: 'test', version: '0.0.0' },
-        },
-      }),
-    });
-    expect(initRes.status).toBe(200);
-    const sessionId = initRes.headers.get('mcp-session-id');
-    if (!sessionId) throw new Error('initialize did not return a session id');
-    await initRes.text();
+    const sessionId = await initializeSession(handle.port, 'Bearer client-issued-bearer');
 
     const callRes = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
       method: 'POST',
       headers: {
+        Authorization: 'Bearer client-issued-bearer',
         'Content-Type': 'application/json',
         Accept: 'application/json, text/event-stream',
         'mcp-session-id': sessionId,
@@ -489,6 +589,7 @@ describe('startHttpTransport (Zendesk 401 backstop)', () => {
     const followUp = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
       method: 'POST',
       headers: {
+        Authorization: 'Bearer client-issued-bearer',
         'Content-Type': 'application/json',
         Accept: 'application/json, text/event-stream',
         'mcp-session-id': sessionId,

--- a/tests/unit/transports/http.test.ts
+++ b/tests/unit/transports/http.test.ts
@@ -356,14 +356,18 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
           'Content-Length': String(SMALL_CAP * 2),
         },
       });
+      let responseReceived = false;
       req.on('response', (res) => {
+        responseReceived = true;
         res.resume();
         resolve(res.statusCode ?? 0);
       });
-      // The server destroys the socket right after the 413 — an ECONNRESET
-      // here is the expected teardown, not a failure, unless no response
-      // ever arrived.
-      req.on('error', (err) => reject(err));
+      // The server destroys the socket right after the 413, and the RST can
+      // race the response bytes on a loaded kernel — an ECONNRESET after the
+      // response is the expected teardown, not a failure.
+      req.on('error', (err) => {
+        if (!responseReceived) reject(err);
+      });
       // Send just past the cap, then keep the request open forever.
       req.write(Buffer.alloc(SMALL_CAP + 1024, 120));
     });


### PR DESCRIPTION
Follow-up to #40: fixes the 9 findings from a code review of the HTTP transport branch. Targets `claude/allons-traiter-1-Sxf5O` so it folds into #40 before merge.

## Correctness / security

1. **Authorization is now validated on every `/mcp` request** (was: only at session init — a leaked `mcp-session-id` alone granted access to the session's Zendesk token, and a revoked bearer was never re-checked). The latest presented bearer is adopted per session, so mid-session token refresh works. Locked by new tests: sessionful request without bearer → 401; rotated bearer reaches the Zendesk call (asserted via MSW).
2. **Request bodies are capped at 4 MB** → `413` (was: unbounded buffering before `JSON.parse`, read before any auth check on the existing-session path).
3. **Idle sessions are evicted after 30 minutes** (sweep every 60 s, `unref`'d). The SDK only fires `onclose` on an explicit DELETE, so clients that vanished leaked a `McpServer` + bearer per session forever. Timeout is injectable for tests.
4. **Malformed JSON now returns `400` + JSON-RPC `-32700` Parse Error** (was: escaped to the outer catch → `500` / `-32603`).
5. **`--cors-origin` / `CORS_ORIGIN` values are normalized to their URL origin** in `loadConfig` — `https://app.example.com/` (trailing slash, natural when copy-pasting) previously passed validation but could never match the browser's `Origin` header.

## Cleanup

6. Single strict `parsePort` helper shared by `--port`, `PORT`, `--callback-port` and `ZENDESK_OAUTH_CALLBACK_PORT` (the callback ports previously used bare `Number()`).
7. The `PUBLIC_URL` warning goes through the structured logger (`public_url_unset`) instead of raw `console.error`.
8. One `sendJsonRpcError` helper instead of three hand-built JSON-RPC error envelopes.
9. Dropped the `isOriginAllowed` wrapper (tests now assert on `resolveAllowedOrigin` directly); sessions close in parallel on shutdown.

## Verification

- `pnpm typecheck` / `pnpm check` clean
- `pnpm test`: 338 tests pass (was 326; +12 new/updated)
- `pnpm test:coverage`: 96.28 / 82.38 / 99.09 / 97.03 (gate 94/77/98/95)
- `pnpm test:smoke`: both `stdio_transport_ready` and `http_transport_ready` markers observed
- README HTTP section documents the new operational behavior (per-request auth, 4 MB cap, 30-min idle eviction)

Note: the test "routes a follow-up request to its existing session" previously locked the *absence* of auth on follow-ups; it was updated deliberately as part of fix 1, with a new companion test locking the 401.

https://claude.ai/code/session_01CZ61R9DAyjxijJWLgLTvxw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ61R9DAyjxijJWLgLTvxw)_