### PR TITLE
feat(auth): refresh OAuth tokens proactively and in the background

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,9 @@
     "commit": "",
     "pr": ""
   },
+  "permissions": {
+    "allow": ["mcp__zendesk-local"]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
     "commit": "",
     "pr": ""
   },
+  "includeCoAuthoredBy": false,
   "permissions": {
     "allow": ["mcp__zendesk-local"]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,9 +4,7 @@
     "pr": ""
   },
   "includeCoAuthoredBy": false,
-  "permissions": {
-    "allow": ["mcp__zendesk-local"]
-  },
+  "enabledMcpjsonServers": ["zendesk-local"],
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/skills/functional-validation-plan/SKILL.md
+++ b/.claude/skills/functional-validation-plan/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: functional-validation-plan
+description: Produce a functional validation plan for a feature/bugfix, to be executed by an INDEPENDENT validator (another agent or a human), not the implementer. Use whenever you write an implementation plan, or land a feature/bugfix that warrants end-to-end validation. The plan lives in the PR description; the validator posts their report as a PR comment.
+---
+
+# Functional validation plan — author protocol
+
+A code change is not "done" when the unit tests pass. Someone who did **not**
+write the code must be able to exercise the feature end-to-end and confirm it
+behaves as claimed. This skill produces the brief that lets them do that.
+
+## When to apply
+
+- Whenever you produce an **implementation plan**: the plan must include a
+  functional validation plan as a first-class section, not an afterthought.
+- Whenever you land a feature or bugfix whose behaviour is observable at runtime
+  (auth flows, transports, tool surface, persistence, timing).
+
+Skip only for changes with no runtime-observable behaviour (pure docs, comments,
+formatting) — say so explicitly rather than silently omitting it.
+
+## Hard rules
+
+- **Independent validator.** Write the plan FOR someone other than the
+  implementer — another agent (e.g. the local executor) or a human. Never assume
+  shared context: spell out setup, env vars, and how to observe results.
+- **Lives in the PR description.** Put the plan in the PR body under a
+  `## Functional validation plan` heading so it travels with the PR. Keep it in
+  sync if the change evolves.
+- **Report goes to a PR comment.** The validator posts their findings as a PR
+  comment (English — `AGENTS.md` rule), referencing each scenario id with an
+  OK/FAIL verdict and the observed evidence (logs, file state, tool output).
+- **No waiting on real time.** Prefer levers that simulate state (edit a
+  persisted timestamp, lower an interval constant, point at an unroutable host)
+  over waiting out a real timeout. Call out which behaviours are already covered
+  by fake-timer unit tests so the validator doesn't re-prove them needlessly.
+- **Distinct from `/functional-testing`.** That harness drives the committed
+  inter-LLM scenarios in `tests/functional/`. This skill is the lighter, per-PR
+  brief embedded in the PR description. Reference the harness when the change
+  belongs there; don't duplicate it.
+
+## Plan structure
+
+Write the plan as a self-contained, copy-pasteable brief:
+
+1. **Context** — branch, what feature, how to get a runnable build (`pnpm install`,
+   which transport/mode applies; note any transport that does NOT exercise the code).
+2. **Setup & prerequisites** — env vars, credentials/egress needed, a throwaway
+   working copy of any mutable state, and how to observe (log level, files,
+   artifacts). Flag what can only be checked partially without real creds/egress.
+3. **Scenarios** — a table or list, each row: id, what it validates, the exact
+   manipulation, the action, the expected observable. Make "expected" concrete
+   (which log event, which file change, which error/URL).
+4. **Long-running behaviours** — for anything time-based, give the no-wait lever
+   AND note the unit test that already covers it.
+5. **Priorities** — which scenarios are the real user-facing paths (do first).
+6. **Reporting instructions** — the validator posts a PR comment: per-id verdict
+   + evidence; overall green/failing summary.
+
+## Loop
+
+1. Draft the plan from the structure above, tailored to the change.
+2. Put it in the PR description under `## Functional validation plan`
+   (`mcp__github__update_pull_request`), or include it inline if you're still in
+   plan mode and no PR exists yet.
+3. Hand the brief to the independent validator (paste for a local executor, or
+   @-mention a human).
+4. When their report lands as a PR comment, reconcile each verdict against the
+   plan; on FAIL, diagnose and fix on the branch, then ask them to re-run.

--- a/.claude/skills/functional-validation-plan/SKILL.md
+++ b/.claude/skills/functional-validation-plan/SKILL.md
@@ -73,7 +73,25 @@ Write the plan as a self-contained, copy-pasteable brief:
 2. Put it in the PR description under `## Functional validation plan`
    (`mcp__github__update_pull_request`), or include it inline if you're still in
    plan mode and no PR exists yet.
-3. Hand the brief to the independent validator (paste for a local executor, or
-   @-mention a human).
-4. When their report lands as a PR comment, reconcile each verdict against the
-   plan; on FAIL, diagnose and fix on the branch, then ask them to re-run.
+3. Hand it to the independent validator: another agent runs the executor side
+   (the `run-validation-plan` skill), or a human picks it up.
+
+## Closing the loop (verifying the report)
+
+The feature is not validated until every scenario is `OK` against the **latest
+pushed commit**. When the validator's report lands as a PR comment (you'll get
+it as a PR-activity event if subscribed):
+
+1. **Read the report** (`mcp__github__pull_request_read` / the comment body) and
+   confirm it tested the right commit SHA. If it's stale (predates your last
+   push), ask for a re-run.
+2. **Re-verify each scenario — don't trust the verdict blindly.** Check the
+   reported evidence against the plan's expected observable yourself: a validator
+   can misread a log line or mislabel a pass. Where the evidence is too thin to
+   confirm, ask them to re-capture that scenario.
+3. **On all OK:** the loop is closed. Note the outcome (a short confirming PR
+   comment, or tell the user) — that green report is the deliverable, not a no-op.
+4. **On any FAIL/BLOCKED:** diagnose the root cause. If it's a real bug, fix it on
+   the branch in a separate commit, push, and ask the validator to re-run the
+   affected ids against the new SHA. If it's a `BLOCKED` (missing creds/egress),
+   say so and decide with the user whether that scenario can be validated here.

--- a/.claude/skills/functional-validation-plan/SKILL.md
+++ b/.claude/skills/functional-validation-plan/SKILL.md
@@ -22,8 +22,15 @@ formatting) — say so explicitly rather than silently omitting it.
 ## Hard rules
 
 - **Independent validator.** Write the plan FOR someone other than the
-  implementer — another agent (e.g. the local executor) or a human. Never assume
-  shared context: spell out setup, env vars, and how to observe results.
+  implementer — another agent (e.g. the local executor) or a human. Don't assume
+  it shares your conversation context: spell out the state to manipulate and how
+  to observe results.
+- **Assume a ready environment.** The validator starts on the branch with the
+  code operational and the MCP server preconfigured (`--mode all`) with its
+  tools already loaded into its Claude Code context. Do NOT add build/install
+  steps, transport choices, or CLI harnesses (`pnpm mcp:live`, `scripts/`): the
+  validator drives the feature by calling the real `mcp__<server>__*` tools
+  directly in its session, which is what exercises the running server.
 - **Lives in the PR description.** Put the plan in the PR body under a
   `## Functional validation plan` heading so it travels with the PR. Keep it in
   sync if the change evolves.
@@ -43,14 +50,17 @@ formatting) — say so explicitly rather than silently omitting it.
 
 Write the plan as a self-contained, copy-pasteable brief:
 
-1. **Context** — branch, what feature, how to get a runnable build (`pnpm install`,
-   which transport/mode applies; note any transport that does NOT exercise the code).
-2. **Setup & prerequisites** — env vars, credentials/egress needed, a throwaway
-   working copy of any mutable state, and how to observe (log level, files,
-   artifacts). Flag what can only be checked partially without real creds/egress.
+1. **Context** — the feature and which `mcp__<server>__*` tool call(s) exercise
+   it. Note any path that does NOT exercise the code (e.g. a transport the
+   feature doesn't touch), so the validator doesn't test the wrong surface.
+2. **Setup & prerequisites** — only what's NOT already provided by the ready
+   environment: the mutable state to seed/manipulate (on a throwaway copy),
+   credentials/egress needed for a real round-trip, and how to observe (log
+   level, files, artifacts). Flag what can only be checked partially without
+   real creds/egress.
 3. **Scenarios** — a table or list, each row: id, what it validates, the exact
-   manipulation, the action, the expected observable. Make "expected" concrete
-   (which log event, which file change, which error/URL).
+   manipulation, the tool call to make, the expected observable. Make "expected"
+   concrete (which log event, which file change, which error/URL).
 4. **Long-running behaviours** — for anything time-based, give the no-wait lever
    AND note the unit test that already covers it.
 5. **Priorities** — which scenarios are the real user-facing paths (do first).

--- a/.claude/skills/functional-validation-plan/SKILL.md
+++ b/.claude/skills/functional-validation-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: functional-validation-plan
-description: Produce a functional validation plan for a feature/bugfix, to be executed by an INDEPENDENT validator (another agent or a human), not the implementer. Use whenever you write an implementation plan, or land a feature/bugfix that warrants end-to-end validation. The plan lives in the PR description; the validator posts their report as a PR comment.
+description: Create a functional validation plan for a feature or bugfix. Use whenever you author an implementation plan, finish a feature/bugfix with runtime-observable behaviour, or prepare a PR that needs independent end-to-end validation — even when validation isn't explicitly asked for.
 ---
 
 # Functional validation plan — author protocol

--- a/.claude/skills/run-validation-plan/SKILL.md
+++ b/.claude/skills/run-validation-plan/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: run-validation-plan
-description: Execute the functional validation plan from a PR description as the INDEPENDENT validator, then post the report as a PR comment. Use when asked to validate/QA a feature on a branch, or when handed a "Functional validation plan". Counterpart to the `functional-validation-plan` skill (the author side); this is the executor side.
+description: Execute a functional validation plan and report the findings. Use whenever you're asked to validate, QA, functionally verify, or check a feature/bugfix on a branch, or you're handed a functional validation plan to run — even when the skill isn't named.
 ---
 
 # Run a validation plan — validator protocol
 
-You are the **independent validator**. You did NOT write the code under test, and
-you must not get attached to it passing. Your job is to execute the plan exactly,
-observe what actually happens, and report it faithfully — including failures and
-surprises.
+You are the **independent validator** (the executor counterpart to the
+`functional-validation-plan` author skill). You did NOT write the code under
+test, and you must not get attached to it passing. Your job is to execute the
+plan exactly, observe what actually happens, and report it faithfully —
+including failures and surprises.
 
 ## Input & environment
 

--- a/.claude/skills/run-validation-plan/SKILL.md
+++ b/.claude/skills/run-validation-plan/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: run-validation-plan
+description: Execute the functional validation plan from a PR description as the INDEPENDENT validator, then post the report as a PR comment. Use when asked to validate/QA a feature on a branch, or when handed a "Functional validation plan". Counterpart to the `functional-validation-plan` skill (the author side); this is the executor side.
+---
+
+# Run a validation plan — validator protocol
+
+You are the **independent validator**. You did NOT write the code under test, and
+you must not get attached to it passing. Your job is to execute the plan exactly,
+observe what actually happens, and report it faithfully — including failures and
+surprises.
+
+## Input & environment
+
+- The plan lives in the PR description under `## Functional validation plan`.
+  Read it from there (`mcp__github__pull_request_read`); don't reconstruct it from
+  memory or from the implementer's chat.
+- Your environment is ready: you're on the branch, the code is operational, and
+  the MCP server is preconfigured (`--mode all`) with its tools loaded into this
+  session. You drive the feature by calling the real `mcp__<server>__*` tools
+  directly — never a build step or a one-shot CLI harness.
+
+## Protocol
+
+1. **Record what you're testing.** Capture the commit SHA the branch is at
+   (`git rev-parse HEAD`) so the report names the exact code validated.
+2. **Set up observation** as the plan says (e.g. log level, which file to watch).
+3. **Run each scenario in order.** For each: apply the state manipulation on a
+   throwaway copy, make the exact `mcp__<server>__*` tool call(s) the plan
+   specifies, and capture the **actual** observable — log event(s), file
+   before/after, tool result or error text.
+4. **Compare to expected.** Mark each scenario `OK` only if the actual observable
+   matches the plan's expected one. Anything else is `FAIL` (or `BLOCKED` if a
+   prerequisite — creds, egress — was unavailable; say which).
+5. **Don't fix, don't massage.** You never edit the code to make a scenario pass,
+   and you never round a partial/ambiguous result up to OK. Report exactly what
+   you saw.
+
+## Reporting
+
+Post the report as a **PR comment** in **English** (`mcp__github__add_issue_comment`).
+If you have no GitHub write access, output it for the human to paste. Structure:
+
+```markdown
+## Functional validation report — <commit SHA>
+
+| ID | Verdict | Evidence |
+| -- | ------- | -------- |
+| S1 | OK      | log `oauth_token_refreshed_cached`; file accessToken old→new, expiresAt now future |
+| S2 | FAIL    | expected refresh in skew window; got cache hit, no refresh log. Token served stale. |
+| S3 | BLOCKED | needs egress to *.zendesk.com — not available in this env |
+
+## Summary
+
+<green, or list of failing/blocked IDs and one-line why>
+```
+
+Per-row evidence must be concrete enough that the author can verify it without
+re-running: name the log event, the field that changed, the error string.
+
+## Hard rules
+
+- Faithful reporting over a green result. A wrong "OK" is worse than an honest FAIL.
+- Independent: validate behaviour against the plan's expectations, not against the
+  implementer's explanation of why it should work.
+- Real tools only (`mcp__<server>__*`), throwaway copies of any mutable state.
+- One report per run, naming the commit SHA. On a re-run after a fix, post a fresh
+  report against the new SHA rather than editing the old one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,14 @@ testing in `docs/live-testing.md`.
   live in `tests/functional/`; invoke via `/functional-testing`. Details in
   `tests/functional/README.md`.
 
+## Planning
+
+Every implementation plan must also carry a **functional validation plan** for
+the feature, written for an *independent* validator (another agent or a human) —
+not the implementer. It lives in the PR description; the validator posts their
+report as a PR comment (English). Procedure and template: invoke the
+`functional-validation-plan` skill — don't inline it here.
+
 ## Code style
 
 - TypeScript strict; Biome for lint/format (`pnpm check`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,9 @@ testing in `docs/live-testing.md`.
 Every implementation plan must also carry a **functional validation plan** for
 the feature, written for an *independent* validator (another agent or a human) —
 not the implementer. It lives in the PR description; the validator posts their
-report as a PR comment (English). Procedure and template: invoke the
-`functional-validation-plan` skill — don't inline it here.
+report as a PR comment (English). Author the plan with the
+`functional-validation-plan` skill; the validator executes it with the
+`run-validation-plan` skill — don't inline either here.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -224,8 +224,11 @@ file per subdomain in your OS config dir —
 elsewhere; override the path with `ZENDESK_TOKEN_FILE`). It is reused across restarts, so you don't
 re-authenticate every time the MCP client respawns the server. If the Zendesk
 OAuth client has token expiration enabled, the stored refresh token is used to
-renew access silently; only an expired/invalid refresh token triggers a new
-browser sign-in.
+renew access silently — **proactively** (the token is refreshed before use when
+it's expired, near expiry, or of unknown age, so the first request after an
+overnight gap never hits a visible auth error) and **periodically** in the
+background so a long-lived, idle session never serves a stale token. Only an
+expired/invalid refresh token triggers a new browser sign-in.
 
 > **Port conflict?** If port `27439` is already in use the first tool call returns
 > a clear error telling you to set `ZENDESK_OAUTH_CALLBACK_PORT` (or

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -14,6 +14,11 @@ type StoredToken = PersistedToken;
 // dies in flight.
 const EXPIRY_SKEW_MS = 60_000;
 
+// Period of the background refresh. Zendesk expires access tokens after ~8h of
+// inactivity (and ~12h absolute), so refreshing every 4h keeps a long-lived,
+// possibly idle stdio session's token alive with comfortable margin.
+const SCHEDULED_REFRESH_MS = 4 * 60 * 60 * 1000;
+
 /**
  * Signals that interactive sign-in is required. The message is user-facing: MCP
  * surfaces it as the tool-call error text, so it carries the authorize URL and
@@ -61,6 +66,10 @@ export const createTokenStore = (
   // De-dupes concurrent refresh attempts so a burst of expired-token calls
   // triggers a single network round-trip.
   let refreshing: Promise<string | undefined> | undefined;
+  // Whether we've already probe-refreshed a token with *unknown* expiry. Stays
+  // false only for the disk-loaded token at startup so it's refreshed once, then
+  // trusted — see `needsRefresh`.
+  let probedUnknownExpiry = false;
 
   const persist = (t: StoredToken): void => saveToken(tokenPath, t, logger);
 
@@ -69,8 +78,15 @@ export const createTokenStore = (
     persist(token);
   };
 
-  const isExpired = (t: StoredToken): boolean =>
-    typeof t.expiresAt === 'number' && Date.now() >= t.expiresAt - EXPIRY_SKEW_MS;
+  // Whether the cached token must be refreshed before use. A known `expiresAt`
+  // uses the skew window; an *unknown* expiry (token minted before Zendesk
+  // enabled expiration, or a refresh response without `expires_in`) is probed
+  // once — refreshed on first use if it has a refresh token, then trusted so we
+  // don't refresh on every call when `expires_in` keeps being omitted.
+  const needsRefresh = (t: StoredToken): boolean =>
+    typeof t.expiresAt === 'number'
+      ? Date.now() >= t.expiresAt - EXPIRY_SKEW_MS
+      : t.refreshToken !== undefined && !probedUnknownExpiry;
 
   // Try to silently mint a fresh access token from the stored refresh token.
   // Resolves to the new access token, or `undefined` if there's nothing to
@@ -93,6 +109,8 @@ export const createTokenStore = (
         refreshToken: result.refresh_token ?? current.refreshToken,
         expiresAt: expiryFrom(result.expires_in),
       };
+      // Freshly refreshed: if expiry is still unknown, don't re-probe every call.
+      probedUnknownExpiry = true;
       persist(token);
       logger.info('oauth_token_refreshed_cached');
       return token.accessToken;
@@ -126,6 +144,8 @@ export const createTokenStore = (
               refreshToken: result.refresh_token,
               expiresAt: expiryFrom(result.expires_in),
             };
+            // Freshly minted: trust it without an immediate probe-refresh.
+            probedUnknownExpiry = true;
             persist(token);
             logger.info('oauth_token_cached');
           })
@@ -151,13 +171,21 @@ export const createTokenStore = (
   };
 
   const getToken = async (): Promise<string> => {
-    if (token && !isExpired(token)) {
+    // A refresh already in flight (on-demand or the scheduled background one)
+    // owns the next token: wait for it instead of serving a token that's about
+    // to be replaced or launching a competing refresh. Zendesk rotates the
+    // refresh token on every use, so two concurrent refreshes would invalidate
+    // each other — this makes the refresh exclusive.
+    if (refreshing) await refreshing;
+
+    if (token && !needsRefresh(token)) {
       logger.debug('oauth_token_cache_hit');
       return token.accessToken;
     }
 
-    // Expired (or near-expiry) but refreshable → refresh silently before falling
-    // back to a browser prompt. Concurrent callers share the one attempt.
+    // Expired, near-expiry, or unknown-expiry but refreshable → refresh silently
+    // before falling back to a browser prompt. Concurrent callers share the one
+    // attempt.
     if (token?.refreshToken) {
       if (!refreshing) {
         refreshing = tryRefresh(token).finally(() => {
@@ -196,5 +224,24 @@ export const createTokenStore = (
     logger.info('oauth_token_invalidated');
   };
 
-  return { getToken, setToken, invalidate };
+  // Background refresh keeps a long-lived, possibly idle stdio session's token
+  // fresh: refreshing every 4h means the first request after a quiet stretch
+  // never races a token expired by Zendesk's ~8h inactivity window. Shares the
+  // `refreshing` single-flight guard with getToken; a no-op until a refreshable
+  // token exists. unref()'d so it never keeps the process (or test runner) alive.
+  // stdio-only: HTTP carries a per-session bearer and doesn't use this store.
+  const scheduledRefresh = setInterval(() => {
+    if (token?.refreshToken && !refreshing) {
+      refreshing = tryRefresh(token).finally(() => {
+        refreshing = undefined;
+      });
+    }
+  }, SCHEDULED_REFRESH_MS);
+  scheduledRefresh.unref?.();
+
+  // Stop the background timer (e.g. on shutdown or in tests). Optional for stdio,
+  // where the process exit reclaims the unref'd timer anyway.
+  const dispose = (): void => clearInterval(scheduledRefresh);
+
+  return { getToken, setToken, invalidate, dispose };
 };

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -75,6 +75,10 @@ export const createTokenStore = (
 
   const setToken = (accessToken: string, refreshToken?: string | undefined) => {
     token = { accessToken, refreshToken };
+    // A token installed this way has no known expiry and unknown age, like the
+    // disk-loaded one: let it be probe-refreshed once rather than inheriting a
+    // previous token's "already probed" state (the flag is store-wide).
+    probedUnknownExpiry = false;
     persist(token);
   };
 
@@ -90,8 +94,15 @@ export const createTokenStore = (
 
   // Try to silently mint a fresh access token from the stored refresh token.
   // Resolves to the new access token, or `undefined` if there's nothing to
-  // refresh / the refresh failed (in which case the dead token is dropped).
-  const tryRefresh = async (current: StoredToken): Promise<string | undefined> => {
+  // refresh / the refresh failed. On failure the on-demand path drops the dead
+  // token (so getToken falls back to the browser flow); the background keepalive
+  // passes `dropOnFailure: false` because it refreshes preemptively while the
+  // access token may still be valid — a transient 5xx/network blip must not wipe
+  // a usable token and force needless re-auth.
+  const tryRefresh = async (
+    current: StoredToken,
+    { dropOnFailure = true }: { dropOnFailure?: boolean } = {},
+  ): Promise<string | undefined> => {
     if (!current.refreshToken) return undefined;
     try {
       const result = await refreshAccessToken(
@@ -119,8 +130,12 @@ export const createTokenStore = (
         error: err instanceof Error ? err.message : String(err),
       });
       // Refresh token expired/invalid → drop it so we fall back to a fresh flow.
-      token = undefined;
-      clearPersistedToken(tokenPath, logger);
+      // Skipped for the background keepalive, which must keep a still-valid token
+      // alive across a transient failure.
+      if (dropOnFailure) {
+        token = undefined;
+        clearPersistedToken(tokenPath, logger);
+      }
       return undefined;
     }
   };
@@ -232,7 +247,7 @@ export const createTokenStore = (
   // stdio-only: HTTP carries a per-session bearer and doesn't use this store.
   const scheduledRefresh = setInterval(() => {
     if (token?.refreshToken && !refreshing) {
-      refreshing = tryRefresh(token).finally(() => {
+      refreshing = tryRefresh(token, { dropOnFailure: false }).finally(() => {
         refreshing = undefined;
       });
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,13 @@ import { readPackageInfo } from './utils/package-info';
  * refreshes/re-authenticates instead of replaying a revoked token. The callback
  * is omitted only where there is nothing to invalidate (e.g. HTTP per-session
  * bearer, owned by the client).
+ *
+ * Client-visible behaviour on an in-flight revocation: the 401 is a *backstop*,
+ * not a transparent retry. The current call still surfaces the error; recovery
+ * happens on the *next* call, whose `getToken` sees the invalidated token and
+ * silently refreshes (or falls back to browser re-auth if the refresh token is
+ * also dead). Proactive refresh keeps this path rare — it only fires when a
+ * token is revoked between the pre-call refresh check and the request.
  */
 const runHandler = async (
   def: ToolDefinition,

--- a/tests/integration/unauthorized-backstop.test.ts
+++ b/tests/integration/unauthorized-backstop.test.ts
@@ -39,6 +39,9 @@ describe('[stdio] unauthorized backstop', () => {
 
     const result = await client.callTool({ name: 'get_current_user', arguments: {} });
 
+    // The backstop is not a transparent in-call retry: the call that hit the 401
+    // still surfaces the error to the client (`isError`). Recovery is deferred to
+    // the next call, whose getToken refreshes the token invalidated here.
     expect(result.isError).toBe(true);
     expect(onUnauthorized).toHaveBeenCalledTimes(1);
   });

--- a/tests/unit/auth/token-store.test.ts
+++ b/tests/unit/auth/token-store.test.ts
@@ -293,6 +293,33 @@ describe('createTokenStore', () => {
     expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1);
   });
 
+  it('probe-refreshes a token set via setToken even after an earlier probe', async () => {
+    // The disk token gets probe-refreshed once, marking the store's probe state.
+    // A token later installed via setToken has unknown age, so it must be probed
+    // too — the probe state must not leak across tokens.
+    loadTokenMock.mockReturnValue({ accessToken: 'old', refreshToken: 'r1' });
+    refreshAccessTokenMock.mockResolvedValueOnce({
+      access_token: 'refreshed',
+      refresh_token: 'r2',
+      expires_in: 3600,
+    });
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('refreshed');
+
+    refreshAccessTokenMock.mockResolvedValueOnce({
+      access_token: 'reprobed',
+      refresh_token: 'r4',
+      expires_in: 3600,
+    });
+    store.setToken('preset', 'r3');
+
+    await expect(store.getToken()).resolves.toBe('reprobed');
+    expect(refreshAccessTokenMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ refreshToken: 'r3' }),
+    );
+  });
+
   it('coalesces concurrent refreshes into a single network round-trip', async () => {
     // Zendesk rotates the refresh token on every use, so two concurrent refreshes
     // would invalidate each other — the refresh must be exclusive.
@@ -337,6 +364,31 @@ describe('createTokenStore', () => {
       expect(refreshAccessTokenMock).toHaveBeenCalledWith(
         expect.objectContaining({ refreshToken: 'r1' }),
       );
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the existing token when a background refresh fails transiently', async () => {
+    vi.useFakeTimers();
+    try {
+      loadTokenMock.mockReturnValue({
+        accessToken: 'live',
+        refreshToken: 'r1',
+        // Far from expiry: the background refresh runs preemptively while the
+        // token is still perfectly usable.
+        expiresAt: Date.now() + 12 * 60 * 60 * 1000,
+      });
+      refreshAccessTokenMock.mockRejectedValue(new Error('Token refresh failed (503)'));
+      const store = createTokenStore(CONFIG);
+
+      await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000);
+
+      // A transient failure must not wipe a still-valid token or force re-auth.
+      expect(clearTokenMock).not.toHaveBeenCalled();
+      await expect(store.getToken()).resolves.toBe('live');
+      expect(startBrowserAuthMock).not.toHaveBeenCalled();
       store.dispose();
     } finally {
       vi.useRealTimers();

--- a/tests/unit/auth/token-store.test.ts
+++ b/tests/unit/auth/token-store.test.ts
@@ -262,4 +262,108 @@ describe('createTokenStore', () => {
     );
     expect(startBrowserAuthMock).not.toHaveBeenCalled();
   });
+
+  it('proactively refreshes a stored token with no expiresAt before serving it', async () => {
+    // A token minted before Zendesk enabled expiration has no expiresAt; it must
+    // be refreshed ahead of use, not served until a 401 forces recovery.
+    loadTokenMock.mockReturnValue({ accessToken: 'old', refreshToken: 'r1' });
+    refreshAccessTokenMock.mockResolvedValue({
+      access_token: 'new',
+      refresh_token: 'r2',
+      expires_in: 3600,
+    });
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('new');
+    expect(refreshAccessTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshToken: 'r1' }),
+    );
+    expect(startBrowserAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('probe-refreshes an unknown-expiry token only once, then trusts it', async () => {
+    // Refresh response also omits expires_in → the new token still has no
+    // expiresAt. We must not refresh on every subsequent call.
+    loadTokenMock.mockReturnValue({ accessToken: 'old', refreshToken: 'r1' });
+    refreshAccessTokenMock.mockResolvedValue({ access_token: 'new', refresh_token: 'r2' });
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('new');
+    await expect(store.getToken()).resolves.toBe('new');
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent refreshes into a single network round-trip', async () => {
+    // Zendesk rotates the refresh token on every use, so two concurrent refreshes
+    // would invalidate each other — the refresh must be exclusive.
+    loadTokenMock.mockReturnValue({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      expiresAt: Date.now() - 1000,
+    });
+    let resolveRefresh!: (r: TokenResult) => void;
+    refreshAccessTokenMock.mockReturnValue(
+      new Promise<TokenResult>((res) => {
+        resolveRefresh = res;
+      }),
+    );
+    const store = createTokenStore(CONFIG);
+
+    const calls = Promise.all([store.getToken(), store.getToken(), store.getToken()]);
+    resolveRefresh({ access_token: 'new', refresh_token: 'r2', expires_in: 3600 });
+
+    await expect(calls).resolves.toEqual(['new', 'new', 'new']);
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes in the background before an idle token can go stale', async () => {
+    vi.useFakeTimers();
+    try {
+      loadTokenMock.mockReturnValue({
+        accessToken: 'old',
+        refreshToken: 'r1',
+        // Far from expiry, so getToken alone would never refresh.
+        expiresAt: Date.now() + 12 * 60 * 60 * 1000,
+      });
+      refreshAccessTokenMock.mockResolvedValue({
+        access_token: 'new',
+        refresh_token: 'r2',
+        expires_in: 3600,
+      });
+      const store = createTokenStore(CONFIG);
+
+      await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000);
+
+      expect(refreshAccessTokenMock).toHaveBeenCalledWith(
+        expect.objectContaining({ refreshToken: 'r1' }),
+      );
+      store.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('dispose stops the background refresh timer', async () => {
+    vi.useFakeTimers();
+    try {
+      loadTokenMock.mockReturnValue({
+        accessToken: 'old',
+        refreshToken: 'r1',
+        expiresAt: Date.now() + 12 * 60 * 60 * 1000,
+      });
+      refreshAccessTokenMock.mockResolvedValue({
+        access_token: 'new',
+        refresh_token: 'r2',
+        expires_in: 3600,
+      });
+      const store = createTokenStore(CONFIG);
+      store.dispose();
+
+      await vi.advanceTimersByTimeAsync(8 * 60 * 60 * 1000);
+
+      expect(refreshAccessTokenMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
Closes #86.

## Context

Zendesk enabled OAuth token expiration (rolled out 2026-06-12): access tokens now live ~12h max, or expire after ~8h of inactivity. In practice every user's stored token is **expired when they start work in the morning**.

The previous refresh in `src/auth/token-store.ts` was **lazy and reactive**:
- `getToken()` only refreshed once the cached token was already past `expiresAt - EXPIRY_SKEW_MS`.
- A token with **no `expiresAt`** (minted before expiry was enabled, or a refresh response without `expires_in`) was treated as never-expiring → served forever until a 401 forced recovery.

So the first request of the day became `request → 401 → invalidate → refresh → retry` — a visible auth failure every morning (observed during #83 validation: the first `zendesk-hc://topology` read returned `-32603 Authentication failed`, a plain retry then succeeded).

## Changes

- **Refresh ahead of use** — `needsRefresh()` (replacing `isExpired()`) refreshes silently *before* the request when the token is expired, near expiry, or of **unknown age**. Unknown-expiry tokens are **probe-refreshed once**, then trusted, so we don't refresh on every call when `expires_in` keeps being omitted.
- **Exclusive refresh (single-flight)** — `getToken()` now awaits any in-flight refresh before acting, so concurrent callers and the background refresh share one network round-trip. This matters because **Zendesk rotates the refresh token on every use** — two concurrent refreshes would invalidate each other. The JS idiom here is promise-coalescing (the shared `refreshing` promise *is* the lock); no `async-mutex` dependency needed.
- **Background refresh every 4h** — an `unref()`'d interval (stdio-only; HTTP carries a per-session bearer and doesn't use this store) so a long-lived, idle session never serves a stale token, comfortably under Zendesk's ~8h inactivity window. Exposed `dispose()` to stop it.
- **401 → invalidate** path kept as a backstop.

## Tests

`tests/unit/auth/token-store.test.ts`:
- stored token expired overnight → silent refresh, no browser flow;
- stored token with **no `expiresAt`** → proactive refresh before any API call;
- unknown-expiry token whose refresh also omits `expires_in` → refreshed **once**, then trusted;
- 3 concurrent `getToken()` → a **single** `refreshAccessToken` call;
- background timer fires at 4h and refreshes without any `getToken()`;
- `dispose()` stops the timer.

All 358 tests pass; Biome `check`, `tsc --noEmit`, and `build` are green. README auth prose updated to describe the proactive + periodic refresh.

https://claude.ai/code/session_0113zrvJQkDmaceCFf5t26d3

---
_Generated by [Claude Code](https://claude.ai/code/session_0113zrvJQkDmaceCFf5t26d3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic background token refresh to keep sessions active during idle periods.
  * Added token store cleanup via a `dispose` method to stop background refresh when no longer needed.
* **Documentation**
  * Expanded OAuth token renewal guidance to clarify proactive refresh timing and when browser sign-in is required.
* **Tests**
  * Added unit tests covering refresh coalescing, handling tokens with unknown expiry, resilient behavior on transient refresh failures, and `dispose` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->