### PR TITLE
chore: generalize AI assistant wording on OAuth success page

### DIFF
--- a/src/auth/browser-oauth.ts
+++ b/src/auth/browser-oauth.ts
@@ -181,7 +181,7 @@ export const startBrowserAuth = (
         res.end(
           '<html><body>' +
             '<h1>Authentication successful!</h1>' +
-            '<p>You can close this tab and return to Claude Code.</p>' +
+            '<p>You can close this tab and return to your AI assistant.</p>' +
             '<p>This tab will auto-close in <span id="t">10</span>s.</p>' +
             '<script>' +
             'let n=10;' +


### PR DESCRIPTION
## Why

The stdio OAuth PKCE success page (shown in the browser at the end of the auth flow) told the user to *"close this tab and return to **Claude Code**"*. That wording is too specific — this server is built to work with every mainstream MCP client (Claude Desktop, Cursor, VS Code, Zed, Cline…), and the page is **user-facing**, not developer-facing, so it shouldn't lean on a technical term like "MCP client" either.

## What

`src/auth/browser-oauth.ts` — replace the success-page copy with the generic, user-facing term:

> You can close this tab and return to **your AI assistant**.

Single occurrence in `src/`; text stays ASCII-only per the auth-path constraint.

## Tests

- `tests/unit/auth/browser-oauth.test.ts` only asserts `"Authentication successful!"`, so no regression — suite stays green (9/9).
- `pnpm check` (Biome) clean.

https://claude.ai/code/session_01Mxh5czVjg1CsQka6yV2BV3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mxh5czVjg1CsQka6yV2BV3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the message displayed after OAuth authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->