### PR TITLE
chore: disable Claude co-author attribution in commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## What

Add an `attribution` setting to `.claude/settings.json` with empty `commit` and `pr` strings.

## Why

This disables the `Co-Authored-By: Claude` trailer in commit messages and the "Generated with Claude Code" line in PR bodies, by default, for all Claude Code sessions on this repository (including web sessions).

The previous `includeCoAuthoredBy` boolean is deprecated; `attribution` is the current supported replacement.

## Notes

Existing hooks in the settings file are left unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F93Ee8eVbFFdoeThSYTJqm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->