### PR TITLE
fix(tools): enrich descriptions and parameters of low-scoring tools

### DIFF
--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -169,11 +169,26 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       namespace: 'help_center',
       readOnly: true,
       title: 'List Help Center Categories',
-      description: 'List all Help Center categories. Optionally filter by locale.',
+      description:
+        'List all Help Center categories. Categories are the top level of the Guide hierarchy (category → section → article); each entry includes its id, name and locale. Results are cursor-paginated. Pair a returned category id with list_sections to drill down, then list_articles to reach articles. Pass a locale to read category names in that translation.',
       inputSchema: z.object({
-        locale: z.string().optional(),
-        page_size: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
-        cursor: z.string().optional(),
+        locale: z
+          .string()
+          .optional()
+          .describe(
+            'Locale for category names (e.g., "en-us", "fr"). Defaults to the Help Center default locale.',
+          ),
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Categories per page (1-100, default 100).'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response; omit for the first page.'),
       }),
       annotations: {
         readOnlyHint: true,
@@ -214,12 +229,33 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       namespace: 'help_center',
       readOnly: true,
       title: 'List Help Center Sections',
-      description: 'List sections, optionally filtered by category ID and locale.',
+      description:
+        "List Help Center sections. Sections are the middle level of the Guide hierarchy (category → section → article) and group related articles; each entry includes its id, name, category_id and locale. Results are cursor-paginated. Pass category_id to list only one category's sections (ids come from list_categories), then use a section id with list_articles. Pass a locale to read section names in that translation.",
       inputSchema: z.object({
-        category_id: z.number().int().optional(),
-        locale: z.string().optional(),
-        page_size: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
-        cursor: z.string().optional(),
+        category_id: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            'Restrict to sections of this category (id from list_categories). Omit to list every section.',
+          ),
+        locale: z
+          .string()
+          .optional()
+          .describe(
+            'Locale for section names (e.g., "en-us", "fr"). Defaults to the Help Center default locale.',
+          ),
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Sections per page (1-100, default 100).'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response; omit for the first page.'),
       }),
       annotations: {
         readOnlyHint: true,
@@ -381,13 +417,19 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       namespace: 'help_center',
       readOnly: false,
       title: 'Create Article Translation',
-      description: 'Create a translation for an existing article in a specific locale.',
+      description:
+        'Create a translation for an existing article in a specific locale. The article must already exist (create it with create_article); this adds a new localized version and returns the created translation (locale, title, draft state). The target locale must not already have a translation — use update_article_translation to modify an existing one, and list_article_translations to see which locales exist. Provide the full HTML body.',
       inputSchema: z.object({
-        article_id: z.number().int(),
+        article_id: z.number().int().describe('ID of the existing article to translate.'),
         locale: z.string().describe('Target locale (e.g., "fr", "de")'),
-        title: z.string().min(1),
+        title: z.string().min(1).describe('Translated article title.'),
         body: z.string().min(1).describe('Translated body (HTML)'),
-        draft: z.boolean().default(false),
+        draft: z
+          .boolean()
+          .default(false)
+          .describe(
+            'Create the translation as a draft (not visible to end users). Defaults to false (published).',
+          ),
       }),
       annotations: {
         readOnlyHint: false,
@@ -638,9 +680,13 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       namespace: 'help_center',
       readOnly: false,
       title: 'Create Content Tag',
-      description: 'Create a new content tag for Guide articles.',
+      description:
+        'Create a new content tag for Guide articles. Content tags are end-user visible labels that help readers discover related articles; this returns the created tag with its id. Check list_content_tags first to avoid duplicates, then attach the new id via the content_tag_ids parameter of create_article or update_article. For internal search-ranking labels that are not shown to end users, use article labels (list_labels) instead.',
       inputSchema: z.object({
-        name: z.string().min(1).describe('Content tag name'),
+        name: z
+          .string()
+          .min(1)
+          .describe('Content tag name as shown to end users (e.g., "billing", "getting-started").'),
       }),
       annotations: {
         readOnlyHint: false,
@@ -722,9 +768,13 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       namespace: 'help_center',
       readOnly: true,
       title: 'List Article Attachments',
-      description: 'List all attachments for an article.',
+      description:
+        'List all attachments for an article. Returns attachment metadata only (id, file name, content type, size, URL), not the file bytes; both inline and block attachments are included. This is for Help Center articles — for attachments on support tickets use get_ticket_attachments instead. Upload new files with create_article_attachment.',
       inputSchema: z.object({
-        article_id: z.number().int().describe('Article ID'),
+        article_id: z
+          .number()
+          .int()
+          .describe('ID of the Help Center article whose attachments to list.'),
       }),
       annotations: {
         readOnlyHint: true,

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -282,16 +282,31 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Create Zendesk Ticket',
       description:
-        'Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags.',
+        'Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags. The description becomes the first public comment of the ticket, and the new ticket id is returned. After creation, use update_ticket to change status or assignee, add_public_comment or add_private_note to reply, and manage_tags to adjust tags. Look up valid assignee_id / group_id and custom field ids via search_users or your Zendesk admin settings.',
       inputSchema: z.object({
         subject: z.string().min(1).describe('Ticket subject'),
         description: z.string().min(1).describe('Ticket description'),
-        priority: z.enum(['urgent', 'high', 'normal', 'low']).optional(),
-        type: z.enum(['problem', 'incident', 'question', 'task']).optional(),
-        assignee_id: z.number().int().optional(),
-        group_id: z.number().int().optional(),
-        tags: z.array(z.string()).optional(),
-        custom_fields: z.array(z.object({ id: z.number().int(), value: z.unknown() })).optional(),
+        priority: z
+          .enum(['urgent', 'high', 'normal', 'low'])
+          .optional()
+          .describe('Ticket priority. One of urgent, high, normal, low.'),
+        type: z
+          .enum(['problem', 'incident', 'question', 'task'])
+          .optional()
+          .describe('Ticket type. One of problem, incident, question, task.'),
+        assignee_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('User id of the agent to assign the ticket to.'),
+        group_id: z.number().int().optional().describe('Id of the group to assign the ticket to.'),
+        tags: z.array(z.string()).optional().describe('Tags to set on the ticket.'),
+        custom_fields: z
+          .array(z.object({ id: z.number().int(), value: z.unknown() }))
+          .optional()
+          .describe(
+            'Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings).',
+          ),
       }),
       annotations: {
         readOnlyHint: false,
@@ -323,17 +338,40 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Update Zendesk Ticket',
       description:
-        'Update an existing ticket (status, priority, type, assignee, group, subject, tags, custom fields).',
+        'Update an existing ticket (status, priority, type, assignee, group, subject, tags, custom fields). Only the fields you pass are changed, and the updated ticket is returned. Setting tags here replaces the whole tag set — use manage_tags to add or remove individual tags without overwriting the rest. This tool does not post replies: use add_public_comment or add_private_note for that. Find the ticket id via search_tickets or list_tickets.',
       inputSchema: z.object({
         ticket_id: z.number().int().describe('Ticket ID'),
-        status: z.enum(['new', 'open', 'pending', 'hold', 'solved', 'closed']).optional(),
-        priority: z.enum(['urgent', 'high', 'normal', 'low']).optional(),
-        type: z.enum(['problem', 'incident', 'question', 'task']).optional(),
-        assignee_id: z.number().int().optional(),
-        group_id: z.number().int().optional(),
-        subject: z.string().optional(),
-        tags: z.array(z.string()).optional(),
-        custom_fields: z.array(z.object({ id: z.number().int(), value: z.unknown() })).optional(),
+        status: z
+          .enum(['new', 'open', 'pending', 'hold', 'solved', 'closed'])
+          .optional()
+          .describe('New ticket status. One of new, open, pending, hold, solved, closed.'),
+        priority: z
+          .enum(['urgent', 'high', 'normal', 'low'])
+          .optional()
+          .describe('Ticket priority. One of urgent, high, normal, low.'),
+        type: z
+          .enum(['problem', 'incident', 'question', 'task'])
+          .optional()
+          .describe('Ticket type. One of problem, incident, question, task.'),
+        assignee_id: z
+          .number()
+          .int()
+          .optional()
+          .describe('User id of the agent to assign the ticket to.'),
+        group_id: z.number().int().optional().describe('Id of the group to assign the ticket to.'),
+        subject: z.string().optional().describe('New ticket subject line.'),
+        tags: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Replaces the full tag set on the ticket. Use manage_tags for incremental add/remove.',
+          ),
+        custom_fields: z
+          .array(z.object({ id: z.number().int(), value: z.unknown() }))
+          .optional()
+          .describe(
+            'Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings).',
+          ),
       }),
       annotations: {
         readOnlyHint: false,

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -142,10 +142,20 @@ export const createUserTools = (ctx: ToolContext): ToolDefinition[] => {
       namespace: 'users',
       readOnly: true,
       title: 'List Zendesk Organizations',
-      description: 'List all organizations with pagination.',
+      description:
+        'List all organizations with pagination. Returns the name and id of each organization plus basic fields; results are cursor-paginated. Use get_organization with an id for full details (tags, domains, notes), or search for query-based lookups by name. Organizations group end users and can be referenced when creating or filtering tickets.',
       inputSchema: z.object({
-        page_size: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
-        cursor: z.string().optional(),
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Organizations per page (1-100, default 100).'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response; omit for the first page.'),
       }),
       annotations: {
         readOnlyHint: true,


### PR DESCRIPTION
## Summary

Glama grades each tool on 6 axes (Behavior, Conciseness, Completeness, Parameters, Purpose, Usage Guidelines); the overall letter is the average, and **A starts around 3.5/5**. Eight tools sat at **B or C** because their descriptions were terse and several parameters had no description. This PR enriches those 8 tools — and only those — so no A-rated tool regresses.

| Tool | Grade before | Weak axes |
|------|-----------|--------------|
| `list_categories` | C 2.7 | Behavior, Completeness, Parameters, Usage |
| `create_article_translation` | C 2.9 | Behavior, Completeness, Parameters, Usage |
| `list_organizations` | C 2.9 | Completeness, **Parameters 1/5**, Usage |
| `create_content_tag` | B 3.1 | Behavior, Usage |
| `list_sections` | B 3.1 | Parameters, Usage |
| `update_ticket` | B 3.1 | Completeness, Usage |
| `create_ticket` | B 3.2 | Behavior, Completeness, Usage |
| `list_article_attachments` | B 3.2 | Behavior, Usage |

For each tool: added behavior/return notes, pagination & locale defaults, cross-references to sibling tools (Usage Guidelines), and a `.describe()` on every parameter that was missing one. The **first sentence** of each description is preserved verbatim, so the proxy summaries in `namespace` / `single` modes (`summarizeDescription`, which truncates to the first sentence) are unchanged — verified.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally (340/340)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings (no findings)
- [x] Documentation is updated where needed (README tool-table rows still match each tool's first sentence; no rows needed changes)
- [x] If this PR adds an MCP tool: it is documented in `README.md` (N/A — no tool added or removed; counts unchanged)

## Notes for the reviewer (human or AI)
- No validation logic, enum options, or handler signatures changed — descriptions and `.describe()` metadata only.
- Proxy first-sentence truncation was verified for all 8 tools (no enriched text leaks into proxy summaries).
- Scope is deliberately limited to the B/C tools to avoid perturbing tools already rated A (some sit just above the 3.5 threshold).

https://claude.ai/code/session_01HQVY3rbT8niCwxWS4rZ9yb