### PR TITLE
chore: fix language hook false positives on typographic chars

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '[.tool_input.title, .tool_input.body] | map(select(type==\"string\")) | join(\" \")' | grep -qiE '\\b(avec|sans|donc|nous|vous|votre|notre|cette|dans|leur|une|aux|qui|que|mais|ses|alors|ainsi|aussi|chez|vers|selon|comme|cela)\\b|[éèêàâçùûüôîïœ]' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"GitHub content appears to be in French. Project rule (CLAUDE.md): all GitHub PRs, comments and reviews must be in English. Rewrite the text in English and retry.\"}}' || true"
+            "command": "jq -r '[.tool_input.title, .tool_input.body] | map(select(type==\"string\")) | join(\" \")' | grep -qiP '(*UTF)(*UCP)\\b(avec|sans|donc|nous|vous|votre|notre|cette|dans|leur|une|aux|qui|que|mais|ses|alors|ainsi|aussi|chez|vers|selon|comme|cela)\\b|[\\x{e9}\\x{e8}\\x{ea}\\x{e0}\\x{e2}\\x{e7}\\x{f9}\\x{fb}\\x{fc}\\x{f4}\\x{ee}\\x{ef}\\x{eb}\\x{0153}]' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"GitHub content appears to be in French. Project rule (CLAUDE.md): all GitHub PRs, comments and reviews must be in English. Rewrite the text in English and retry.\"}}' || true"
           }
         ]
       }


### PR DESCRIPTION
## What

The `PreToolUse` GitHub language guard in `.claude/settings.json` (which blocks non-English content on PRs, issues and comments) was rejecting legitimate **English** text that contained ordinary typographic punctuation.

## Why

The accent branch of the guard used a byte-class regex under GNU `grep -E`:

```
grep -qiE '...|[accented-letters]'
```

With an unset / `C` locale, `grep` matches a multibyte character class **byte by byte**. Several common punctuation marks share a UTF-8 byte with one of the accented letters, so they falsely matched:

- en dash `U+2013` (`E2 80 93`) shares byte `0x93` with the oe-ligature (`C5 93`)
- multiplication sign `U+00D7` (`C3 97`) shares lead byte `0xC3` with the e-acute / a-grave family

So English content like a `1`-to-`3` range written with an en dash, or `value x effort` written with a multiplication sign, tripped the check and was blocked.

## Fix

Switch the accent branch to `grep -P` with `(*UTF)(*UCP)` and explicit codepoint escapes (`\x{e9}`, ...), so the class matches whole characters rather than stray bytes. This is locale-independent.

Verified locally (unset locale):

| Input | Before | After |
|---|---|---|
| English with en dash / multiplication sign / ellipsis / emojis | blocked (false positive) | allowed |
| Genuine French sentence (function words present) | blocked | blocked |
| French text with accented letters only | blocked | blocked |

The French function-word list is unchanged.

https://claude.ai/code/session_01Fmxxf7RYcHLZoWsrvQ3bkh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fmxxf7RYcHLZoWsrvQ3bkh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection accuracy for French-language content processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->