### PR TITLE
fix: send content_tag wrapper when creating Guide content tags

### DIFF
--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -651,14 +651,16 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       handler: async (params) => {
         const { name } = params as { name: string };
         const token = await getToken();
-        const { record } = await zendeskPost<{ record: ZendeskContentTag }>(
+        const { content_tag } = await zendeskPost<{ content_tag: ZendeskContentTag }>(
           subdomain,
           token,
           '/guide/content_tags',
-          { record: { name } },
+          { content_tag: { name } },
         );
         return {
-          content: [{ type: 'text', text: `Content tag created.\n\n${formatContentTag(record)}` }],
+          content: [
+            { type: 'text', text: `Content tag created.\n\n${formatContentTag(content_tag)}` },
+          ],
         };
       },
     },

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -362,7 +362,17 @@ export const handlers = [
   http.get(`${BASE}/guide/content_tags`, () =>
     HttpResponse.json({ records: [MOCK_CONTENT_TAG], count: 1 }),
   ),
-  http.post(`${BASE}/guide/content_tags`, () => HttpResponse.json({ record: MOCK_CONTENT_TAG })),
+  http.post(`${BASE}/guide/content_tags`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    const tag = body['content_tag'] as Record<string, unknown> | undefined;
+    if (!tag?.['name']) {
+      return HttpResponse.json(
+        { errors: [{ title: 'Value `undefined` for /content_tag', code: 'TypeError' }] },
+        { status: 400 },
+      );
+    }
+    return HttpResponse.json({ content_tag: { ...MOCK_CONTENT_TAG, name: tag['name'] } });
+  }),
 
   // Help Center - User Segments
   http.get(`${HC_BASE}/user_segments`, () =>

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -270,7 +270,7 @@ describe('help center tools', () => {
       const tool = findTool('create_content_tag');
       const result = await tool.handler({ name: 'accessibility' });
       expect(result.content[0]?.text).toContain('Content tag created');
-      expect(result.content[0]?.text).toContain('scanner');
+      expect(result.content[0]?.text).toContain('accessibility');
     });
   });
 


### PR DESCRIPTION
## Summary

`create_content_tag` (help_center) failed **systematically** with a Zendesk `400 Bad Request`. The handler wrapped the request body under `record` instead of `content_tag` — the key the Zendesk Guide *Create Content Tag* endpoint expects — so Zendesk saw `/content_tag` as `undefined` and rejected every call. The response was also destructured from the wrong `record` key.

Fixes #79.

## Changes

- **`src/tools/help-center.ts`** — `create_content_tag` now wraps the request body in `content_tag` and reads the created tag back from the `content_tag` response envelope (was `record` on both sides). The `list_content_tags` endpoint correctly uses `records` and is untouched.
- **`tests/msw-handlers.ts`** — hardened the `POST /guide/content_tags` mock (following the existing `POST /tickets` pattern) to assert the incoming `content_tag` wrapper and return the same 400 the real API does otherwise, while mirroring the real response envelope. This closes the TDD gap that let the wrong wrapper slip through.
- **`tests/unit/tools/help-center.test.ts`** — the `create_content_tag` test now asserts the returned tag reflects the input name, validating the full round-trip.

## Verification

- `pnpm test` — 340 passing. The hardened mock now fails the test if the handler reverts to `record`.
- `pnpm check` — clean.

No tool-surface change (name, count, namespace unchanged) → no README/count updates needed.

https://claude.ai/code/session_01N2YmVcRopu7EvUm5dckAwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2YmVcRopu7EvUm5dckAwJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the request and response mapping for content tag creation to align with Zendesk API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->