### PR TITLE
chore(lint): enable a conservative set of new Biome 2.5 rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,19 @@
     "rules": {
       "recommended": true,
       "complexity": {
-        "useLiteralKeys": "off"
+        "useLiteralKeys": "off",
+        "useArrayFind": "error",
+        "noUselessReturn": "error"
+      },
+      "suspicious": {
+        "useArraySortCompare": "error",
+        "noDuplicatedSpreadProps": "error",
+        "noReturnAssign": "error",
+        "noProto": "error"
+      },
+      "style": {
+        "useErrorCause": "error",
+        "useGlobalThis": "error"
       }
     }
   },

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -669,6 +669,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           if (error instanceof ZendeskApiError && error.status === 403) {
             throw new Error(
               'list_sla_policies reads SLA policy *configuration* (GET /slas/policies), which Zendesk restricts to admins (or a custom role granted the SLA-management permission). The current token lacks that permission (HTTP 403). This does not affect live SLA on tickets: per-metric SLA stage and breach countdown are available to any agent via get_ticket and search_tickets -- use those for triage and prioritization.',
+              { cause: error },
             );
           }
           throw error;

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -39,7 +39,10 @@ describe('filterTools', () => {
       tools: ['get_ticket', 'get_current_user'],
     });
     expect(filtered).toHaveLength(2);
-    expect(filtered.map((t) => t.name).sort()).toEqual(['get_current_user', 'get_ticket']);
+    expect(filtered.map((t) => t.name).sort((a, b) => a.localeCompare(b))).toEqual([
+      'get_current_user',
+      'get_ticket',
+    ]);
   });
 
   it('combines readOnly + namespace', () => {

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -85,7 +85,10 @@ describe('createMcpServer', () => {
       { ...baseConfig, mode: 'all', tools: ['get_ticket', 'get_current_user'] },
       getToken,
     );
-    expect(registeredToolNames(server).sort()).toEqual(['get_current_user', 'get_ticket']);
+    expect(registeredToolNames(server).sort((a, b) => a.localeCompare(b))).toEqual([
+      'get_current_user',
+      'get_ticket',
+    ]);
   });
 
   it('registers a single read-only proxy when namespace and read-only are combined', () => {


### PR DESCRIPTION
## What

First, conservative pass at opting into rules that landed since Biome 2.3 (we're now on 2.5.0). Only rules that are a genuine safety net for this TypeScript / functional backend are enabled — the framework-specific bulk of the newly promoted rules (Vue / React Native / GraphQL / HTML / CSS / a11y) is intentionally skipped.

**Enabled**
- `complexity`: `useArrayFind`, `noUselessReturn`
- `suspicious`: `useArraySortCompare`, `noDuplicatedSpreadProps`, `noReturnAssign`, `noProto`
- `style`: `useErrorCause`, `useGlobalThis`

**Compliance fixes**
- `list_sla_policies`: chain the original 403 `ZendeskApiError` via `{ cause }` instead of dropping it (message unchanged).
- Two string sorts in unit tests get explicit comparators.

**Deliberately left out**
- `noEqualsToNull`: `!= null` is an intentional loose null/undefined check on optional API fields (`next_page?`, `count?` are `| undefined`). The `!== null` autofix is flagged *unsafe* by Biome precisely because it changes semantics — `undefined` would slip through and e.g. set `has_more: true` wrongly. Not worth rewriting 8 sites to `=== null || === undefined`.

A second round can consider type-aware rules (`noUnnecessaryConditions`, `noBaseToString`) once we measure their perf cost against CI.

## Functional validation plan

For an independent validator:

1. `pnpm install && pnpm check` → exits 0, no warnings (the `--error-on-warnings` gate).
2. `pnpm test` → all suites green (375 tests).
3. Confirm the only runtime-observable change is error chaining: in `src/tools/tickets.ts`, the 403 branch of `list_sla_policies` now passes `{ cause: error }`. Verify the thrown `Error.message` is byte-for-byte unchanged and `error.cause` is the original `ZendeskApiError` (status 403). The existing SLA-403 test should still pass without message edits.
4. Sanity-check no behavioural drift elsewhere: `git diff` touches only `biome.json`, `src/tools/tickets.ts` (cause), and two test files (sort comparators) — no logic paths altered.

https://claude.ai/code/session_0123GJHHqgihTytAo1oTMhii

---
_Generated by [Claude Code](https://claude.ai/code/session_0123GJHHqgihTytAo1oTMhii)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when access is denied for SLA policy actions, preserving the original error details for easier troubleshooting.

* **Chores**
  * Expanded linting checks to enforce more code-quality and consistency rules.

* **Tests**
  * Updated test assertions to use deterministic sorting, making tool-filtering tests more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->