### PR TITLE
feat: surface live SLA state on tickets and add list_sla_policies

### DIFF
--- a/.claude/skills/functional-validation-plan/SKILL.md
+++ b/.claude/skills/functional-validation-plan/SKILL.md
@@ -25,21 +25,31 @@ formatting) — say so explicitly rather than silently omitting it.
   implementer — another agent (e.g. the local executor) or a human. Don't assume
   it shares your conversation context: spell out the state to manipulate and how
   to observe results.
-- **Assume a ready environment.** The validator starts on the branch with the
-  code operational and the MCP server preconfigured (`--mode all`) with its
-  tools already loaded into its Claude Code context. Do NOT add build/install
-  steps, transport choices, or CLI harnesses (`pnpm mcp:live`, `scripts/`): the
-  validator drives the feature by calling the real `mcp__<server>__*` tools
-  directly in its session, which is what exercises the running server.
+- **Assume a fully ready environment — don't make the validator build it.** The
+  validator's session is already **on the PR branch, in a live checkout, with the
+  MCP server running and authenticated** and its tools loaded as `mcp__<server>__*`
+  (`--mode all`). So the plan must NOT ask the validator to:
+  - check out / fetch / clone / pull the branch (it's already on it — at most,
+    capture `git rev-parse HEAD` to name the SHA);
+  - build, install, or start the server (`pnpm …`, transport choices,
+    `pnpm mcp:live`, other `scripts/`);
+  - locate or configure credentials, tokens, or the base URL (a valid token is
+    already wired into the running server and reused by any sanctioned script).
+
+  The validator drives the feature by calling the real `mcp__<server>__*` tools
+  directly — that *is* what exercises the running server. A credential/egress
+  error is a `BLOCKED` finding to report, never a setup task to perform.
   - **Exception — ground-truth capture.** When the change depends on the shape
     of an undocumented external response that the *formatted* tool output cannot
     reveal (e.g. a Zendesk sideload whose exact field names we guessed), the
     MCP tools are insufficient on their own: they show rendered text, never the
     raw upstream JSON. In that case a small **read-only capture probe**
-    (`scripts/probe-*.ts`, reusing the existing auth/client) IS warranted. Make
-    it the first, blocking scenario: the validator runs it and pastes the raw
-    payload into the PR so the implementer can align the types, any correlation
-    key, and the test mocks to reality before the rest of the plan is trusted.
+    (`scripts/probe-*.ts`) IS warranted. It **reuses the already-present auth**
+    (the same `ZENDESK_OAUTH_TOKEN` / cached token file the running server uses) —
+    state the exact command to run, not how to obtain a token. Make it the first,
+    blocking scenario: the validator runs it and pastes the raw payload into the
+    PR so the implementer can align the types, any correlation key, and the test
+    mocks to reality before the rest of the plan is trusted.
 - **Lives in the PR description.** Put the plan in the PR body under a
   `## Functional validation plan` heading so it travels with the PR. Keep it in
   sync if the change evolves.

--- a/.claude/skills/functional-validation-plan/SKILL.md
+++ b/.claude/skills/functional-validation-plan/SKILL.md
@@ -31,6 +31,15 @@ formatting) — say so explicitly rather than silently omitting it.
   steps, transport choices, or CLI harnesses (`pnpm mcp:live`, `scripts/`): the
   validator drives the feature by calling the real `mcp__<server>__*` tools
   directly in its session, which is what exercises the running server.
+  - **Exception — ground-truth capture.** When the change depends on the shape
+    of an undocumented external response that the *formatted* tool output cannot
+    reveal (e.g. a Zendesk sideload whose exact field names we guessed), the
+    MCP tools are insufficient on their own: they show rendered text, never the
+    raw upstream JSON. In that case a small **read-only capture probe**
+    (`scripts/probe-*.ts`, reusing the existing auth/client) IS warranted. Make
+    it the first, blocking scenario: the validator runs it and pastes the raw
+    payload into the PR so the implementer can align the types, any correlation
+    key, and the test mocks to reality before the rest of the plan is trusted.
 - **Lives in the PR description.** Put the plan in the PR body under a
   `## Functional validation plan` heading so it travels with the PR. Keep it in
   sync if the change evolves.
@@ -57,7 +66,8 @@ Write the plan as a self-contained, copy-pasteable brief:
    environment: the mutable state to seed/manipulate (on a throwaway copy),
    credentials/egress needed for a real round-trip, and how to observe (log
    level, files, artifacts). Flag what can only be checked partially without
-   real creds/egress.
+   real creds/egress. If a ground-truth capture probe exists (see the exception
+   above), state how to run it and that its raw output must be reported.
 3. **Scenarios** — a table or list, each row: id, what it validates, the exact
    manipulation, the tool call to make, the expected observable. Make "expected"
    concrete (which log event, which file change, which error/URL).

--- a/.claude/skills/run-validation-plan/SKILL.md
+++ b/.claude/skills/run-validation-plan/SKILL.md
@@ -16,10 +16,32 @@ including failures and surprises.
 - The plan lives in the PR description under `## Functional validation plan`.
   Read it from there (`mcp__github__pull_request_read`); don't reconstruct it from
   memory or from the implementer's chat.
-- Your environment is ready: you're on the branch, the code is operational, and
-  the MCP server is preconfigured (`--mode all`) with its tools loaded into this
-  session. You drive the feature by calling the real `mcp__<server>__*` tools
-  directly — never a build step or a one-shot CLI harness.
+
+### Your environment is already set up — do NOT re-create it
+
+This session was launched **on the PR branch, in a checkout of the code under
+test, with the MCP server already running and authenticated**. Everything you
+need is under your feet. Concretely:
+
+- **You are already on the branch.** The working tree *is* the code to validate.
+  Do **not** `git fetch` / `checkout` / `clone` / `pull` the PR branch, and do not
+  switch branches — you'd only move *away* from what you're meant to test. To name
+  the code you validated, just read the current SHA (`git rev-parse HEAD`); if you
+  want to confirm it's the PR head, compare against the PR — don't fetch to "get"
+  it.
+- **The MCP server is live and authenticated in this session.** Its tools are
+  already loaded as `mcp__<server>__*` (e.g. `mcp__zendesk-local__*`). A valid
+  token is already wired in — the running server uses it, and any helper script
+  reuses the same auth (`ZENDESK_OAUTH_TOKEN`, else the cached token file resolved
+  by the auth layer). **Do not go looking for the token, the auth flow, or the
+  base URL in the source** to "set things up": there is nothing to configure. If a
+  tool returns a 401/credential error, that is a *finding* to report (`BLOCKED`),
+  not a cue to start wiring auth.
+- **You drive the feature by calling the real `mcp__<server>__*` tools directly.**
+  No build, no install, no `pnpm` step, no `mcp:live` / `scripts/` CLI harness to
+  "start" the server — calling the tools *is* exercising the running server. The
+  only sanctioned script is a read-only ground-truth capture probe when the plan
+  explicitly names one (it reuses the same already-present auth — see below).
 
 ## Protocol
 

--- a/.claude/skills/run-validation-plan/SKILL.md
+++ b/.claude/skills/run-validation-plan/SKILL.md
@@ -13,9 +13,22 @@ including failures and surprises.
 
 ## Input & environment
 
-- The plan lives in the PR description under `## Functional validation plan`.
-  Read it from there (`mcp__github__pull_request_read`); don't reconstruct it from
-  memory or from the implementer's chat.
+- **The plan is the verbatim `## Functional validation plan` section of the PR
+  description** — never a paraphrase reconstructed from the implementer's chat or
+  your own memory (that would break the independence this protocol exists to
+  protect). Obtain it in this order, stopping at the first that works:
+  1. **If the launcher handed it to you** (the plan text, or a PR number / URL,
+     injected into your session at launch), use that.
+  2. **Otherwise resolve the PR from the branch you are already on** — you do not
+     *search* for it. With the GitHub CLI: `gh pr view --json body,number` (no
+     argument = the current branch's PR). If the GitHub MCP is connected instead,
+     use `mcp__github__pull_request_read`. **Never `gh pr list` or any
+     head/search lookup** — you are sitting on the PR branch, so resolve it
+     directly.
+  - Do not assume a specific GitHub channel exists: the GitHub MCP
+    (`mcp__github__*`) is **not guaranteed** to be mounted in a validator session
+    — often only the server-under-test MCP is. Check what's available and fall
+    back to `gh`; don't burn a turn calling GitHub MCP tools that aren't there.
 
 ### Your environment is already set up — do NOT re-create it
 
@@ -30,7 +43,10 @@ need is under your feet. Concretely:
   want to confirm it's the PR head, compare against the PR — don't fetch to "get"
   it.
 - **The MCP server is live and authenticated in this session.** Its tools are
-  already loaded as `mcp__<server>__*` (e.g. `mcp__zendesk-local__*`). A valid
+  already loaded as `mcp__<server>__*` (e.g. `mcp__zendesk-local__*`) — but only
+  the **server under test** is mounted; do **not** assume the GitHub MCP
+  (`mcp__github__*`) is also present (see plan retrieval above — fall back to
+  `gh`). A valid
   token is already wired in — the running server uses it, and any helper script
   reuses the same auth (`ZENDESK_OAUTH_TOKEN`, else the cached token file resolved
   by the auth layer). **Do not go looking for the token, the auth flow, or the
@@ -61,8 +77,10 @@ need is under your feet. Concretely:
 
 ## Reporting
 
-Post the report as a **PR comment** in **English** (`mcp__github__add_issue_comment`).
-If you have no GitHub write access, output it for the human to paste. Structure:
+Post the report as a **PR comment** in **English**, resolving the channel the same
+way as the plan retrieval: `gh pr comment` (on the current branch) or, if the
+GitHub MCP is connected, `mcp__github__add_issue_comment`. If neither is available
+(no GitHub write access), output the full report for the human to paste. Structure:
 
 ```markdown
 ## Functional validation report — <commit SHA>

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ zendesk-mcp-server acme --namespace tickets
 | `search_tickets` | Search tickets using Zendesk query syntax, with per-result SLA state | read |
 | `list_tickets` | List tickets with cursor-based pagination | read |
 | `get_linked_incidents` | Get incidents linked to a problem ticket | read |
-| `list_sla_policies` | List SLA policies with filter conditions and per-priority targets | read |
+| `list_sla_policies` | List SLA policies with filter conditions and per-priority targets (requires an admin token, or a custom role with the SLA-management permission) | read |
 | `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |
 | `update_ticket` | Update ticket status, priority, assignee, tags, custom fields | write |
 | `add_private_note` | Add an internal note (not visible to requester) | write |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ zendesk-mcp-server acme --namespace tickets
 
 | Tool | Description | Mode |
 |------|-------------|------|
-| `get_ticket` | Retrieve a ticket by ID with optional comments | read |
+| `get_ticket` | Retrieve a ticket by ID with optional comments and its live SLA state (resolved via a scoped search) | read |
 | `get_ticket_attachments` | Download ticket attachments (images as base64, others as references) | read |
 | `search_tickets` | Search tickets using Zendesk query syntax, with per-result SLA state | read |
 | `list_tickets` | List tickets with cursor-based pagination | read |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ zendesk-mcp-server acme --namespace tickets
 
 | Tool | Description | Mode |
 |------|-------------|------|
-| `get_ticket` | Retrieve a ticket by ID with optional comments and its live SLA state | read |
+| `get_ticket` | Retrieve a ticket by ID with optional comments | read |
 | `get_ticket_attachments` | Download ticket attachments (images as base64, others as references) | read |
 | `search_tickets` | Search tickets using Zendesk query syntax, with per-result SLA state | read |
 | `list_tickets` | List tickets with cursor-based pagination | read |

--- a/README.md
+++ b/README.md
@@ -122,11 +122,12 @@ zendesk-mcp-server acme --namespace tickets
 
 | Tool | Description | Mode |
 |------|-------------|------|
-| `get_ticket` | Retrieve a ticket by ID with optional comments | read |
+| `get_ticket` | Retrieve a ticket by ID with optional comments and its live SLA state | read |
 | `get_ticket_attachments` | Download ticket attachments (images as base64, others as references) | read |
-| `search_tickets` | Search tickets using Zendesk query syntax | read |
+| `search_tickets` | Search tickets using Zendesk query syntax, with per-result SLA state | read |
 | `list_tickets` | List tickets with cursor-based pagination | read |
 | `get_linked_incidents` | Get incidents linked to a problem ticket | read |
+| `list_sla_policies` | List SLA policies with filter conditions and per-priority targets | read |
 | `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |
 | `update_ticket` | Update ticket status, priority, assignee, tags, custom fields | write |
 | `add_private_note` | Add an internal note (not visible to requester) | write |

--- a/scripts/probe-sla-shape.ts
+++ b/scripts/probe-sla-shape.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env tsx
+import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';
+/**
+ * Ground-truth capture for the Zendesk SLA sideload (issue #92 / PR #93).
+ *
+ * The MCP tools only ever return *formatted text*, never the raw Zendesk JSON,
+ * so the exact shape of the `slas` sideload (which is not crisply documented)
+ * cannot be observed through them. This one-shot probe hits the live tenant
+ * directly and prints the RAW JSON for:
+ *   - GET /api/v2/tickets/{id}.json?include=slas   (the per-ticket SLA sideload)
+ *   - GET /api/v2/slas/policies.json               (the policy matrix)
+ *
+ * It only prints the SLA-relevant keys (top-level key list + `slas` payload +
+ * policies), never ticket subjects/bodies, so there is minimal PII to redact.
+ *
+ * Usage (same auth model as scripts/mcp-live.ts):
+ *   ZENDESK_SUBDOMAIN=fruggr ZENDESK_OAUTH_TOKEN=<token> \
+ *     pnpm tsx scripts/probe-sla-shape.ts <ticket_id>
+ *
+ * If you have already authenticated the server once (stdio OAuth flow), the
+ * access token cached on disk for the subdomain is used automatically and
+ * ZENDESK_OAUTH_TOKEN can be omitted.
+ *
+ * Paste the output into a PR comment so the maintainer can align the
+ * TypeScript types, the `findSlaForTicket` correlation key and the MSW mock
+ * (MOCK_SLA_SIDELOAD) to the real shape.
+ */
+import { zendeskGet } from '../src/client/zendesk-api';
+import { loadConfig } from '../src/config';
+
+const ticketId = process.argv[2];
+if (!ticketId || !/^\d+$/.test(ticketId)) {
+  console.error(
+    'Usage: pnpm tsx scripts/probe-sla-shape.ts <ticket_id>\n' +
+      '  ticket_id must be a numeric id of a ticket that is covered by an SLA policy.',
+  );
+  process.exit(1);
+}
+
+const config = loadConfig([]);
+const { subdomain } = config;
+
+const resolveToken = (): string => {
+  const fromEnv = process.env['ZENDESK_OAUTH_TOKEN'];
+  if (fromEnv) return fromEnv;
+  const cached = loadToken(resolveTokenPath(subdomain));
+  if (cached?.accessToken) return cached.accessToken;
+  console.error(
+    `No token available. Export ZENDESK_OAUTH_TOKEN, or authenticate the server once for "${subdomain}" ` +
+      `so a token is cached at ${resolveTokenPath(subdomain)}.`,
+  );
+  process.exit(1);
+};
+
+const dump = (label: string, value: unknown): void => {
+  console.log(`\n===== ${label} =====`);
+  console.log(JSON.stringify(value, null, 2));
+};
+
+const main = async (): Promise<void> => {
+  const token = resolveToken();
+
+  const ticket = await zendeskGet<Record<string, unknown>>(
+    subdomain,
+    token,
+    `/tickets/${ticketId}`,
+    { include: 'slas' },
+  );
+  // Print only the structural ground truth, not the ticket body.
+  dump('GET /tickets/{id}?include=slas — top-level keys', Object.keys(ticket));
+  dump(
+    'GET /tickets/{id}?include=slas — slas payload',
+    ticket['slas'] ?? '(no "slas" key present)',
+  );
+
+  const policies = await zendeskGet<Record<string, unknown>>(subdomain, token, '/slas/policies');
+  dump('GET /slas/policies — top-level keys', Object.keys(policies));
+  const list = (policies['sla_policies'] as unknown[]) ?? [];
+  dump('GET /slas/policies — first policy (representative shape)', list[0] ?? '(no policies)');
+  console.log(`\n(${list.length} SLA policies total)`);
+};
+
+main().catch((error) => {
+  console.error('probe-sla-shape failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/probe-sla-shape.ts
+++ b/scripts/probe-sla-shape.ts
@@ -11,6 +11,8 @@
  *   - GET /api/v2/tickets/{id}.json?include=slas            (NOT honored here)
  *   - GET /api/v2/tickets/{id}.json?include=metric_events   (SLA `sla` objects?)
  *   - GET /api/v2/tickets/{id}/metrics.json                 (generic metric_set)
+ *   - GET /api/v2/tickets/show_many.json?ids={id}&include=  (sideload honored?)
+ *   - GET /api/v2/search.json?query=...requester:{id}       (single-ticket reuse?)
  *   - GET /api/v2/slas/policies.json                        (the policy matrix)
  *
  * A first probe of `?include=metric_events` came back as just `["ticket"]`, but
@@ -230,6 +232,46 @@ const main = async (): Promise<void> => {
     'GET /tickets/{id}/metrics — ticket_metric (no SLA policy/target/breach expected)',
     metrics['ticket_metric'] ?? metrics,
   );
+
+  // (d) Show MANY Tickets — a DIFFERENT endpoint than Show Ticket. Test whether
+  // it honors the `slas` / `metric_events` sideload that Show Ticket silently
+  // drops. If it does, get_ticket gains a CLEAN, reliable per-id SLA path (one
+  // extra call, no pagination/indexing caveats) and the SLA can come back here.
+  for (const inc of ['slas', 'metric_events'] as const) {
+    const many = await zendeskGet<Record<string, unknown>>(subdomain, token, '/tickets/show_many', {
+      ids: targetId,
+      include: inc,
+    });
+    dump(`GET /tickets/show_many?ids={id}&include=${inc} — top-level keys`, Object.keys(many));
+    dump(`show_many ${inc} payload`, many[inc] ?? `(no "${inc}" key present)`);
+  }
+
+  // (e) Search-by-correlation feasibility — there is NO `id:` operator, so the
+  // only way to reuse the working Search `slas` sideload for ONE ticket is a
+  // scoped query (here: same requester) matched back by exact id. Measure the
+  // two failure modes of that approach: COVERAGE (is the target even in the
+  // result set?) and how many siblings we'd have to page through.
+  const targetTicket = (ticketSlas['ticket'] as Record<string, unknown> | undefined) ?? {};
+  const requesterId = targetTicket['requester_id'];
+  if (requesterId != null) {
+    const scoped = await zendeskGet<{ results?: Array<Record<string, unknown>>; count?: number }>(
+      subdomain,
+      token,
+      '/search',
+      { query: `type:ticket requester:${requesterId}`, include: 'tickets(slas)' },
+    );
+    const results = scoped.results ?? [];
+    const hit = results.find((r) => String(r['id']) === String(targetId));
+    dump('Search by requester + correlate by id — feasibility of a get_ticket fallback', {
+      requester_id: requesterId,
+      total_count: scoped['count'],
+      returned_on_first_page: results.length,
+      target_found_on_first_page: Boolean(hit),
+      target_slas: hit?.['slas'] ?? '(target NOT on first page — coverage gap)',
+    });
+  } else {
+    console.log('\n(no requester_id on the target ticket; skipping search-correlation probe)');
+  }
 
   const policies = await zendeskGet<Record<string, unknown>>(subdomain, token, '/slas/policies');
   dump('GET /slas/policies — top-level keys', Object.keys(policies));

--- a/scripts/probe-sla-shape.ts
+++ b/scripts/probe-sla-shape.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env tsx
-import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';
 /**
  * Ground-truth capture for the Zendesk SLA sideload (issue #92 / PR #93).
  *
@@ -16,20 +15,23 @@ import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';
  * It only prints the SLA-relevant keys (top-level key list + payloads), never
  * ticket subjects/bodies, so there is minimal PII to redact.
  *
- * Usage (same auth model as scripts/mcp-live.ts):
+ * Usage (zero setup in an env where the zendesk-local MCP server is configured):
+ *   pnpm tsx scripts/probe-sla-shape.ts <ticket_id>
+ *
+ * The subdomain is read from ZENDESK_SUBDOMAIN, else from the zendesk-local entry
+ * in .mcp.json. The token is read from ZENDESK_OAUTH_TOKEN, else from the access
+ * token cached on disk when the server was authenticated once (stdio OAuth flow).
+ * Override either explicitly when needed:
  *   ZENDESK_SUBDOMAIN=fruggr ZENDESK_OAUTH_TOKEN=<token> \
  *     pnpm tsx scripts/probe-sla-shape.ts <ticket_id>
- *
- * If you have already authenticated the server once (stdio OAuth flow), the
- * access token cached on disk for the subdomain is used automatically and
- * ZENDESK_OAUTH_TOKEN can be omitted.
  *
  * Paste the output into a PR comment so the maintainer can align the
  * TypeScript types, the `findSlaForTicket` correlation key and the MSW mock
  * (MOCK_SLA_SIDELOAD) to the real shape.
  */
+import { readFileSync } from 'node:fs';
+import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';
 import { zendeskGet } from '../src/client/zendesk-api';
-import { loadConfig } from '../src/config';
 
 const ticketId = process.argv[2];
 if (!ticketId || !/^\d+$/.test(ticketId)) {
@@ -40,8 +42,29 @@ if (!ticketId || !/^\d+$/.test(ticketId)) {
   process.exit(1);
 }
 
-const config = loadConfig([]);
-const { subdomain } = config;
+// The probe only needs a subdomain + a token to make GETs — not the full server
+// config. Resolve the subdomain from the same places the server uses, so it runs
+// with zero manual setup: ZENDESK_SUBDOMAIN, else the subdomain `.mcp.json`
+// already configures the local server with (its env is injected into the MCP
+// subprocess only, never the interactive shell, which is why a bare run fails).
+const resolveSubdomain = (): string => {
+  const fromEnv = process.env['ZENDESK_SUBDOMAIN'];
+  if (fromEnv) return fromEnv;
+  try {
+    const mcp = JSON.parse(readFileSync(new URL('../.mcp.json', import.meta.url), 'utf8'));
+    const sub = mcp?.mcpServers?.['zendesk-local']?.env?.ZENDESK_SUBDOMAIN;
+    if (typeof sub === 'string' && sub) return sub;
+  } catch {
+    // fall through to the error below
+  }
+  console.error(
+    'No Zendesk subdomain. Set ZENDESK_SUBDOMAIN, or run from a checkout whose ' +
+      '.mcp.json configures the zendesk-local server.',
+  );
+  process.exit(1);
+};
+
+const subdomain = resolveSubdomain();
 
 const resolveToken = (): string => {
   const fromEnv = process.env['ZENDESK_OAUTH_TOKEN'];

--- a/scripts/probe-sla-shape.ts
+++ b/scripts/probe-sla-shape.ts
@@ -79,7 +79,14 @@ const main = async (): Promise<void> => {
 
   const policies = await zendeskGet<Record<string, unknown>>(subdomain, token, '/slas/policies');
   dump('GET /slas/policies — top-level keys', Object.keys(policies));
-  const list = (policies['sla_policies'] as unknown[]) ?? [];
+  const rawSlaPolicies = policies['sla_policies'];
+  if (!Array.isArray(rawSlaPolicies)) {
+    dump(
+      'GET /slas/policies — unexpected `sla_policies` shape',
+      rawSlaPolicies ?? '(no "sla_policies" key present)',
+    );
+  }
+  const list = Array.isArray(rawSlaPolicies) ? rawSlaPolicies : [];
   dump('GET /slas/policies — first policy (representative shape)', list[0] ?? '(no policies)');
   console.log(`\n(${list.length} SLA policies total)`);
 };

--- a/scripts/probe-sla-shape.ts
+++ b/scripts/probe-sla-shape.ts
@@ -60,17 +60,21 @@ const dump = (label: string, value: unknown): void => {
 const main = async (): Promise<void> => {
   const token = resolveToken();
 
+  // Both `slas` and `metric_events` are documented single-ticket sideloads.
+  // `slas` is the primary source (live countdown); `metric_events` is the
+  // documented fallback (apply_sla / breach / update_status events).
   const ticket = await zendeskGet<Record<string, unknown>>(
     subdomain,
     token,
     `/tickets/${ticketId}`,
-    { include: 'slas' },
+    { include: 'slas,metric_events' },
   );
   // Print only the structural ground truth, not the ticket body.
-  dump('GET /tickets/{id}?include=slas — top-level keys', Object.keys(ticket));
+  dump('GET /tickets/{id}?include=slas,metric_events — top-level keys', Object.keys(ticket));
+  dump('slas payload', ticket['slas'] ?? '(no "slas" key present)');
   dump(
-    'GET /tickets/{id}?include=slas — slas payload',
-    ticket['slas'] ?? '(no "slas" key present)',
+    'metric_events payload (fallback)',
+    ticket['metric_events'] ?? '(no "metric_events" key present)',
   );
 
   const policies = await zendeskGet<Record<string, unknown>>(subdomain, token, '/slas/policies');

--- a/scripts/probe-sla-shape.ts
+++ b/scripts/probe-sla-shape.ts
@@ -1,42 +1,57 @@
 #!/usr/bin/env tsx
 /**
- * Ground-truth capture for the Zendesk SLA sideload (issue #92 / PR #93).
+ * Ground-truth capture for live per-ticket SLA (issue #92 / PR #93).
  *
  * The MCP tools only ever return *formatted text*, never the raw Zendesk JSON,
  * so the exact shape of the SLA data (which is not crisply documented) cannot be
  * observed through them. This one-shot probe hits the live tenant directly and
  * prints the RAW JSON for every candidate per-ticket SLA source, each probed in
  * ISOLATION so an unrecognized sibling sideload can't mask a valid one:
- *   - GET /api/v2/tickets/{id}.json?include=slas           (NOT honored here)
- *   - GET /api/v2/tickets/{id}.json?include=metric_events  (SLA `sla` objects?)
- *   - GET /api/v2/tickets/{id}/metrics.json                (generic metric_set)
- *   - GET /api/v2/slas/policies.json                       (the policy matrix)
+ *   - GET /api/v2/users/me.json                             (token role: admin?)
+ *   - GET /api/v2/tickets/{id}.json?include=slas            (NOT honored here)
+ *   - GET /api/v2/tickets/{id}.json?include=metric_events   (SLA `sla` objects?)
+ *   - GET /api/v2/tickets/{id}/metrics.json                 (generic metric_set)
+ *   - GET /api/v2/slas/policies.json                        (the policy matrix)
  *
- * It only prints the SLA-relevant keys (top-level key list + payloads), never
+ * A first probe of `?include=metric_events` came back as just `["ticket"]`, but
+ * that run was INCONCLUSIVE, not a refutation: the research report flags two
+ * preconditions for SLA data to surface — the token must be an admin, and the
+ * ticket must actually have an SLA policy applied (priority set, policy matched;
+ * Group SLAs may only surface via metric_events). So this probe now:
+ *   1. prints the token's role up front (warns if it is not admin), and
+ *   2. uses Search (`include=tickets(slas)`) to AUTO-DISCOVER a ticket that
+ *      genuinely carries live `policy_metrics`, and probes that one when the id
+ *      passed on the CLI has no live SLA (or no id is passed at all).
+ * It also highlights any `sla` / `group_sla` object found on a metric event —
+ * that object (policy {id,title} + target minutes + business/calendar + breach)
+ * is the candidate source for a get_ticket SLA block.
+ *
+ * It only prints SLA-relevant keys (top-level key lists, payloads, ids), never
  * ticket subjects/bodies, so there is minimal PII to redact.
  *
  * Usage (zero setup in an env where the zendesk-local MCP server is configured):
- *   pnpm tsx scripts/probe-sla-shape.ts <ticket_id>
+ *   pnpm tsx scripts/probe-sla-shape.ts [ticket_id]
  *
- * The subdomain is read from ZENDESK_SUBDOMAIN, else from the zendesk-local entry
- * in .mcp.json. The token is read from ZENDESK_OAUTH_TOKEN, else from the access
- * token cached on disk when the server was authenticated once (stdio OAuth flow).
- * Override either explicitly when needed:
+ * Pass a ticket_id known to be covered by an SLA, or omit it to let the probe
+ * discover one. The subdomain is read from ZENDESK_SUBDOMAIN, else from the
+ * zendesk-local entry in .mcp.json. The token is read from ZENDESK_OAUTH_TOKEN,
+ * else from the access token cached on disk when the server was authenticated
+ * once (stdio OAuth flow). Override either explicitly when needed:
  *   ZENDESK_SUBDOMAIN=fruggr ZENDESK_OAUTH_TOKEN=<token> \
- *     pnpm tsx scripts/probe-sla-shape.ts <ticket_id>
+ *     pnpm tsx scripts/probe-sla-shape.ts [ticket_id]
  *
- * Paste the output into a PR comment so the maintainer can align the
- * TypeScript types and the MSW mock (MOCK_SLA_SIDELOAD) to the real shape.
+ * Paste the output into a PR comment so the maintainer can decide whether
+ * get_ticket can surface SLA via metric_events, and align types/mocks.
  */
 import { readFileSync } from 'node:fs';
 import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';
 import { zendeskGet } from '../src/client/zendesk-api';
 
-const ticketId = process.argv[2];
-if (!ticketId || !/^\d+$/.test(ticketId)) {
+const cliTicketId = process.argv[2];
+if (cliTicketId && !/^\d+$/.test(cliTicketId)) {
   console.error(
-    'Usage: pnpm tsx scripts/probe-sla-shape.ts <ticket_id>\n' +
-      '  ticket_id must be a numeric id of a ticket that is covered by an SLA policy.',
+    'Usage: pnpm tsx scripts/probe-sla-shape.ts [ticket_id]\n' +
+      '  ticket_id (optional) must be numeric; omit it to auto-discover an SLA-covered ticket.',
   );
   process.exit(1);
 }
@@ -82,38 +97,103 @@ const dump = (label: string, value: unknown): void => {
   console.log(JSON.stringify(value, null, 2));
 };
 
+const hasLiveSla = (slas: unknown): boolean =>
+  Array.isArray((slas as { policy_metrics?: unknown[] } | undefined)?.policy_metrics) &&
+  ((slas as { policy_metrics: unknown[] }).policy_metrics.length ?? 0) > 0;
+
+// Pull the SLA-bearing object off a metric event under either documented key.
+const slaObjectOf = (ev: unknown): unknown => {
+  const e = ev as Record<string, unknown> | undefined;
+  return e?.['sla'] ?? e?.['group_sla'] ?? null;
+};
+
 const main = async (): Promise<void> => {
   const token = resolveToken();
 
-  // Probe each candidate single-ticket SLA source in ISOLATION, so an
-  // unrecognized sibling sideload can't mask a valid one (the first probe
-  // requested `slas,metric_events` together and got back only `["ticket"]`,
-  // which couldn't tell us whether `metric_events` itself is honored here).
+  // (0) Token role — `metric_events`/SLA data is admin-gated, so a non-admin
+  // token is the first thing that would make this probe come back empty.
+  let role: unknown = '(unknown)';
+  try {
+    const me = await zendeskGet<Record<string, unknown>>(subdomain, token, '/users/me');
+    const user = (me['user'] as Record<string, unknown> | undefined) ?? {};
+    role = { role: user['role'], role_type: user['role_type'], id: user['id'] };
+    dump('GET /users/me — token identity (role MUST be admin for SLA data)', role);
+    if (user['role'] !== 'admin') {
+      console.log(
+        '\n!!! WARNING: token role is not "admin" — SLA sideloads/metric_events are ' +
+          'admin-gated, so empty results below are EXPECTED and INCONCLUSIVE. Re-run ' +
+          'with an admin token (ZENDESK_OAUTH_TOKEN).',
+      );
+    }
+  } catch (e) {
+    console.log(`\n(could not read /users/me: ${e instanceof Error ? e.message : e})`);
+  }
+
+  // (1) Auto-discover a ticket that genuinely carries live SLA, via the one
+  // source we KNOW works (Search `include=tickets(slas)`). This both confirms
+  // the search shape and gives a guaranteed-covered ticket id to probe, so an
+  // empty metric_events result can't be blamed on "this ticket had no SLA".
+  let targetId = cliTicketId;
+  try {
+    const search = await zendeskGet<{ results?: Array<Record<string, unknown>> }>(
+      subdomain,
+      token,
+      '/search',
+      { query: 'type:ticket status<solved', include: 'tickets(slas)' },
+    );
+    const results = search.results ?? [];
+    const covered = results.filter((r) => hasLiveSla(r['slas']));
+    dump(
+      'Search type:ticket include=tickets(slas) — ids WITH live policy_metrics',
+      covered.map((r) => ({ id: r['id'], slas: r['slas'] })).slice(0, 5),
+    );
+    console.log(
+      `\n(${covered.length}/${results.length} returned tickets carry live SLA policy_metrics)`,
+    );
+    if (!targetId && covered[0]?.['id'] != null) {
+      targetId = String(covered[0]['id']);
+      console.log(
+        `\n-> No ticket_id passed; probing auto-discovered SLA-covered ticket ${targetId}.`,
+      );
+    } else if (targetId && !covered.some((r) => String(r['id']) === targetId)) {
+      const fallback = covered[0]?.['id'];
+      console.log(
+        `\n!!! Ticket ${targetId} is NOT among the SLA-covered tickets above; its SLA probes ` +
+          `may be empty for that reason.${fallback != null ? ` Consider re-running with ${fallback}.` : ''}`,
+      );
+    }
+  } catch (e) {
+    console.log(`\n(search discovery failed: ${e instanceof Error ? e.message : e})`);
+  }
+
+  if (!targetId) {
+    console.error(
+      '\nNo ticket to probe (none passed and none discovered with a live SLA). ' +
+        'Pass an SLA-covered ticket_id explicitly.',
+    );
+    process.exit(1);
+  }
 
   // (a) `slas` on Show Ticket — expected NOT honored (silently dropped).
   const ticketSlas = await zendeskGet<Record<string, unknown>>(
     subdomain,
     token,
-    `/tickets/${ticketId}`,
-    {
-      include: 'slas',
-    },
+    `/tickets/${targetId}`,
+    { include: 'slas' },
   );
   dump('GET /tickets/{id}?include=slas — top-level keys', Object.keys(ticketSlas));
   dump('slas payload', ticketSlas['slas'] ?? '(no "slas" key present)');
 
-  // (b) `metric_events` on Show Ticket — per Zendesk docs each SLA metric event
-  // carries an `sla`/`group_sla` object (policy {id,title,description} + target
-  // in minutes + business/calendar + the breach timestamp). If present, this is
-  // the richer source for the get_ticket SLA block. Print the first event of
-  // each distinct type so the shape (esp. the `sla` object) is visible.
+  // (b) `metric_events` on Show Ticket — the candidate richer source. Per the
+  // Zendesk docs each SLA metric event carries an `sla`/`group_sla` object
+  // (policy {id,title,description} + target minutes + business/calendar + breach
+  // timestamp). Print one event per type, then isolate the SLA objects so we can
+  // see whether stage + breach_at + policy + target are all reconstructable.
   const ticketEvents = await zendeskGet<Record<string, unknown>>(
     subdomain,
     token,
-    `/tickets/${ticketId}`,
-    {
-      include: 'metric_events',
-    },
+    `/tickets/${targetId}`,
+    { include: 'metric_events' },
   );
   dump('GET /tickets/{id}?include=metric_events — top-level keys', Object.keys(ticketEvents));
   const events = ticketEvents['metric_events'];
@@ -124,6 +204,17 @@ const main = async (): Promise<void> => {
       if (!byType.has(type)) byType.set(type, ev);
     }
     dump(`metric_events — ${events.length} total, one sample per type`, [...byType.values()]);
+    const slaObjects = events.map(slaObjectOf).filter((s) => s != null);
+    dump(
+      `metric_events — ${slaObjects.length} events carry an sla/group_sla object`,
+      slaObjects.slice(0, 6),
+    );
+    if (slaObjects.length === 0) {
+      console.log(
+        '\n!!! No sla/group_sla object on any metric event. If the token is admin and the ' +
+          'ticket is SLA-covered (see discovery above), get_ticket has NO reliable SLA source.',
+      );
+    }
   } else {
     dump('metric_events payload', events ?? '(no "metric_events" key present)');
   }
@@ -133,7 +224,7 @@ const main = async (): Promise<void> => {
   const metrics = await zendeskGet<Record<string, unknown>>(
     subdomain,
     token,
-    `/tickets/${ticketId}/metrics`,
+    `/tickets/${targetId}/metrics`,
   );
   dump(
     'GET /tickets/{id}/metrics — ticket_metric (no SLA policy/target/breach expected)',

--- a/scripts/probe-sla-shape.ts
+++ b/scripts/probe-sla-shape.ts
@@ -4,14 +4,17 @@ import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';
  * Ground-truth capture for the Zendesk SLA sideload (issue #92 / PR #93).
  *
  * The MCP tools only ever return *formatted text*, never the raw Zendesk JSON,
- * so the exact shape of the `slas` sideload (which is not crisply documented)
- * cannot be observed through them. This one-shot probe hits the live tenant
- * directly and prints the RAW JSON for:
- *   - GET /api/v2/tickets/{id}.json?include=slas   (the per-ticket SLA sideload)
- *   - GET /api/v2/slas/policies.json               (the policy matrix)
+ * so the exact shape of the SLA data (which is not crisply documented) cannot be
+ * observed through them. This one-shot probe hits the live tenant directly and
+ * prints the RAW JSON for every candidate per-ticket SLA source, each probed in
+ * ISOLATION so an unrecognized sibling sideload can't mask a valid one:
+ *   - GET /api/v2/tickets/{id}.json?include=slas           (NOT honored here)
+ *   - GET /api/v2/tickets/{id}.json?include=metric_events  (SLA `sla` objects?)
+ *   - GET /api/v2/tickets/{id}/metrics.json                (generic metric_set)
+ *   - GET /api/v2/slas/policies.json                       (the policy matrix)
  *
- * It only prints the SLA-relevant keys (top-level key list + `slas` payload +
- * policies), never ticket subjects/bodies, so there is minimal PII to redact.
+ * It only prints the SLA-relevant keys (top-level key list + payloads), never
+ * ticket subjects/bodies, so there is minimal PII to redact.
  *
  * Usage (same auth model as scripts/mcp-live.ts):
  *   ZENDESK_SUBDOMAIN=fruggr ZENDESK_OAUTH_TOKEN=<token> \
@@ -60,21 +63,59 @@ const dump = (label: string, value: unknown): void => {
 const main = async (): Promise<void> => {
   const token = resolveToken();
 
-  // Both `slas` and `metric_events` are documented single-ticket sideloads.
-  // `slas` is the primary source (live countdown); `metric_events` is the
-  // documented fallback (apply_sla / breach / update_status events).
-  const ticket = await zendeskGet<Record<string, unknown>>(
+  // Probe each candidate single-ticket SLA source in ISOLATION, so an
+  // unrecognized sibling sideload can't mask a valid one (the first probe
+  // requested `slas,metric_events` together and got back only `["ticket"]`,
+  // which couldn't tell us whether `metric_events` itself is honored here).
+
+  // (a) `slas` on Show Ticket — expected NOT honored (silently dropped).
+  const ticketSlas = await zendeskGet<Record<string, unknown>>(
     subdomain,
     token,
     `/tickets/${ticketId}`,
-    { include: 'slas,metric_events' },
+    {
+      include: 'slas',
+    },
   );
-  // Print only the structural ground truth, not the ticket body.
-  dump('GET /tickets/{id}?include=slas,metric_events — top-level keys', Object.keys(ticket));
-  dump('slas payload', ticket['slas'] ?? '(no "slas" key present)');
+  dump('GET /tickets/{id}?include=slas — top-level keys', Object.keys(ticketSlas));
+  dump('slas payload', ticketSlas['slas'] ?? '(no "slas" key present)');
+
+  // (b) `metric_events` on Show Ticket — per Zendesk docs each SLA metric event
+  // carries an `sla`/`group_sla` object (policy {id,title,description} + target
+  // in minutes + business/calendar + the breach timestamp). If present, this is
+  // the richer source for the get_ticket SLA block. Print the first event of
+  // each distinct type so the shape (esp. the `sla` object) is visible.
+  const ticketEvents = await zendeskGet<Record<string, unknown>>(
+    subdomain,
+    token,
+    `/tickets/${ticketId}`,
+    {
+      include: 'metric_events',
+    },
+  );
+  dump('GET /tickets/{id}?include=metric_events — top-level keys', Object.keys(ticketEvents));
+  const events = ticketEvents['metric_events'];
+  if (Array.isArray(events)) {
+    const byType = new Map<unknown, unknown>();
+    for (const ev of events) {
+      const type = (ev as Record<string, unknown>)?.['type'];
+      if (!byType.has(type)) byType.set(type, ev);
+    }
+    dump(`metric_events — ${events.length} total, one sample per type`, [...byType.values()]);
+  } else {
+    dump('metric_events payload', events ?? '(no "metric_events" key present)');
+  }
+
+  // (c) The per-ticket metric_set (reply/resolution timing) — confirm it carries
+  // NO SLA policy/target/breach, i.e. it cannot stand in for the SLA block.
+  const metrics = await zendeskGet<Record<string, unknown>>(
+    subdomain,
+    token,
+    `/tickets/${ticketId}/metrics`,
+  );
   dump(
-    'metric_events payload (fallback)',
-    ticket['metric_events'] ?? '(no "metric_events" key present)',
+    'GET /tickets/{id}/metrics — ticket_metric (no SLA policy/target/breach expected)',
+    metrics['ticket_metric'] ?? metrics,
   );
 
   const policies = await zendeskGet<Record<string, unknown>>(subdomain, token, '/slas/policies');

--- a/scripts/probe-sla-shape.ts
+++ b/scripts/probe-sla-shape.ts
@@ -26,8 +26,7 @@
  *     pnpm tsx scripts/probe-sla-shape.ts <ticket_id>
  *
  * Paste the output into a PR comment so the maintainer can align the
- * TypeScript types, the `findSlaForTicket` correlation key and the MSW mock
- * (MOCK_SLA_SIDELOAD) to the real shape.
+ * TypeScript types and the MSW mock (MOCK_SLA_SIDELOAD) to the real shape.
  */
 import { readFileSync } from 'node:fs';
 import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -16,10 +16,19 @@ import {
 import type {
   ZendeskComment,
   ZendeskListResponse,
+  ZendeskSlaPolicy,
+  ZendeskSlaSideloadEntry,
   ZendeskTicket,
   ZendeskTicketAttachment,
 } from '../types';
-import { formatComment, formatList, formatTicket, truncateIfNeeded } from '../utils/formatting';
+import {
+  formatComment,
+  formatList,
+  formatSlaBlock,
+  formatSlaPolicy,
+  formatTicket,
+  truncateIfNeeded,
+} from '../utils/formatting';
 import {
   buildCursorParams,
   buildOffsetParams,
@@ -112,6 +121,19 @@ const collectAttachmentBlocks = async (
   return blocks;
 };
 
+// Correlate a top-level `slas` sideload back to a single ticket. Prefers an
+// explicit ticket_id match; falls back to a lone entry without a ticket_id
+// (the get_ticket case, where the sideload describes the one fetched ticket).
+const findSlaForTicket = (
+  slas: ZendeskSlaSideloadEntry[] | undefined,
+  ticketId: number,
+): ZendeskSlaSideloadEntry | undefined => {
+  const entries = slas ?? [];
+  const match = entries.find((e) => e.ticket_id === ticketId);
+  if (match) return match;
+  return entries.length === 1 && entries[0]?.ticket_id == null ? entries[0] : undefined;
+};
+
 export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
   const { subdomain, getToken } = ctx;
 
@@ -122,7 +144,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Get Zendesk Ticket',
       description:
-        'Retrieve a Zendesk ticket by ID, including its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes.',
+        'Retrieve a Zendesk ticket by ID, including its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The live SLA state (applied policy, per-metric targets, due dates, time remaining and breach status) is included automatically whenever an SLA policy applies to the ticket.',
       inputSchema: z.object({
         ticket_id: z.number().int().describe('Ticket ID'),
         include_comments: z.boolean().default(false).describe('Include ticket comments'),
@@ -139,12 +161,11 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           include_comments: boolean;
         };
         const token = await getToken();
-        const { ticket } = await zendeskGet<{ ticket: ZendeskTicket }>(
-          subdomain,
-          token,
-          `/tickets/${ticket_id}`,
-        );
-        let text = formatTicket(ticket);
+        const { ticket, slas } = await zendeskGet<{
+          ticket: ZendeskTicket;
+          slas?: ZendeskSlaSideloadEntry[];
+        }>(subdomain, token, `/tickets/${ticket_id}`, { include: 'slas' });
+        let text = formatTicket(ticket) + formatSlaBlock(findSlaForTicket(slas, ticket.id));
         if (include_comments) {
           const { comments } = await zendeskGet<{ comments: ZendeskComment[] }>(
             subdomain,
@@ -228,7 +249,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Search Zendesk Tickets',
       description:
-        'Search tickets using Zendesk query syntax (e.g., "status:open assignee:me", "priority:urgent type:incident"). Returns total count.',
+        'Search tickets using Zendesk query syntax (e.g., "status:open assignee:me", "priority:urgent type:incident"). Returns total count. Each result carries its live SLA state when an SLA policy applies, so queue triage like "breaching today" works without a per-ticket fetch.',
       inputSchema: z.object({
         query: z.string().min(1).describe('Zendesk search query string'),
         per_page: z
@@ -253,22 +274,22 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           page: number;
         };
         const token = await getToken();
-        const response = await zendeskGet<ZendeskListResponse<ZendeskTicket>>(
-          subdomain,
-          token,
-          '/search',
-          {
-            query: `type:ticket ${query}`,
-            ...buildOffsetParams(per_page, page),
-          },
-        );
+        const response = await zendeskGet<
+          ZendeskListResponse<ZendeskTicket> & { slas?: ZendeskSlaSideloadEntry[] }
+        >(subdomain, token, '/search', {
+          query: `type:ticket ${query}`,
+          include: 'tickets(slas)',
+          ...buildOffsetParams(per_page, page),
+        });
+        const formatTicketWithSla = (ticket: ZendeskTicket): string =>
+          formatTicket(ticket) + formatSlaBlock(findSlaForTicket(response.slas, ticket.id));
         return {
           content: [
             {
               type: 'text',
               text: formatList(
                 response.results ?? [],
-                formatTicket,
+                formatTicketWithSla,
                 extractSearchPaginationMeta(response, per_page, page),
               ),
             },
@@ -564,6 +585,52 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
             {
               type: 'text',
               text: `Tags updated on ticket #${ticket_id}. Current: ${updated.tags.join(', ') || 'none'}`,
+            },
+          ],
+        };
+      },
+    },
+    {
+      name: 'list_sla_policies',
+      namespace: 'tickets',
+      readOnly: true,
+      title: 'List SLA Policies',
+      description:
+        'List the configured SLA policies with their filter conditions and per-priority reply/resolution targets. Use this to explain why a given target applies to a ticket and to reconstruct deadlines deterministically instead of hard-coding the policy matrix.',
+      inputSchema: z.object({
+        per_page: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Results per page'),
+        page: z.number().int().min(1).default(1).describe('Page number'),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { per_page, page } = params as { per_page: number; page: number };
+        const token = await getToken();
+        const response = await zendeskGet<ZendeskListResponse<ZendeskSlaPolicy>>(
+          subdomain,
+          token,
+          '/slas/policies',
+          buildOffsetParams(per_page, page),
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: formatList(
+                response.sla_policies ?? [],
+                formatSlaPolicy,
+                extractSearchPaginationMeta(response, per_page, page),
+              ),
             },
           ],
         };

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -633,7 +633,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'List SLA Policies',
       description:
-        'List the configured SLA policies with their filter conditions and per-priority reply/resolution targets. Use this to explain why a given target applies to a ticket and to reconstruct deadlines deterministically instead of hard-coding the policy matrix.',
+        'List the configured SLA policies with their filter conditions and per-priority reply/resolution targets. Use this to explain why a given target applies to a ticket and to reconstruct deadlines deterministically instead of hard-coding the policy matrix. Requires an admin token (or a custom role granted the SLA-management permission); a standard agent token gets 403 here, though it can still read live per-ticket SLA via get_ticket / search_tickets.',
       inputSchema: z.object({
         per_page: z
           .number()

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -622,17 +622,16 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           '/slas/policies',
           buildOffsetParams(per_page, page),
         );
+        const policies = response.sla_policies ?? [];
+        // The SLA policies endpoint returns the full config list and, in
+        // practice, omits the `count` wrapper, so fall back to the array length
+        // rather than reporting "Results: 0".
+        const meta =
+          response.count != null
+            ? extractSearchPaginationMeta(response, per_page, page)
+            : { count: policies.length, has_more: false, after_cursor: null };
         return {
-          content: [
-            {
-              type: 'text',
-              text: formatList(
-                response.sla_policies ?? [],
-                formatSlaPolicy,
-                extractSearchPaginationMeta(response, per_page, page),
-              ),
-            },
-          ],
+          content: [{ type: 'text', text: formatList(policies, formatSlaPolicy, meta) }],
         };
       },
     },

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -17,6 +17,7 @@ import type {
   ZendeskComment,
   ZendeskListResponse,
   ZendeskSlaPolicy,
+  ZendeskSlaSideloadEntry,
   ZendeskTicket,
   ZendeskTicketAttachment,
 } from '../types';
@@ -123,6 +124,45 @@ const collectAttachmentBlocks = async (
 // Correlate a top-level `slas` sideload back to a single ticket. Prefers an
 // explicit ticket_id match; falls back to a lone entry without a ticket_id
 // (the get_ticket case, where the sideload describes the one fetched ticket).
+// get_ticket has no direct SLA source — Zendesk silently ignores the `slas`
+// sideload on both Show Ticket and Show Many (#92). The only endpoint that
+// returns live SLA is Search, so resolve a single ticket's SLA via a tightly
+// scoped Search — its own requester, within a +/-1 day window around its
+// creation day (the window absorbs account-timezone skew in search dates) — and
+// correlate the result back by exact id. Best-effort by design: returns
+// undefined (never mis-attributed data) when the ticket falls outside the
+// result window (very high-volume requester) or Search is briefly unavailable
+// / not yet indexed.
+const fetchTicketSla = async (
+  subdomain: string,
+  token: string,
+  ticket: ZendeskTicket,
+): Promise<ZendeskSlaSideloadEntry | undefined> => {
+  const day = ticket.created_at.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return undefined;
+  const shiftDay = (offset: number): string => {
+    const d = new Date(`${day}T00:00:00Z`);
+    d.setUTCDate(d.getUTCDate() + offset);
+    return d.toISOString().slice(0, 10);
+  };
+  try {
+    const { results } = await zendeskGet<ZendeskListResponse<ZendeskTicket>>(
+      subdomain,
+      token,
+      '/search',
+      {
+        query: `type:ticket requester:${ticket.requester_id} created>${shiftDay(-1)} created<${shiftDay(1)}`,
+        include: 'tickets(slas)',
+        ...buildOffsetParams(MAX_PAGE_SIZE, 1),
+      },
+    );
+    return (results ?? []).find((r) => r.id === ticket.id)?.slas;
+  } catch {
+    // SLA is supplementary — never fail get_ticket because the lookup faltered.
+    return undefined;
+  }
+};
+
 export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
   const { subdomain, getToken } = ctx;
 
@@ -133,7 +173,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Get Zendesk Ticket',
       description:
-        "Retrieve a Zendesk ticket by ID, including its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. To see a ticket's live SLA state (stage and breach countdown), use search_tickets, which surfaces it per result; the per-ticket Show endpoint does not expose SLA data.",
+        'Retrieve a Zendesk ticket by ID, including its live SLA state (per-metric stage and breach countdown) when an SLA policy applies, plus its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The per-ticket Show endpoint exposes no SLA, so the SLA block is resolved via a scoped search and may be absent for a very high-volume requester or a just-updated ticket; SLA targets and policy conditions live in list_sla_policies.',
       inputSchema: z.object({
         ticket_id: z.number().int().describe('Ticket ID'),
         include_comments: z.boolean().default(false).describe('Include ticket comments'),
@@ -150,15 +190,14 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           include_comments: boolean;
         };
         const token = await getToken();
-        // No SLA block here: Zendesk does not expose live SLA on the Show Ticket
-        // endpoint (`include=slas` is silently ignored). SLA surfaces via
-        // search_tickets instead — see #92.
         const { ticket } = await zendeskGet<{ ticket: ZendeskTicket }>(
           subdomain,
           token,
           `/tickets/${ticket_id}`,
         );
-        let text = formatTicket(ticket);
+        // Show Ticket exposes no SLA (#92); resolve it via a scoped Search.
+        let text =
+          formatTicket(ticket) + formatSlaBlock(await fetchTicketSla(subdomain, token, ticket));
         if (include_comments) {
           const { comments } = await zendeskGet<{ comments: ZendeskComment[] }>(
             subdomain,
@@ -242,7 +281,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Search Zendesk Tickets',
       description:
-        'Search tickets using Zendesk query syntax (e.g., "status:open assignee:me", "priority:urgent type:incident"). Returns total count. Each result carries its live SLA state when an SLA policy applies, so queue triage like "breaching today" works without a per-ticket fetch.',
+        'Search tickets using Zendesk query syntax, returning each result with its live SLA state (per-metric stage and breach countdown) when an SLA policy applies. Examples: "status:open assignee:me", "priority:urgent type:incident". Returns total count, so queue triage like "breaching today" works without a per-ticket fetch.',
       inputSchema: z.object({
         query: z.string().min(1).describe('Zendesk search query string'),
         per_page: z

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -653,12 +653,26 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       handler: async (params) => {
         const { per_page, page } = params as { per_page: number; page: number };
         const token = await getToken();
-        const response = await zendeskGet<ZendeskListResponse<ZendeskSlaPolicy>>(
-          subdomain,
-          token,
-          '/slas/policies',
-          buildOffsetParams(per_page, page),
-        );
+        let response: ZendeskListResponse<ZendeskSlaPolicy>;
+        try {
+          response = await zendeskGet<ZendeskListResponse<ZendeskSlaPolicy>>(
+            subdomain,
+            token,
+            '/slas/policies',
+            buildOffsetParams(per_page, page),
+          );
+        } catch (error) {
+          // /slas/policies is the SLA *configuration* endpoint, which Zendesk
+          // restricts to admins. A 403 here means the token lacks that role, so
+          // replace the generic "Permission denied" with guidance the LLM can
+          // act on -- including the agent-accessible alternative.
+          if (error instanceof ZendeskApiError && error.status === 403) {
+            throw new Error(
+              'list_sla_policies reads SLA policy *configuration* (GET /slas/policies), which Zendesk restricts to admins (or a custom role granted the SLA-management permission). The current token lacks that permission (HTTP 403). This does not affect live SLA on tickets: per-metric SLA stage and breach countdown are available to any agent via get_ticket and search_tickets -- use those for triage and prioritization.',
+            );
+          }
+          throw error;
+        }
         const policies = response.sla_policies ?? [];
         // The SLA policies endpoint returns the full config list and, in
         // practice, omits the `count` wrapper, so fall back to the array length

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -17,7 +17,6 @@ import type {
   ZendeskComment,
   ZendeskListResponse,
   ZendeskSlaPolicy,
-  ZendeskSlaSideloadEntry,
   ZendeskTicket,
   ZendeskTicketAttachment,
 } from '../types';
@@ -124,16 +123,6 @@ const collectAttachmentBlocks = async (
 // Correlate a top-level `slas` sideload back to a single ticket. Prefers an
 // explicit ticket_id match; falls back to a lone entry without a ticket_id
 // (the get_ticket case, where the sideload describes the one fetched ticket).
-const findSlaForTicket = (
-  slas: ZendeskSlaSideloadEntry[] | undefined,
-  ticketId: number,
-): ZendeskSlaSideloadEntry | undefined => {
-  const entries = slas ?? [];
-  const match = entries.find((e) => e.ticket_id === ticketId);
-  if (match) return match;
-  return entries.length === 1 && entries[0]?.ticket_id == null ? entries[0] : undefined;
-};
-
 export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
   const { subdomain, getToken } = ctx;
 
@@ -144,7 +133,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Get Zendesk Ticket',
       description:
-        'Retrieve a Zendesk ticket by ID, including its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The live SLA state (applied policy, per-metric targets, due dates, time remaining and breach status) is included automatically whenever an SLA policy applies to the ticket.',
+        "Retrieve a Zendesk ticket by ID, including its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. To see a ticket's live SLA state (stage and breach countdown), use search_tickets, which surfaces it per result; the per-ticket Show endpoint does not expose SLA data.",
       inputSchema: z.object({
         ticket_id: z.number().int().describe('Ticket ID'),
         include_comments: z.boolean().default(false).describe('Include ticket comments'),
@@ -161,11 +150,15 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           include_comments: boolean;
         };
         const token = await getToken();
-        const { ticket, slas } = await zendeskGet<{
-          ticket: ZendeskTicket;
-          slas?: ZendeskSlaSideloadEntry[];
-        }>(subdomain, token, `/tickets/${ticket_id}`, { include: 'slas' });
-        let text = formatTicket(ticket) + formatSlaBlock(findSlaForTicket(slas, ticket.id));
+        // No SLA block here: Zendesk does not expose live SLA on the Show Ticket
+        // endpoint (`include=slas` is silently ignored). SLA surfaces via
+        // search_tickets instead — see #92.
+        const { ticket } = await zendeskGet<{ ticket: ZendeskTicket }>(
+          subdomain,
+          token,
+          `/tickets/${ticket_id}`,
+        );
+        let text = formatTicket(ticket);
         if (include_comments) {
           const { comments } = await zendeskGet<{ comments: ZendeskComment[] }>(
             subdomain,
@@ -274,15 +267,20 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           page: number;
         };
         const token = await getToken();
-        const response = await zendeskGet<
-          ZendeskListResponse<ZendeskTicket> & { slas?: ZendeskSlaSideloadEntry[] }
-        >(subdomain, token, '/search', {
-          query: `type:ticket ${query}`,
-          include: 'tickets(slas)',
-          ...buildOffsetParams(per_page, page),
-        });
+        const response = await zendeskGet<ZendeskListResponse<ZendeskTicket>>(
+          subdomain,
+          token,
+          '/search',
+          {
+            query: `type:ticket ${query}`,
+            include: 'tickets(slas)',
+            ...buildOffsetParams(per_page, page),
+          },
+        );
+        // The `slas` sideload is nested on each result (no top-level array, no
+        // ticket_id correlation) — read it straight off the ticket.
         const formatTicketWithSla = (ticket: ZendeskTicket): string =>
-          formatTicket(ticket) + formatSlaBlock(findSlaForTicket(response.slas, ticket.id));
+          formatTicket(ticket) + formatSlaBlock(ticket.slas);
         return {
           content: [
             {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,10 @@ export interface ZendeskTicket {
   created_at: string;
   updated_at: string;
   custom_fields: Array<{ id: number; value: unknown }>;
+  // Live SLA state, present only on Search results fetched with
+  // `include=tickets(slas)` (nested per result). Absent on the Show Ticket
+  // endpoint — Zendesk silently ignores `include=slas` there (see #92).
+  slas?: ZendeskSlaSideloadEntry;
 }
 
 // GET /api/v2/slas/policies.json — a configured SLA policy with its filter
@@ -43,38 +47,19 @@ export interface ZendeskSlaPolicy {
   url?: string;
 }
 
-// Live per-ticket SLA state, returned as a top-level `slas` sideload when a
-// ticket is fetched with `?include=slas` (or `?include=tickets(slas)` in search).
-// The exact field names of this sideload are not crisply documented, so the
-// volatile fields are optional and the formatter reads them defensively
-// (`stage ?? status`, `breach_at ?? due_at`, `business ?? business_hours`).
+// Live per-ticket SLA state, nested on each ticket result of a Search fetched
+// with `include=tickets(slas)` (verified against the live API, see #92). It
+// carries only the live metrics: no `ticket_id` (correlation is by nesting),
+// no policy identity and no target (those live in `/slas/policies`, surfaced
+// by `list_sla_policies`).
 export interface ZendeskSlaLiveMetric {
   metric: string;
-  stage?: string;
-  status?: string;
-  target?: number;
-  business?: boolean;
-  business_hours?: boolean;
+  stage?: string; // active | paused | achieved | fulfilled | breached | ...
   breach_at?: string | null;
-  due_at?: string | null;
-}
-
-// Nested applied-policy object. Zendesk consistently exposes the applied policy
-// as `policy: { id, title, description }` (e.g. the `sla` object on ticket
-// metric events), so the sideload is read that way first, with flat
-// `policy_id` / `title` kept as a fallback.
-export interface ZendeskSlaPolicyRef {
-  id?: number;
-  title?: string;
-  description?: string | null;
+  days?: number; // whole days to breach, when Zendesk includes it
 }
 
 export interface ZendeskSlaSideloadEntry {
-  ticket_id?: number;
-  policy?: ZendeskSlaPolicyRef;
-  policy_id?: number;
-  title?: string;
-  description?: string | null;
   policy_metrics: ZendeskSlaLiveMetric[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface ZendeskSlaPolicyMetric {
   priority: string;
   metric: string;
   target: number;
+  target_in_seconds?: number;
   business_hours: boolean;
 }
 
@@ -39,6 +40,7 @@ export interface ZendeskSlaPolicy {
   policy_metrics: ZendeskSlaPolicyMetric[];
   created_at: string;
   updated_at: string;
+  url?: string;
 }
 
 // Live per-ticket SLA state, returned as a top-level `slas` sideload when a

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,8 +59,19 @@ export interface ZendeskSlaLiveMetric {
   due_at?: string | null;
 }
 
+// Nested applied-policy object. Zendesk consistently exposes the applied policy
+// as `policy: { id, title, description }` (e.g. the `sla` object on ticket
+// metric events), so the sideload is read that way first, with flat
+// `policy_id` / `title` kept as a fallback.
+export interface ZendeskSlaPolicyRef {
+  id?: number;
+  title?: string;
+  description?: string | null;
+}
+
 export interface ZendeskSlaSideloadEntry {
   ticket_id?: number;
+  policy?: ZendeskSlaPolicyRef;
   policy_id?: number;
   title?: string;
   description?: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,56 @@ export interface ZendeskTicket {
   custom_fields: Array<{ id: number; value: unknown }>;
 }
 
+// GET /api/v2/slas/policies.json — a configured SLA policy with its filter
+// conditions and per-priority reply/resolution targets.
+export interface ZendeskSlaCondition {
+  field: string;
+  operator: string;
+  value: unknown;
+}
+
+export interface ZendeskSlaPolicyMetric {
+  priority: string;
+  metric: string;
+  target: number;
+  business_hours: boolean;
+}
+
+export interface ZendeskSlaPolicy {
+  id: number;
+  title: string;
+  description: string | null;
+  position: number;
+  filter: { all: ZendeskSlaCondition[]; any: ZendeskSlaCondition[] };
+  policy_metrics: ZendeskSlaPolicyMetric[];
+  created_at: string;
+  updated_at: string;
+}
+
+// Live per-ticket SLA state, returned as a top-level `slas` sideload when a
+// ticket is fetched with `?include=slas` (or `?include=tickets(slas)` in search).
+// The exact field names of this sideload are not crisply documented, so the
+// volatile fields are optional and the formatter reads them defensively
+// (`stage ?? status`, `breach_at ?? due_at`, `business ?? business_hours`).
+export interface ZendeskSlaLiveMetric {
+  metric: string;
+  stage?: string;
+  status?: string;
+  target?: number;
+  business?: boolean;
+  business_hours?: boolean;
+  breach_at?: string | null;
+  due_at?: string | null;
+}
+
+export interface ZendeskSlaSideloadEntry {
+  ticket_id?: number;
+  policy_id?: number;
+  title?: string;
+  description?: string | null;
+  policy_metrics: ZendeskSlaLiveMetric[];
+}
+
 export interface ZendeskTicketAttachment {
   id: number;
   file_name: string;
@@ -170,6 +220,7 @@ export interface ZendeskListResponse<T> {
   comments?: T[];
   translations?: T[];
   permission_groups?: T[];
+  sla_policies?: T[];
   meta?: {
     has_more: boolean;
     after_cursor: string;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -10,6 +10,9 @@ import type {
   ZendeskOrganization,
   ZendeskPermissionGroup,
   ZendeskSection,
+  ZendeskSlaLiveMetric,
+  ZendeskSlaPolicy,
+  ZendeskSlaSideloadEntry,
   ZendeskTicket,
   ZendeskTranslation,
   ZendeskUser,
@@ -40,6 +43,82 @@ export const formatTicket = (ticket: ZendeskTicket): string =>
   ]
     .filter(Boolean)
     .join('\n');
+
+const formatConditionValue = (value: unknown): string =>
+  value === null || value === undefined
+    ? ''
+    : typeof value === 'object'
+      ? JSON.stringify(value)
+      : String(value);
+
+export const formatSlaPolicy = (policy: ZendeskSlaPolicy): string => {
+  const conditions = [
+    ...policy.filter.all.map((c) =>
+      `all: ${c.field} ${c.operator} ${formatConditionValue(c.value)}`.trim(),
+    ),
+    ...policy.filter.any.map((c) =>
+      `any: ${c.field} ${c.operator} ${formatConditionValue(c.value)}`.trim(),
+    ),
+  ];
+  const targets = policy.policy_metrics.map(
+    (m) =>
+      `  - ${m.priority} / ${m.metric}: ${m.target} min${m.business_hours ? ' (business)' : ''}`,
+  );
+  return [
+    `## SLA policy: ${policy.title} (${policy.id})`,
+    policy.description ? `- **Description**: ${policy.description}` : '',
+    `- **Position**: ${policy.position}`,
+    conditions.length > 0 ? `- **Conditions**: ${conditions.join('; ')}` : '',
+    targets.length > 0 ? '- **Targets**:' : '',
+    ...targets,
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+const minutesUntil = (iso: string): number | null => {
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : Math.round((t - Date.now()) / 60_000);
+};
+
+const formatSlaMetric = (m: ZendeskSlaLiveMetric): string => {
+  const stage = m.stage ?? m.status ?? 'unknown';
+  const due = m.breach_at ?? m.due_at ?? null;
+  const business = m.business ?? m.business_hours ?? false;
+  const parts = [`- **${m.metric}** — ${stage}`];
+  if (m.target != null) parts.push(`target ${m.target} min${business ? ' (business)' : ''}`);
+  if (due) {
+    const remaining = minutesUntil(due);
+    if (stage === 'paused' || stage === 'achieved' || stage === 'fulfilled' || remaining == null) {
+      parts.push(`due ${due}`);
+    } else if (remaining < 0) {
+      parts.push(`due ${due} — breached (${Math.abs(remaining)} min overdue)`);
+    } else {
+      parts.push(`due ${due} — ${remaining} min remaining`);
+    }
+  }
+  return parts.join('; ');
+};
+
+// SLA block appended after a formatted ticket. Returns '' when no policy
+// applies, so it is safe to concatenate unconditionally (incl. in search rows).
+export const formatSlaBlock = (entry: ZendeskSlaSideloadEntry | undefined): string => {
+  if (!entry?.policy_metrics || entry.policy_metrics.length === 0) return '';
+  const lines = ['### SLA'];
+  if (entry.title || entry.policy_id != null) {
+    const id = entry.policy_id != null ? ` (${entry.policy_id})` : '';
+    lines.push(`- **Policy**: ${entry.title ?? 'unknown'}${id}`);
+  }
+  const futureBreaches = entry.policy_metrics
+    .map((m) => m.breach_at ?? m.due_at)
+    .map((d) => (d ? Date.parse(d) : Number.NaN))
+    .filter((t) => !Number.isNaN(t) && t > Date.now());
+  if (futureBreaches.length > 0) {
+    lines.push(`- **Next breach**: ${new Date(Math.min(...futureBreaches)).toISOString()}`);
+  }
+  for (const m of entry.policy_metrics) lines.push(formatSlaMetric(m));
+  return `\n\n${lines.join('\n')}`;
+};
 
 export const formatComment = (comment: ZendeskComment): string => {
   const lines = [

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -82,11 +82,9 @@ const minutesUntil = (iso: string): number | null => {
 };
 
 const formatSlaMetric = (m: ZendeskSlaLiveMetric): string => {
-  const stage = m.stage ?? m.status ?? 'unknown';
-  const due = m.breach_at ?? m.due_at ?? null;
-  const business = m.business_hours ?? m.business ?? false;
+  const stage = m.stage ?? 'unknown';
+  const due = m.breach_at ?? null;
   const parts = [`- **${m.metric}** — ${stage}`];
-  if (m.target != null) parts.push(`target ${m.target} min${business ? ' (business)' : ''}`);
   if (due) {
     const remaining = minutesUntil(due);
     if (stage === 'paused' || stage === 'achieved' || stage === 'fulfilled' || remaining == null) {
@@ -100,19 +98,16 @@ const formatSlaMetric = (m: ZendeskSlaLiveMetric): string => {
   return parts.join('; ');
 };
 
-// SLA block appended after a formatted ticket. Returns '' when no policy
-// applies, so it is safe to concatenate unconditionally (incl. in search rows).
+// Live SLA block appended after a formatted ticket. Renders only the state the
+// Search `slas` sideload actually carries (per-metric stage + breach countdown)
+// — targets and policy identity are not on the wire (see `list_sla_policies`).
+// Returns '' when no policy applies, so it is safe to concatenate
+// unconditionally (incl. in search rows).
 export const formatSlaBlock = (entry: ZendeskSlaSideloadEntry | undefined): string => {
   if (!entry?.policy_metrics || entry.policy_metrics.length === 0) return '';
   const lines = ['### SLA'];
-  const policyTitle = entry.policy?.title ?? entry.title;
-  const policyId = entry.policy?.id ?? entry.policy_id;
-  if (policyTitle || policyId != null) {
-    const id = policyId != null ? ` (${policyId})` : '';
-    lines.push(`- **Policy**: ${policyTitle ?? 'unknown'}${id}`);
-  }
   const futureBreaches = entry.policy_metrics
-    .map((m) => m.breach_at ?? m.due_at)
+    .map((m) => m.breach_at)
     .map((d) => (d ? Date.parse(d) : Number.NaN))
     .filter((t) => !Number.isNaN(t) && t > Date.now());
   if (futureBreaches.length > 0) {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -84,7 +84,7 @@ const minutesUntil = (iso: string): number | null => {
 const formatSlaMetric = (m: ZendeskSlaLiveMetric): string => {
   const stage = m.stage ?? m.status ?? 'unknown';
   const due = m.breach_at ?? m.due_at ?? null;
-  const business = m.business ?? m.business_hours ?? false;
+  const business = m.business_hours ?? m.business ?? false;
   const parts = [`- **${m.metric}** — ${stage}`];
   if (m.target != null) parts.push(`target ${m.target} min${business ? ' (business)' : ''}`);
   if (due) {
@@ -105,9 +105,11 @@ const formatSlaMetric = (m: ZendeskSlaLiveMetric): string => {
 export const formatSlaBlock = (entry: ZendeskSlaSideloadEntry | undefined): string => {
   if (!entry?.policy_metrics || entry.policy_metrics.length === 0) return '';
   const lines = ['### SLA'];
-  if (entry.title || entry.policy_id != null) {
-    const id = entry.policy_id != null ? ` (${entry.policy_id})` : '';
-    lines.push(`- **Policy**: ${entry.title ?? 'unknown'}${id}`);
+  const policyTitle = entry.policy?.title ?? entry.title;
+  const policyId = entry.policy?.id ?? entry.policy_id;
+  if (policyTitle || policyId != null) {
+    const id = policyId != null ? ` (${policyId})` : '';
+    lines.push(`- **Policy**: ${policyTitle ?? 'unknown'}${id}`);
   }
   const futureBreaches = entry.policy_metrics
     .map((m) => m.breach_at ?? m.due_at)

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -88,6 +88,17 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(names).toContain('get_current_user');
         expect(names).toContain('get_ticket');
         expect(names).toContain('create_ticket');
+        expect(names).toContain('list_sla_policies');
+      });
+
+      it('reaches list_sla_policies over the wire and returns the policy matrix', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'list_sla_policies',
+          arguments: {},
+        });
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('SLA contractuels fruggr - Bugs/Incidents');
       });
 
       it('exposes one proxy per namespace in "namespace" mode', async () => {

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -56,30 +56,14 @@ export const MOCK_SLA_POLICY = {
   url: 'https://testsubdomain.zendesk.com/api/v2/slas/policies/123',
 };
 
-// Live per-ticket SLA sideload (`?include=slas`). One achieved metric and one
-// active metric whose breach is far in the future so "remaining" stays positive.
+// Live per-ticket SLA, nested on each Search result (`include=tickets(slas)`).
+// Mirrors the real shape (see #92): only live metrics — no ticket_id, no policy
+// identity, no target. One achieved metric and one active metric whose breach is
+// far in the future so "remaining" stays positive.
 export const MOCK_SLA_SIDELOAD = {
-  ticket_id: 1,
-  policy: {
-    id: 123,
-    title: 'SLA contractuels fruggr - Bugs/Incidents',
-    description: 'Contractual SLA for bugs and incidents',
-  },
   policy_metrics: [
-    {
-      metric: 'first_reply_time',
-      stage: 'achieved',
-      target: 420,
-      business_hours: false,
-      breach_at: '2026-01-01T07:00:00Z',
-    },
-    {
-      metric: 'requester_wait_time',
-      stage: 'active',
-      target: 4200,
-      business_hours: false,
-      breach_at: '2099-06-18T21:37:00Z',
-    },
+    { metric: 'first_reply_time', stage: 'achieved', breach_at: '2026-01-01T07:00:00Z' },
+    { metric: 'requester_wait_time', stage: 'active', breach_at: '2099-06-18T21:37:00Z', days: 12 },
   ],
 };
 
@@ -281,15 +265,12 @@ export const manyCategoriesHandler = http.get(`${HC_BASE}/categories`, () =>
 
 export const handlers = [
   // Tickets
-  http.get(`${BASE}/tickets/:id`, ({ params, request }) => {
+  http.get(`${BASE}/tickets/:id`, ({ params }) => {
     if (params['id'] === '404') return HttpResponse.json({}, { status: 404 });
     const id = Number(params['id']);
-    const ticket = { ...MOCK_TICKET, id };
-    const include = new URL(request.url).searchParams.get('include') ?? '';
-    if (include.includes('slas')) {
-      return HttpResponse.json({ ticket, slas: [{ ...MOCK_SLA_SIDELOAD, ticket_id: id }] });
-    }
-    return HttpResponse.json({ ticket });
+    // The Show Ticket endpoint does not expose SLA (Zendesk ignores
+    // `include=slas` there, see #92), so no `slas` is ever returned here.
+    return HttpResponse.json({ ticket: { ...MOCK_TICKET, id } });
   }),
   http.get(`${BASE}/tickets/:id/comments`, () => HttpResponse.json({ comments: [MOCK_COMMENT] })),
   http.get(`${BASE}/attachments/:id`, ({ params }) => {
@@ -345,12 +326,10 @@ export const handlers = [
     const query = url.searchParams.get('query') ?? '';
     const withSla = (url.searchParams.get('include') ?? '').includes('slas');
     if (query.includes('type:ticket')) {
-      const body: Record<string, unknown> = {
-        results: [{ ...MOCK_TICKET, result_type: 'ticket' }],
-        count: 1,
-      };
-      if (withSla) body['slas'] = [{ ...MOCK_SLA_SIDELOAD, ticket_id: MOCK_TICKET.id }];
-      return HttpResponse.json(body);
+      // `slas` is nested on each result, not a top-level array (see #92).
+      const ticket: Record<string, unknown> = { ...MOCK_TICKET, result_type: 'ticket' };
+      if (withSla) ticket['slas'] = MOCK_SLA_SIDELOAD;
+      return HttpResponse.json({ results: [ticket], count: 1 });
     }
     if (query.includes('type:user')) {
       return HttpResponse.json({ results: [{ ...MOCK_USER, result_type: 'user' }], count: 1 });

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -60,22 +60,24 @@ export const MOCK_SLA_POLICY = {
 // active metric whose breach is far in the future so "remaining" stays positive.
 export const MOCK_SLA_SIDELOAD = {
   ticket_id: 1,
-  policy_id: 123,
-  title: 'SLA contractuels fruggr - Bugs/Incidents',
-  description: 'Contractual SLA for bugs and incidents',
+  policy: {
+    id: 123,
+    title: 'SLA contractuels fruggr - Bugs/Incidents',
+    description: 'Contractual SLA for bugs and incidents',
+  },
   policy_metrics: [
     {
       metric: 'first_reply_time',
       stage: 'achieved',
       target: 420,
-      business: false,
+      business_hours: false,
       breach_at: '2026-01-01T07:00:00Z',
     },
     {
       metric: 'requester_wait_time',
       stage: 'active',
       target: 4200,
-      business: false,
+      business_hours: false,
       breach_at: '2099-06-18T21:37:00Z',
     },
   ],

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -20,6 +20,48 @@ export const MOCK_TICKET = {
   custom_fields: [],
 };
 
+export const MOCK_SLA_POLICY = {
+  id: 123,
+  title: 'SLA contractuels fruggr - Bugs/Incidents',
+  description: 'Contractual SLA for bugs and incidents',
+  position: 1,
+  filter: {
+    all: [{ field: 'type', operator: 'is', value: 'incident' }],
+    any: [],
+  },
+  policy_metrics: [
+    { priority: 'high', metric: 'first_reply_time', target: 420, business_hours: false },
+    { priority: 'high', metric: 'requester_wait_time', target: 4200, business_hours: false },
+  ],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+};
+
+// Live per-ticket SLA sideload (`?include=slas`). One achieved metric and one
+// active metric whose breach is far in the future so "remaining" stays positive.
+export const MOCK_SLA_SIDELOAD = {
+  ticket_id: 1,
+  policy_id: 123,
+  title: 'SLA contractuels fruggr - Bugs/Incidents',
+  description: 'Contractual SLA for bugs and incidents',
+  policy_metrics: [
+    {
+      metric: 'first_reply_time',
+      stage: 'achieved',
+      target: 420,
+      business: false,
+      breach_at: '2026-01-01T07:00:00Z',
+    },
+    {
+      metric: 'requester_wait_time',
+      stage: 'active',
+      target: 4200,
+      business: false,
+      breach_at: '2099-06-18T21:37:00Z',
+    },
+  ],
+};
+
 export const MOCK_USER = {
   id: 9999,
   name: 'Test User',
@@ -218,9 +260,15 @@ export const manyCategoriesHandler = http.get(`${HC_BASE}/categories`, () =>
 
 export const handlers = [
   // Tickets
-  http.get(`${BASE}/tickets/:id`, ({ params }) => {
+  http.get(`${BASE}/tickets/:id`, ({ params, request }) => {
     if (params['id'] === '404') return HttpResponse.json({}, { status: 404 });
-    return HttpResponse.json({ ticket: { ...MOCK_TICKET, id: Number(params['id']) } });
+    const id = Number(params['id']);
+    const ticket = { ...MOCK_TICKET, id };
+    const include = new URL(request.url).searchParams.get('include') ?? '';
+    if (include.includes('slas')) {
+      return HttpResponse.json({ ticket, slas: [{ ...MOCK_SLA_SIDELOAD, ticket_id: id }] });
+    }
+    return HttpResponse.json({ ticket });
   }),
   http.get(`${BASE}/tickets/:id/comments`, () => HttpResponse.json({ comments: [MOCK_COMMENT] })),
   http.get(`${BASE}/attachments/:id`, ({ params }) => {
@@ -266,12 +314,23 @@ export const handlers = [
     HttpResponse.json({ ticket: { ...MOCK_TICKET, id: Number(params['id']), status: 'solved' } }),
   ),
 
+  // SLA policies
+  http.get(`${BASE}/slas/policies`, () =>
+    HttpResponse.json({ sla_policies: [MOCK_SLA_POLICY], count: 1 }),
+  ),
+
   // Search
   http.get(`${BASE}/search`, ({ request }) => {
     const url = new URL(request.url);
     const query = url.searchParams.get('query') ?? '';
+    const withSla = (url.searchParams.get('include') ?? '').includes('slas');
     if (query.includes('type:ticket')) {
-      return HttpResponse.json({ results: [{ ...MOCK_TICKET, result_type: 'ticket' }], count: 1 });
+      const body: Record<string, unknown> = {
+        results: [{ ...MOCK_TICKET, result_type: 'ticket' }],
+        count: 1,
+      };
+      if (withSla) body['slas'] = [{ ...MOCK_SLA_SIDELOAD, ticket_id: MOCK_TICKET.id }];
+      return HttpResponse.json(body);
     }
     if (query.includes('type:user')) {
       return HttpResponse.json({ results: [{ ...MOCK_USER, result_type: 'user' }], count: 1 });

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -20,21 +20,40 @@ export const MOCK_TICKET = {
   custom_fields: [],
 };
 
+// Shape mirrors the official SLA Policies API reference: condition values can be
+// arrays (e.g. `includes`), policy_metrics carry target_in_seconds, and the
+// record has a `url`. The resolution metric is `total_resolution_time`.
 export const MOCK_SLA_POLICY = {
   id: 123,
   title: 'SLA contractuels fruggr - Bugs/Incidents',
   description: 'Contractual SLA for bugs and incidents',
   position: 1,
   filter: {
-    all: [{ field: 'type', operator: 'is', value: 'incident' }],
+    all: [
+      { field: 'type', operator: 'is', value: 'incident' },
+      { field: 'custom_status_id', operator: 'includes', value: ['1', '2'] },
+    ],
     any: [],
   },
   policy_metrics: [
-    { priority: 'high', metric: 'first_reply_time', target: 420, business_hours: false },
-    { priority: 'high', metric: 'requester_wait_time', target: 4200, business_hours: false },
+    {
+      priority: 'high',
+      metric: 'first_reply_time',
+      target: 420,
+      target_in_seconds: 25200,
+      business_hours: false,
+    },
+    {
+      priority: 'high',
+      metric: 'total_resolution_time',
+      target: 4200,
+      target_in_seconds: 252000,
+      business_hours: false,
+    },
   ],
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-02T00:00:00Z',
+  url: 'https://testsubdomain.zendesk.com/api/v2/slas/policies/123',
 };
 
 // Live per-ticket SLA sideload (`?include=slas`). One achieved metric and one
@@ -314,10 +333,9 @@ export const handlers = [
     HttpResponse.json({ ticket: { ...MOCK_TICKET, id: Number(params['id']), status: 'solved' } }),
   ),
 
-  // SLA policies
-  http.get(`${BASE}/slas/policies`, () =>
-    HttpResponse.json({ sla_policies: [MOCK_SLA_POLICY], count: 1 }),
-  ),
+  // SLA policies — the real endpoint returns the full config list with no
+  // `count` wrapper, so omit it here to exercise the array-length fallback.
+  http.get(`${BASE}/slas/policies`, () => HttpResponse.json({ sla_policies: [MOCK_SLA_POLICY] })),
 
   // Search
   http.get(`${BASE}/search`, ({ request }) => {

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -61,7 +61,7 @@ describe('groupByNamespace', () => {
     const ticketCount = grouped.get('tickets')?.length ?? 0;
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
-    expect(ticketCount).toBe(11); // 10 ticket tools + 1 search
+    expect(ticketCount).toBe(12); // 11 ticket tools + 1 search
     expect(hcCount).toBe(21);
     expect(userCount).toBe(5);
   });

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -2,6 +2,7 @@ import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createTicketTools } from '../../../src/tools/tickets';
+import { MOCK_SLA_SIDELOAD, MOCK_TICKET } from '../../msw-handlers';
 import { mswServer } from '../../setup';
 
 const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
@@ -33,10 +34,41 @@ describe('ticket tools', () => {
       expect(result.content[0]?.text).toContain('Test ticket');
     });
 
-    it('does not surface an SLA block (not exposed on the Show Ticket endpoint)', async () => {
+    it('surfaces live SLA state resolved via the scoped search fallback', async () => {
       const tool = findTool('get_ticket');
       const result = await tool.handler({ ticket_id: 1, include_comments: false });
-      expect(result.content[0]?.text).not.toContain('### SLA');
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('### SLA');
+      expect(text).toContain('requester_wait_time');
+      expect(text).toContain('remaining');
+    });
+
+    it('omits the SLA block when the ticket is not in the fallback search window', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/search', () =>
+          // A result for a *different* ticket id — correlation must not match.
+          HttpResponse.json({ results: [{ ...MOCK_TICKET, id: 999, slas: MOCK_SLA_SIDELOAD }] }),
+        ),
+      );
+      const tool = findTool('get_ticket');
+      const result = await tool.handler({ ticket_id: 1, include_comments: false });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('Ticket #1');
+      expect(text).not.toContain('### SLA');
+    });
+
+    it('still returns the ticket when the SLA fallback search errors', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/search', () =>
+          HttpResponse.json({}, { status: 500 }),
+        ),
+      );
+      const tool = findTool('get_ticket');
+      const result = await tool.handler({ ticket_id: 1, include_comments: false });
+      const text = result.content[0]?.text ?? '';
+      expect(result.isError).toBeFalsy();
+      expect(text).toContain('Ticket #1');
+      expect(text).not.toContain('### SLA');
     });
 
     it('includes comments when requested', async () => {

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -33,45 +33,10 @@ describe('ticket tools', () => {
       expect(result.content[0]?.text).toContain('Test ticket');
     });
 
-    it('includes the live SLA state when a policy applies', async () => {
+    it('does not surface an SLA block (not exposed on the Show Ticket endpoint)', async () => {
       const tool = findTool('get_ticket');
       const result = await tool.handler({ ticket_id: 1, include_comments: false });
-      const text = result.content[0]?.text ?? '';
-      expect(text).toContain('### SLA');
-      expect(text).toContain('SLA contractuels fruggr - Bugs/Incidents');
-      expect(text).toContain('requester_wait_time');
-      expect(text).toContain('remaining');
-    });
-
-    it('shows no SLA block when no policy applies', async () => {
-      mswServer.use(
-        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id', ({ params }) =>
-          HttpResponse.json({
-            ticket: {
-              id: Number(params['id']),
-              subject: 'No SLA ticket',
-              description: '',
-              status: 'open',
-              priority: 'low',
-              type: 'question',
-              assignee_id: null,
-              requester_id: 1,
-              group_id: null,
-              organization_id: null,
-              tags: [],
-              created_at: '2026-01-01T00:00:00Z',
-              updated_at: '2026-01-02T00:00:00Z',
-              custom_fields: [],
-            },
-            slas: [],
-          }),
-        ),
-      );
-      const tool = findTool('get_ticket');
-      const result = await tool.handler({ ticket_id: 7, include_comments: false });
-      const text = result.content[0]?.text ?? '';
-      expect(text).toContain('No SLA ticket');
-      expect(text).not.toContain('### SLA');
+      expect(result.content[0]?.text).not.toContain('### SLA');
     });
 
     it('includes comments when requested', async () => {

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -20,9 +20,9 @@ const getAllText = (result: { content: Array<{ type: string; text?: string }> })
     .join('\n');
 
 describe('ticket tools', () => {
-  it('creates 10 tools (10 tickets + 1 search elsewhere)', () => {
+  it('creates 11 tools (search_tickets lives here; the unified search is elsewhere)', () => {
     const tools = createTicketTools(ctx);
-    expect(tools).toHaveLength(10);
+    expect(tools).toHaveLength(11);
   });
 
   describe('get_ticket', () => {
@@ -31,6 +31,47 @@ describe('ticket tools', () => {
       const result = await tool.handler({ ticket_id: 1, include_comments: false });
       expect(result.content[0]?.text).toContain('Ticket #1');
       expect(result.content[0]?.text).toContain('Test ticket');
+    });
+
+    it('includes the live SLA state when a policy applies', async () => {
+      const tool = findTool('get_ticket');
+      const result = await tool.handler({ ticket_id: 1, include_comments: false });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('### SLA');
+      expect(text).toContain('SLA contractuels fruggr - Bugs/Incidents');
+      expect(text).toContain('requester_wait_time');
+      expect(text).toContain('remaining');
+    });
+
+    it('shows no SLA block when no policy applies', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id', ({ params }) =>
+          HttpResponse.json({
+            ticket: {
+              id: Number(params['id']),
+              subject: 'No SLA ticket',
+              description: '',
+              status: 'open',
+              priority: 'low',
+              type: 'question',
+              assignee_id: null,
+              requester_id: 1,
+              group_id: null,
+              organization_id: null,
+              tags: [],
+              created_at: '2026-01-01T00:00:00Z',
+              updated_at: '2026-01-02T00:00:00Z',
+              custom_fields: [],
+            },
+            slas: [],
+          }),
+        ),
+      );
+      const tool = findTool('get_ticket');
+      const result = await tool.handler({ ticket_id: 7, include_comments: false });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('No SLA ticket');
+      expect(text).not.toContain('### SLA');
     });
 
     it('includes comments when requested', async () => {
@@ -369,6 +410,32 @@ describe('ticket tools', () => {
       const tool = findTool('search_tickets');
       const result = await tool.handler({ query: 'status:open', per_page: 100, page: 1 });
       expect(result.content[0]?.text).toContain('Test ticket');
+    });
+
+    it('surfaces per-result SLA state for queue triage', async () => {
+      const tool = findTool('search_tickets');
+      const result = await tool.handler({ query: 'status:open', per_page: 100, page: 1 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('### SLA');
+      expect(text).toContain('requester_wait_time');
+    });
+  });
+
+  describe('list_sla_policies', () => {
+    it('returns the policy matrix with conditions and targets', async () => {
+      const tool = findTool('list_sla_policies');
+      const result = await tool.handler({ per_page: 100, page: 1 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('SLA contractuels fruggr - Bugs/Incidents');
+      expect(text).toContain('first_reply_time');
+      expect(text).toContain('420 min');
+      expect(text).toContain('type is incident');
+    });
+
+    it('has readOnly annotation', () => {
+      const tool = findTool('list_sla_policies');
+      expect(tool.readOnly).toBe(true);
+      expect(tool.annotations.readOnlyHint).toBe(true);
     });
   });
 

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -434,6 +434,23 @@ describe('ticket tools', () => {
       expect(tool.readOnly).toBe(true);
       expect(tool.annotations.readOnlyHint).toBe(true);
     });
+
+    it('explains the admin-only requirement (and the alternative) on a 403', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/slas/policies', () =>
+          HttpResponse.json({ error: 'Forbidden' }, { status: 403 }),
+        ),
+      );
+      const tool = findTool('list_sla_policies');
+      const error = await tool.handler({ per_page: 100, page: 1 }).then(
+        () => {
+          throw new Error('expected list_sla_policies to reject on 403');
+        },
+        (err: unknown) => err as Error,
+      );
+      expect(error.message).toMatch(/admin/i);
+      expect(error.message).toMatch(/get_ticket|search_tickets/);
+    });
   });
 
   describe('create_ticket', () => {

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -89,6 +89,15 @@ describe('formatSlaBlock', () => {
     expect(formatSlaBlock(entry([]))).toBe('');
   });
 
+  it('reads the applied policy from a nested policy object', () => {
+    const result = formatSlaBlock({
+      ticket_id: 1,
+      policy: { id: 531, title: 'Main Policy', description: 'x' },
+      policy_metrics: [{ metric: 'first_reply_time', stage: 'achieved', target: 60 }],
+    } as never);
+    expect(result).toContain('**Policy**: Main Policy (531)');
+  });
+
   it('shows minutes remaining for an active metric with a future breach', () => {
     const future = new Date(Date.now() + 60 * 60_000).toISOString();
     const result = formatSlaBlock(

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -81,27 +81,17 @@ describe('formatSlaPolicy', () => {
 });
 
 describe('formatSlaBlock', () => {
-  const entry = (metrics: unknown[]) =>
-    ({ ticket_id: 1, policy_id: 123, title: 'P', policy_metrics: metrics }) as never;
+  const entry = (metrics: unknown[]) => ({ policy_metrics: metrics }) as never;
 
   it('returns an empty string when no SLA applies', () => {
     expect(formatSlaBlock(undefined)).toBe('');
     expect(formatSlaBlock(entry([]))).toBe('');
   });
 
-  it('reads the applied policy from a nested policy object', () => {
-    const result = formatSlaBlock({
-      ticket_id: 1,
-      policy: { id: 531, title: 'Main Policy', description: 'x' },
-      policy_metrics: [{ metric: 'first_reply_time', stage: 'achieved', target: 60 }],
-    } as never);
-    expect(result).toContain('**Policy**: Main Policy (531)');
-  });
-
   it('shows minutes remaining for an active metric with a future breach', () => {
     const future = new Date(Date.now() + 60 * 60_000).toISOString();
     const result = formatSlaBlock(
-      entry([{ metric: 'requester_wait_time', stage: 'active', target: 4200, breach_at: future }]),
+      entry([{ metric: 'requester_wait_time', stage: 'active', breach_at: future }]),
     );
     expect(result).toContain('### SLA');
     expect(result).toContain('Next breach');
@@ -111,7 +101,7 @@ describe('formatSlaBlock', () => {
   it('flags a breached metric as overdue instead of a negative countdown', () => {
     const past = new Date(Date.now() - 60 * 60_000).toISOString();
     const result = formatSlaBlock(
-      entry([{ metric: 'first_reply_time', stage: 'active', target: 420, breach_at: past }]),
+      entry([{ metric: 'first_reply_time', stage: 'active', breach_at: past }]),
     );
     expect(result).toContain('breached');
     expect(result).toContain('overdue');
@@ -122,36 +112,16 @@ describe('formatSlaBlock', () => {
     const future = new Date(Date.now() + 60 * 60_000).toISOString();
     const result = formatSlaBlock(
       entry([
-        { metric: 'agent_work_time', stage: 'paused', target: 100, breach_at: future },
-        { metric: 'first_reply_time', stage: 'achieved', target: 420, breach_at: future },
+        { metric: 'agent_work_time', stage: 'paused', breach_at: future },
+        { metric: 'first_reply_time', stage: 'achieved', breach_at: future },
       ]),
     );
     expect(result).not.toContain('remaining');
   });
 
-  it('reads the alternate field names defensively (status/due_at/business_hours)', () => {
-    const future = new Date(Date.now() + 60 * 60_000).toISOString();
-    const result = formatSlaBlock(
-      entry([
-        {
-          metric: 'next_reply_time',
-          status: 'active',
-          target: 60,
-          business_hours: true,
-          due_at: future,
-        },
-      ]),
-    );
-    expect(result).toContain('next_reply_time');
-    expect(result).toContain('(business)');
-    expect(result).toContain('min remaining');
-  });
-
   it('tolerates an unparseable timestamp without crashing', () => {
     const result = formatSlaBlock(
-      entry([
-        { metric: 'first_reply_time', stage: 'active', target: 420, breach_at: 'not-a-date' },
-      ]),
+      entry([{ metric: 'first_reply_time', stage: 'active', breach_at: 'not-a-date' }]),
     );
     expect(result).toContain('first_reply_time');
     expect(result).not.toContain('remaining');

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -71,6 +71,12 @@ describe('formatSlaPolicy', () => {
     expect(result).toContain('(123)');
     expect(result).toContain('type is incident');
     expect(result).toContain('high / first_reply_time: 420 min');
+    expect(result).toContain('high / total_resolution_time: 4200 min');
+  });
+
+  it('renders array-valued filter conditions (e.g. includes)', () => {
+    const result = formatSlaPolicy(MOCK_SLA_POLICY);
+    expect(result).toContain('custom_status_id includes ["1","2"]');
   });
 });
 

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -7,6 +7,8 @@ import {
   formatList,
   formatOrganization,
   formatSection,
+  formatSlaBlock,
+  formatSlaPolicy,
   formatTicket,
   formatTranslation,
   formatTranslationSummary,
@@ -19,6 +21,7 @@ import {
   MOCK_COMMENT,
   MOCK_ORGANIZATION,
   MOCK_SECTION,
+  MOCK_SLA_POLICY,
   MOCK_TICKET,
   MOCK_TRANSLATION,
   MOCK_USER,
@@ -58,6 +61,85 @@ describe('formatTicket', () => {
   it('handles missing priority', () => {
     const result = formatTicket({ ...MOCK_TICKET, priority: null });
     expect(result).toContain('none');
+  });
+});
+
+describe('formatSlaPolicy', () => {
+  it('includes title, conditions and per-priority targets', () => {
+    const result = formatSlaPolicy(MOCK_SLA_POLICY);
+    expect(result).toContain('SLA contractuels fruggr - Bugs/Incidents');
+    expect(result).toContain('(123)');
+    expect(result).toContain('type is incident');
+    expect(result).toContain('high / first_reply_time: 420 min');
+  });
+});
+
+describe('formatSlaBlock', () => {
+  const entry = (metrics: unknown[]) =>
+    ({ ticket_id: 1, policy_id: 123, title: 'P', policy_metrics: metrics }) as never;
+
+  it('returns an empty string when no SLA applies', () => {
+    expect(formatSlaBlock(undefined)).toBe('');
+    expect(formatSlaBlock(entry([]))).toBe('');
+  });
+
+  it('shows minutes remaining for an active metric with a future breach', () => {
+    const future = new Date(Date.now() + 60 * 60_000).toISOString();
+    const result = formatSlaBlock(
+      entry([{ metric: 'requester_wait_time', stage: 'active', target: 4200, breach_at: future }]),
+    );
+    expect(result).toContain('### SLA');
+    expect(result).toContain('Next breach');
+    expect(result).toContain('min remaining');
+  });
+
+  it('flags a breached metric as overdue instead of a negative countdown', () => {
+    const past = new Date(Date.now() - 60 * 60_000).toISOString();
+    const result = formatSlaBlock(
+      entry([{ metric: 'first_reply_time', stage: 'active', target: 420, breach_at: past }]),
+    );
+    expect(result).toContain('breached');
+    expect(result).toContain('overdue');
+    expect(result).not.toContain('min remaining');
+  });
+
+  it('omits the countdown for paused and achieved stages', () => {
+    const future = new Date(Date.now() + 60 * 60_000).toISOString();
+    const result = formatSlaBlock(
+      entry([
+        { metric: 'agent_work_time', stage: 'paused', target: 100, breach_at: future },
+        { metric: 'first_reply_time', stage: 'achieved', target: 420, breach_at: future },
+      ]),
+    );
+    expect(result).not.toContain('remaining');
+  });
+
+  it('reads the alternate field names defensively (status/due_at/business_hours)', () => {
+    const future = new Date(Date.now() + 60 * 60_000).toISOString();
+    const result = formatSlaBlock(
+      entry([
+        {
+          metric: 'next_reply_time',
+          status: 'active',
+          target: 60,
+          business_hours: true,
+          due_at: future,
+        },
+      ]),
+    );
+    expect(result).toContain('next_reply_time');
+    expect(result).toContain('(business)');
+    expect(result).toContain('min remaining');
+  });
+
+  it('tolerates an unparseable timestamp without crashing', () => {
+    const result = formatSlaBlock(
+      entry([
+        { metric: 'first_reply_time', stage: 'active', target: 420, breach_at: 'not-a-date' },
+      ]),
+    );
+    expect(result).toContain('first_reply_time');
+    expect(result).not.toContain('remaining');
   });
 });
 


### PR DESCRIPTION
Closes #92.

## Summary

The ticket tools exposed **no SLA information**. This surfaces the *live* SLA state on tickets and adds the policy matrix:

1. **`search_tickets`** adds `include=tickets(slas)` and appends a `### SLA` block per result — the live per-metric **stage** and **breach countdown** (`breach_at`) — so queue triage ("breaching today") works without an N+1 fetch.
2. **`get_ticket`** appends the same `### SLA` block. Zendesk exposes **no** SLA on the Show Ticket (or Show Many) endpoint — confirmed against the live tenant with an **admin** token on an **SLA-covered** ticket (both sideloads came back as just `["ticket"]`; see the ground-truth comment). The only endpoint that returns live SLA is Search, so `get_ticket` resolves it via a **tightly scoped Search** — the ticket's own `requester` within a ±1-day window around its creation day — correlated back by **exact ticket id**. This costs one extra Search call per `get_ticket`.
3. **`list_sla_policies`** (new, read-only) returns the policy matrix — `filter` conditions plus per-priority reply/resolution targets — via `GET /api/v2/slas/policies`.

### Reliability of the get_ticket fallback

It is **best-effort and never mis-attributed**: the result is matched back by exact id, so it can only ever *omit* SLA — never show the wrong policy. The block is simply absent when the ticket falls outside the result window (a very high-volume requester) or Search is briefly unavailable / not yet indexed (the lookup is wrapped so it can never fail `get_ticket`). This is why we still don't join policy targets client-side: that would require re-evaluating policy `filter` conditions, a heuristic that *can* mis-attribute.

### What the live SLA carries (and what it doesn't)

The Search `slas` sideload is nested **per result** as `{ policy_metrics: [{ metric, stage, breach_at, days? }] }` — no `ticket_id` (correlation is by nesting / by id), **no policy identity, and no target**. Targets and conditions live only in `/slas/policies` (surfaced by `list_sla_policies`).

### Implementation notes

- No new namespace, no client change: reuses `zendeskGet`, `buildOffsetParams`, `extractSearchPaginationMeta`, `formatList`, `truncateIfNeeded`.
- `formatTicket`'s signature is unchanged; the SLA block is composed in the handlers via `formatSlaBlock`. `get_ticket`'s SLA comes from the `fetchTicketSla` helper (the scoped-search fallback); `search_tickets` reads `ticket.slas` per result.
- `formatSlaBlock` renders live state only (per-metric stage + breach countdown / overdue) and returns `''` when no policy applies.
- First sentences of `get_ticket` / `search_tickets` state SLA availability explicitly (proxy mode surfaces only the first sentence).

### Tests

- Unit: `search_tickets` per-result SLA; `get_ticket` SLA via fallback + the two graceful-absence paths (target not in window, search errors); `list_sla_policies` matrix + read-only annotation; `formatSlaBlock` edge cases; `formatSlaPolicy`.
- Integration: `list_sla_policies` reachable + returns the matrix over the wire.
- MSW: `MOCK_SLA_POLICY` / `MOCK_SLA_SIDELOAD` (real nested shape), `GET /slas/policies`, per-result `slas` on `/search`.
- README Tickets table synced.

`pnpm check` and `pnpm test` (374 tests) pass; coverage thresholds hold.

---

## Functional validation plan

### Context

Exercised through three tools against the live Fruggr tenant: **`search_tickets`** (per-result `### SLA` block), **`get_ticket`** (same block, resolved via a scoped-search fallback), and **`list_sla_policies`**.

Paths that do **not** exercise this code: the unified `search` tool and any ticket write tool. The SLA countdown math (remaining / breached / paused / achieved / bad timestamps) is already covered by unit tests in `tests/unit/utils/formatting.test.ts` — don't re-prove it.

### Setup & prerequisites

Provided by the ready environment: branch checked out, server running `--mode all` against the real Fruggr Zendesk via per-user OAuth. Capture the SHA under test with `git rev-parse HEAD` (expected `cf82965` or later). One input to discover:
- `T_SLA` — a ticket id covered by an SLA. Run `search_tickets {query: "type:ticket status<solved"}` and pick a result that shows a `### SLA` block.

### Scenarios

| id | Validates | Action | Expected observable |
|----|-----------|--------|---------------------|
| **S0** | **Ground-truth shape (already captured — re-confirm only)** | run `pnpm tsx scripts/probe-sla-shape.ts` in a shell on the branch | Token role `admin`; Search `slas` nested per result as `{ policy_metrics: [{ metric, stage, breach_at, days? }] }`; `GET /tickets/{id}?include=slas`, `?include=metric_events`, and `tickets/show_many?ids={id}&include=slas` **all** lack any SLA key; the `Search by requester + correlate by id` block returns the target's `slas`. (Captured results are in the ground-truth PR comment.) |
| S1 | `list_sla_policies` matrix | `list_sla_policies {}` | Renders each `## SLA policy: <title>` (e.g. *SLA contractuels fruggr - Bugs/Incidents*), its `filter` conditions (e.g. `ticket_type_id is 2`), and per-priority targets (e.g. `first_reply_time: 420 min (business)`). Read-only. |
| S2 | `search_tickets` per-result live SLA | `search_tickets {query: "type:ticket status<solved"}` | At least one result carries a `### SLA` block: a `**Next breach**` line plus per-metric rows like `- **requester_wait_time** — active; due <ISO> — N min remaining`. `achieved` metrics show no countdown. |
| S3 | `get_ticket` resolves SLA via the fallback | `get_ticket {ticket_id: T_SLA, include_comments: false}` | Ticket details render **and** a `### SLA` block whose metrics match what S2 shows for the same ticket (same `stage` / `breach_at`). Confirms the scoped-search correlation works for a single id. |
| S4 | `get_ticket` degrades gracefully | `get_ticket {ticket_id: <a ticket with no SLA policy>}` | Ticket details render with **no** `### SLA` block, no error. (Absence is the only failure mode — never a wrong policy.) |

### Priorities

S2 and S3 are the real user-facing paths — do first. Then S1 (policy reference) and S4 (graceful absence). S0 is already settled; re-run only if S2/S3 look off.

### Reporting

Post a PR comment (English): per-id `OK`/`FAIL` with evidence (rendered tool output / probe payload), the SHA tested, and an overall green/failing summary.