### PR TITLE
fix: reject unknown tool params and fix list pagination footer (#100)

### DIFF
--- a/src/guidance/topology.ts
+++ b/src/guidance/topology.ts
@@ -64,8 +64,9 @@ export const fetchTopology = async (subdomain: string, token: string): Promise<T
     locales,
     categories: categoriesRes.categories ?? [],
     sections: sectionsRes.sections ?? [],
-    sectionsHasMore: extractPaginationMeta(sectionsRes).has_more,
-    categoriesHasMore: extractPaginationMeta(categoriesRes).has_more,
+    sectionsHasMore: extractPaginationMeta(sectionsRes, sectionsRes.sections?.length ?? 0).has_more,
+    categoriesHasMore: extractPaginationMeta(categoriesRes, categoriesRes.categories?.length ?? 0)
+      .has_more,
     userSegments: segmentsRes.user_segments ?? [],
     permissionGroups: permsRes.permission_groups ?? [],
     currentUser: meRes.user,

--- a/src/guidance/topology.ts
+++ b/src/guidance/topology.ts
@@ -59,14 +59,15 @@ export const fetchTopology = async (subdomain: string, token: string): Promise<T
     zendeskGet<{ user: ZendeskUser }>(subdomain, token, '/users/me'),
   ]);
 
+  const categories = categoriesRes.categories ?? [];
+  const sections = sectionsRes.sections ?? [];
   return {
     subdomain,
     locales,
-    categories: categoriesRes.categories ?? [],
-    sections: sectionsRes.sections ?? [],
-    sectionsHasMore: extractPaginationMeta(sectionsRes, sectionsRes.sections?.length ?? 0).has_more,
-    categoriesHasMore: extractPaginationMeta(categoriesRes, categoriesRes.categories?.length ?? 0)
-      .has_more,
+    categories,
+    sections,
+    sectionsHasMore: extractPaginationMeta(sectionsRes, sections.length).has_more,
+    categoriesHasMore: extractPaginationMeta(categoriesRes, categories.length).has_more,
     userSegments: segmentsRes.user_segments ?? [],
     permissionGroups: permsRes.permission_groups ?? [],
     currentUser: meRes.user,

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import type { ToolAnnotations, ToolResult } from './tools/definitions';
 import { createAllTools, type ToolDefinition } from './tools/index';
 import { type Logger, silentLogger } from './utils/logger';
 import { readPackageInfo } from './utils/package-info';
+import { parseToolParams } from './utils/validation';
 
 /**
  * Invoke a tool handler, notifying `onUnauthorized` when Zendesk rejects the
@@ -111,7 +112,9 @@ export const buildProxyDispatch = (
         ],
       };
     }
-    const validated = def.inputSchema.parse(params);
+    // Strict-parse so an unknown/mistyped param fails loudly instead of being
+    // silently dropped (#100). The throw is wrapped as an MCP tool error by the SDK.
+    const validated = parseToolParams(def.inputSchema, params);
     return runHandler(def, validated, onUnauthorized);
   };
 };
@@ -194,8 +197,11 @@ export const createMcpServer = (
           tool.name,
           {
             title: tool.title,
+            // Register the strict schema (not just `.shape`) so the SDK rejects
+            // unknown keys instead of silently stripping them, and advertises
+            // additionalProperties:false to clients (#100).
             description: tool.description,
-            inputSchema: tool.inputSchema.shape,
+            inputSchema: tool.inputSchema.strict(),
             annotations: tool.annotations,
           },
           async (params) => runHandler(tool, params as Record<string, unknown>, onUnauthorized),

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import type { ToolAnnotations, ToolResult } from './tools/definitions';
 import { createAllTools, type ToolDefinition } from './tools/index';
 import { type Logger, silentLogger } from './utils/logger';
 import { readPackageInfo } from './utils/package-info';
-import { parseToolParams } from './utils/validation';
+import { createStrictParamsParser } from './utils/validation';
 
 /**
  * Invoke a tool handler, notifying `onUnauthorized` when Zendesk rejects the
@@ -94,15 +94,19 @@ export const buildProxyDispatch = (
   onUnauthorized: (() => void) | undefined,
 ): ProxyDispatch => {
   const operationNames = tools.map((t) => t.name);
-  const localHandlers = new Map<string, ToolDefinition>(tools.map((t) => [t.name, t]));
+  // Each entry carries a strict params parser built once here (not per call) so
+  // an unknown/mistyped param fails loudly instead of being silently dropped (#100).
+  const localHandlers = new Map(
+    tools.map((t) => [t.name, { def: t, parseParams: createStrictParamsParser(t.inputSchema) }]),
+  );
 
   return async (args) => {
     const { operation, params } = args as {
       operation: string;
       params: Record<string, unknown>;
     };
-    const def = localHandlers.get(operation);
-    if (!def) {
+    const entry = localHandlers.get(operation);
+    if (!entry) {
       return {
         content: [
           {
@@ -112,10 +116,9 @@ export const buildProxyDispatch = (
         ],
       };
     }
-    // Strict-parse so an unknown/mistyped param fails loudly instead of being
-    // silently dropped (#100). The throw is wrapped as an MCP tool error by the SDK.
-    const validated = parseToolParams(def.inputSchema, params);
-    return runHandler(def, validated, onUnauthorized);
+    // The throw is wrapped as an MCP tool error by the SDK.
+    const validated = entry.parseParams(params);
+    return runHandler(entry.def, validated, onUnauthorized);
   };
 };
 

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -210,14 +210,15 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           path,
           buildCursorParams(page_size, cursor),
         );
+        const categories = response.categories ?? [];
         return {
           content: [
             {
               type: 'text',
               text: formatList(
-                response.categories ?? [],
+                categories,
                 formatCategory,
-                extractPaginationMeta(response),
+                extractPaginationMeta(response, categories.length),
               ),
             },
           ],
@@ -285,14 +286,15 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           path,
           buildCursorParams(page_size, cursor),
         );
+        const sections = response.sections ?? [];
         return {
           content: [
             {
               type: 'text',
               text: formatList(
-                response.sections ?? [],
+                sections,
                 formatSection,
-                extractPaginationMeta(response),
+                extractPaginationMeta(response, sections.length),
               ),
             },
           ],
@@ -309,8 +311,17 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       inputSchema: z.object({
         section_id: z.number().int().optional(),
         locale: z.string().optional(),
-        page_size: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
-        cursor: z.string().optional(),
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Articles per page (1-100, default 100).'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response; omit for the first page.'),
         sort_by: z
           .enum(['created_at', 'updated_at', 'position', 'title'])
           .default('position')
@@ -361,7 +372,11 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
             content: [
               {
                 type: 'text',
-                text: formatList(articles, formatArticleSummary, extractPaginationMeta(response)),
+                text: formatList(
+                  articles,
+                  formatArticleSummary,
+                  extractPaginationMeta(response, articles.length),
+                ),
               },
             ],
           };
@@ -377,7 +392,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
             return `${formatArticleSummary(article)}\n- **Translations**: ${locales}`;
           }),
         );
-        const meta = extractPaginationMeta(response);
+        const meta = extractPaginationMeta(response, articles.length);
         const header = meta.count
           ? `Results: ${meta.count}${meta.has_more ? ` | More available (cursor: ${meta.after_cursor})` : ''}`
           : '';

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -510,10 +510,20 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       namespace: 'tickets',
       readOnly: true,
       title: 'List Zendesk Tickets',
-      description: 'List tickets with cursor-based pagination, sorted by most recently updated.',
+      description:
+        'List tickets with cursor-based pagination, sorted by most recently updated. Page size is controlled by page_size (not per_page, which is the offset-based parameter used by search_tickets); paginate by passing the returned cursor.',
       inputSchema: z.object({
-        page_size: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
-        cursor: z.string().optional().describe('Pagination cursor'),
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Tickets per page (1-100, default 100).'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response; omit for the first page.'),
       }),
       annotations: {
         readOnlyHint: true,
@@ -530,14 +540,15 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           '/tickets',
           buildCursorParams(page_size, cursor),
         );
+        const tickets = response.tickets ?? [];
         return {
           content: [
             {
               type: 'text',
               text: formatList(
-                response.tickets ?? [],
+                tickets,
                 formatTicket,
-                extractPaginationMeta(response),
+                extractPaginationMeta(response, tickets.length),
               ),
             },
           ],

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -172,14 +172,15 @@ export const createUserTools = (ctx: ToolContext): ToolDefinition[] => {
           '/organizations',
           buildCursorParams(page_size, cursor),
         );
+        const organizations = response.organizations ?? [];
         return {
           content: [
             {
               type: 'text',
               text: formatList(
-                response.organizations ?? [],
+                organizations,
                 formatOrganization,
-                extractPaginationMeta(response),
+                extractPaginationMeta(response, organizations.length),
               ),
             },
           ],

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -22,10 +22,17 @@ export const buildOffsetParams = (perPage: number, page?: number): Record<string
   return params;
 };
 
-export const extractPaginationMeta = <T>(response: ZendeskListResponse<T>): PaginationMeta => ({
+// Cursor list endpoints (e.g. /tickets) return no `count` wrapper, which
+// previously surfaced as a misleading "Results: 0" footer even when a full page
+// came back (#100). Fall back to the number of items on the returned page so the
+// footer reflects what was actually returned.
+export const extractPaginationMeta = <T>(
+  response: ZendeskListResponse<T>,
+  itemCount: number,
+): PaginationMeta => ({
   has_more: response.meta?.has_more ?? response.next_page != null,
   after_cursor: response.meta?.after_cursor ?? null,
-  count: response.count ?? 0,
+  count: response.count ?? itemCount,
 });
 
 // For search responses — offset-based, count is always present

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,32 +1,40 @@
 import type * as z from 'zod/v4';
 
 /**
- * Strict-parse operation params against a tool's input schema.
+ * Build a strict params parser for a tool's input schema, computing the strict
+ * schema and the valid-key list once (at proxy-dispatch construction) rather
+ * than per call.
  *
  * Zod objects default to `strip`, which silently drops unknown keys. That hid
  * #100: a caller passing `per_page` to list_tickets (whose parameter is
  * `page_size`) had the key dropped, so `page_size` fell back to its default and
- * a large unpaginated page came back. Strict parsing rejects unknown keys, and
- * we rewrite the raw Zod error into a message that names the offending keys and
- * lists the valid parameters so a mistyped/misremembered name fails loudly.
+ * a large unpaginated page came back. The returned parser rejects unknown keys
+ * and rewrites the raw Zod error into a message that names the offending keys
+ * and lists the valid parameters so a mistyped/misremembered name fails loudly.
  *
  * Used on the proxy dispatch path (namespace/single modes), where this code
  * owns the parse. In `all` mode the SDK validates against the strict schema we
  * register and produces its own (also explicit) "Unrecognized key" message.
  */
-export const parseToolParams = (schema: z.ZodObject, params: unknown): Record<string, unknown> => {
-  const result = schema.strict().safeParse(params);
-  if (result.success) return result.data as Record<string, unknown>;
+export const createStrictParamsParser = (
+  schema: z.ZodObject,
+): ((params: unknown) => Record<string, unknown>) => {
+  const strict = schema.strict();
+  const validKeys = Object.keys(schema.shape).sort().join(', ');
 
-  const unknownKeys = result.error.issues
-    .filter((issue) => issue.code === 'unrecognized_keys')
-    .flatMap((issue) => (issue as { keys?: string[] }).keys ?? []);
+  return (params) => {
+    const result = strict.safeParse(params);
+    if (result.success) return result.data as Record<string, unknown>;
 
-  if (unknownKeys.length > 0) {
-    const validKeys = Object.keys(schema.shape).sort().join(', ');
-    throw new Error(
-      `Unknown parameter(s): ${unknownKeys.join(', ')}. Valid parameters: ${validKeys || '(none)'}.`,
-    );
-  }
-  throw result.error;
+    const unknownKeys = result.error.issues
+      .filter((issue) => issue.code === 'unrecognized_keys')
+      .flatMap((issue) => (issue as { keys?: string[] }).keys ?? []);
+
+    if (unknownKeys.length > 0) {
+      throw new Error(
+        `Unknown parameter(s): ${unknownKeys.join(', ')}. Valid parameters: ${validKeys || '(none)'}.`,
+      );
+    }
+    throw result.error;
+  };
 };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,32 @@
+import type * as z from 'zod/v4';
+
+/**
+ * Strict-parse operation params against a tool's input schema.
+ *
+ * Zod objects default to `strip`, which silently drops unknown keys. That hid
+ * #100: a caller passing `per_page` to list_tickets (whose parameter is
+ * `page_size`) had the key dropped, so `page_size` fell back to its default and
+ * a large unpaginated page came back. Strict parsing rejects unknown keys, and
+ * we rewrite the raw Zod error into a message that names the offending keys and
+ * lists the valid parameters so a mistyped/misremembered name fails loudly.
+ *
+ * Used on the proxy dispatch path (namespace/single modes), where this code
+ * owns the parse. In `all` mode the SDK validates against the strict schema we
+ * register and produces its own (also explicit) "Unrecognized key" message.
+ */
+export const parseToolParams = (schema: z.ZodObject, params: unknown): Record<string, unknown> => {
+  const result = schema.strict().safeParse(params);
+  if (result.success) return result.data as Record<string, unknown>;
+
+  const unknownKeys = result.error.issues
+    .filter((issue) => issue.code === 'unrecognized_keys')
+    .flatMap((issue) => (issue as { keys?: string[] }).keys ?? []);
+
+  if (unknownKeys.length > 0) {
+    const validKeys = Object.keys(schema.shape).sort().join(', ');
+    throw new Error(
+      `Unknown parameter(s): ${unknownKeys.join(', ')}. Valid parameters: ${validKeys || '(none)'}.`,
+    );
+  }
+  throw result.error;
+};

--- a/tests/functional/STATE.md
+++ b/tests/functional/STATE.md
@@ -1,7 +1,7 @@
 ---
 branch: claude/issue-100-analysis-tj9dq9
 current_run: 2026-06-26-pr102
-holder: executor
+holder: leading
 ---
 
 # Functional test run state
@@ -17,4 +17,4 @@ raw + report artifacts.
 | 02-namespace-mixed     | OK      | 2026-06-06  |
 | 03-single-readonly     | OK      | 2026-06-06  |
 | 04-all-baseline        | OK      | 2026-06-06  |
-| 05-strict-params       | pending | 2026-06-26  |
+| 05-strict-params       | done    | 2026-06-27  |

--- a/tests/functional/STATE.md
+++ b/tests/functional/STATE.md
@@ -17,4 +17,4 @@ raw + report artifacts.
 | 02-namespace-mixed     | OK      | 2026-06-06  |
 | 03-single-readonly     | OK      | 2026-06-06  |
 | 04-all-baseline        | OK      | 2026-06-06  |
-| 05-strict-params       | done    | 2026-06-27  |
+| 05-strict-params       | OK      | 2026-06-27  |

--- a/tests/functional/STATE.md
+++ b/tests/functional/STATE.md
@@ -1,7 +1,7 @@
 ---
-branch: claude/laughing-lovelace-HmZOn
-current_run: 2026-05-30-pr53
-holder: leading
+branch: claude/issue-100-analysis-tj9dq9
+current_run: 2026-06-26-pr102
+holder: executor
 ---
 
 # Functional test run state
@@ -17,3 +17,4 @@ raw + report artifacts.
 | 02-namespace-mixed     | OK      | 2026-06-06  |
 | 03-single-readonly     | OK      | 2026-06-06  |
 | 04-all-baseline        | OK      | 2026-06-06  |
+| 05-strict-params       | pending | 2026-06-26  |

--- a/tests/functional/reports/05-strict-params.raw.json
+++ b/tests/functional/reports/05-strict-params.raw.json
@@ -1,0 +1,1486 @@
+{
+  "tools": [
+    {
+      "name": "get_ticket",
+      "title": "Get Zendesk Ticket",
+      "description": "Retrieve a Zendesk ticket by ID, including its live SLA state (per-metric stage and breach countdown) when an SLA policy applies, plus its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The per-ticket Show endpoint exposes no SLA, so the SLA block is resolved via a scoped search and may be absent for a very high-volume requester or a just-updated ticket; SLA targets and policy conditions live in list_sla_policies.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "include_comments": {
+            "default": false,
+            "description": "Include ticket comments",
+            "type": "boolean"
+          }
+        },
+        "required": ["ticket_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_ticket_attachments",
+      "title": "Get Zendesk Ticket Attachments",
+      "description": "Retrieve ticket attachments. Images are embedded inline; other files are listed as text references.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "attachment_ids": {
+            "description": "Attachment IDs to fetch directly (e.g. extracted from a previous get_ticket(include_comments=true) call). When provided, skips the comments fetch entirely. When omitted, all attachments of the ticket are returned.",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          }
+        },
+        "required": ["ticket_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "search_tickets",
+      "title": "Search Zendesk Tickets",
+      "description": "Search tickets using Zendesk query syntax, returning each result with its live SLA state (per-metric stage and breach countdown) when an SLA policy applies. Examples: \"status:open assignee:me\", \"priority:urgent type:incident\". Returns total count, so queue triage like \"breaching today\" works without a per-ticket fetch.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Zendesk search query string"
+          },
+          "per_page": {
+            "default": 100,
+            "description": "Results per page",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["query"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_ticket",
+      "title": "Create Zendesk Ticket",
+      "description": "Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags. The description becomes the first public comment of the ticket, and the new ticket id is returned. After creation, use update_ticket to change status or assignee, add_public_comment or add_private_note to reply, and manage_tags to adjust tags. Look up valid assignee_id / group_id and custom field ids via search_users or your Zendesk admin settings.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "subject": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Ticket subject"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Ticket description"
+          },
+          "priority": {
+            "description": "Ticket priority. One of urgent, high, normal, low.",
+            "type": "string",
+            "enum": ["urgent", "high", "normal", "low"]
+          },
+          "type": {
+            "description": "Ticket type. One of problem, incident, question, task.",
+            "type": "string",
+            "enum": ["problem", "incident", "question", "task"]
+          },
+          "assignee_id": {
+            "description": "User id of the agent to assign the ticket to.",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "group_id": {
+            "description": "Id of the group to assign the ticket to.",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "tags": {
+            "description": "Tags to set on the ticket.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "custom_fields": {
+            "description": "Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings).",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "value": {}
+              },
+              "required": ["id", "value"]
+            }
+          }
+        },
+        "required": ["subject", "description"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "update_ticket",
+      "title": "Update Zendesk Ticket",
+      "description": "Update an existing ticket (status, priority, type, assignee, group, subject, tags, custom fields). Only the fields you pass are changed, and the updated ticket is returned. Setting tags here replaces the whole tag set — use manage_tags to add or remove individual tags without overwriting the rest. This tool does not post replies: use add_public_comment or add_private_note for that. Find the ticket id via search_tickets or list_tickets.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "status": {
+            "description": "New ticket status. One of new, open, pending, hold, solved, closed.",
+            "type": "string",
+            "enum": ["new", "open", "pending", "hold", "solved", "closed"]
+          },
+          "priority": {
+            "description": "Ticket priority. One of urgent, high, normal, low.",
+            "type": "string",
+            "enum": ["urgent", "high", "normal", "low"]
+          },
+          "type": {
+            "description": "Ticket type. One of problem, incident, question, task.",
+            "type": "string",
+            "enum": ["problem", "incident", "question", "task"]
+          },
+          "assignee_id": {
+            "description": "User id of the agent to assign the ticket to.",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "group_id": {
+            "description": "Id of the group to assign the ticket to.",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "subject": {
+            "description": "New ticket subject line.",
+            "type": "string"
+          },
+          "tags": {
+            "description": "Replaces the full tag set on the ticket. Use manage_tags for incremental add/remove.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "custom_fields": {
+            "description": "Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings).",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "minimum": -9007199254740991,
+                  "maximum": 9007199254740991
+                },
+                "value": {}
+              },
+              "required": ["id", "value"]
+            }
+          }
+        },
+        "required": ["ticket_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "add_private_note",
+      "title": "Add Private Note",
+      "description": "Add an internal note (not visible to requester) to a ticket.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Note content"
+          }
+        },
+        "required": ["ticket_id", "body"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "add_public_comment",
+      "title": "Add Public Comment",
+      "description": "Add a public comment (visible to requester) to a ticket.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Comment content"
+          }
+        },
+        "required": ["ticket_id", "body"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_tickets",
+      "title": "List Zendesk Tickets",
+      "description": "List tickets with cursor-based pagination, sorted by most recently updated. Page size is controlled by page_size (not per_page, which is the offset-based parameter used by search_tickets); paginate by passing the returned cursor.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "page_size": {
+            "default": 100,
+            "description": "Tickets per page (1-100, default 100).",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "description": "Pagination cursor from a previous response; omit for the first page.",
+            "type": "string"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_linked_incidents",
+      "title": "Get Linked Incidents",
+      "description": "Get all incident tickets linked to a problem ticket.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "problem_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Problem ticket ID"
+          }
+        },
+        "required": ["problem_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "manage_tags",
+      "title": "Manage Ticket Tags",
+      "description": "Add or remove tags on a ticket.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Ticket ID"
+          },
+          "add": {
+            "description": "Tags to add",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "remove": {
+            "description": "Tags to remove",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["ticket_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_sla_policies",
+      "title": "List SLA Policies",
+      "description": "List the configured SLA policies with their filter conditions and per-priority reply/resolution targets. Use this to explain why a given target applies to a ticket and to reconstruct deadlines deterministically instead of hard-coding the policy matrix. Requires an admin token (or a custom role granted the SLA-management permission); a standard agent token gets 403 here, though it can still read live per-ticket SLA via get_ticket / search_tickets.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "per_page": {
+            "default": 100,
+            "description": "Results per page",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "search",
+      "title": "Zendesk Unified Search",
+      "description": "Search across tickets, users, and organizations. Supports filters like \"type:ticket status:open\", \"type:user role:agent\". Returns total count and paginated results (100 per page). Organization results include name and ID only — use get_organization for full details (tags, domains, details).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Zendesk search query"
+          },
+          "per_page": {
+            "default": 100,
+            "description": "Results per page (max 100)",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number (1-based)",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["query"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "search_articles",
+      "title": "Search Help Center Articles",
+      "description": "Full-text search across Help Center articles (metadata only, no body). Use get_article for full content. Supports locale filtering. Returns total count.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Search query"
+          },
+          "locale": {
+            "description": "Filter by locale (e.g., \"en-us\", \"fr\")",
+            "type": "string"
+          },
+          "per_page": {
+            "default": 100,
+            "description": "Results per page",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["query"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_article",
+      "title": "Get Help Center Article",
+      "description": "Retrieve an article by ID with full body content. For large articles, prefer get_article_outline + get_article_section to save tokens. Optionally specify locale for a translated version. Returns body (HTML), metadata, source_locale, and list of available translations.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "locale": {
+            "description": "Locale for translated version",
+            "type": "string"
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_categories",
+      "title": "List Help Center Categories",
+      "description": "List all Help Center categories. Categories are the top level of the Guide hierarchy (category → section → article); each entry includes its id, name and locale. Results are cursor-paginated. Pair a returned category id with list_sections to drill down, then list_articles to reach articles. Pass a locale to read category names in that translation.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "description": "Locale for category names (e.g., \"en-us\", \"fr\"). Defaults to the Help Center default locale.",
+            "type": "string"
+          },
+          "page_size": {
+            "default": 100,
+            "description": "Categories per page (1-100, default 100).",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "description": "Pagination cursor from a previous response; omit for the first page.",
+            "type": "string"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_sections",
+      "title": "List Help Center Sections",
+      "description": "List Help Center sections. Sections are the middle level of the Guide hierarchy (category → section → article) and group related articles; each entry includes its id, name, category_id and locale. Results are cursor-paginated. Pass category_id to list only one category's sections (ids come from list_categories), then use a section id with list_articles. Pass a locale to read section names in that translation.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "category_id": {
+            "description": "Restrict to sections of this category (id from list_categories). Omit to list every section.",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "locale": {
+            "description": "Locale for section names (e.g., \"en-us\", \"fr\"). Defaults to the Help Center default locale.",
+            "type": "string"
+          },
+          "page_size": {
+            "default": 100,
+            "description": "Sections per page (1-100, default 100).",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "description": "Pagination cursor from a previous response; omit for the first page.",
+            "type": "string"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_articles",
+      "title": "List Help Center Articles",
+      "description": "List articles (metadata only, no body). Use get_article for full content. Optionally filter by section ID and locale. Supports sort_by (\"title\", \"created_at\", \"updated_at\") and include_translations: true to show available translation locales per article. Note: include_translations must be re-sent on each paginated request.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "section_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "locale": {
+            "type": "string"
+          },
+          "page_size": {
+            "default": 100,
+            "description": "Articles per page (1-100, default 100).",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "description": "Pagination cursor from a previous response; omit for the first page.",
+            "type": "string"
+          },
+          "sort_by": {
+            "default": "position",
+            "description": "Sort field",
+            "type": "string",
+            "enum": ["created_at", "updated_at", "position", "title"]
+          },
+          "sort_order": {
+            "default": "asc",
+            "description": "Sort direction",
+            "type": "string",
+            "enum": ["asc", "desc"]
+          },
+          "include_translations": {
+            "default": false,
+            "description": "Include available translation locales per article (causes 1 extra API call per article)",
+            "type": "boolean"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_article_translations",
+      "title": "List Article Translations",
+      "description": "List all available translations for an article (metadata only, no body: locale, title, draft, updated_at). Use get_article with locale for full translated content.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_article_translation",
+      "title": "Create Article Translation",
+      "description": "Create a translation for an existing article in a specific locale. The article must already exist (create it with create_article); this adds a new localized version and returns the created translation (locale, title, draft state). The target locale must not already have a translation — use update_article_translation to modify an existing one, and list_article_translations to see which locales exist. Provide the full HTML body.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "ID of the existing article to translate."
+          },
+          "locale": {
+            "type": "string",
+            "description": "Target locale (e.g., \"fr\", \"de\")"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Translated article title."
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Translated body (HTML)"
+          },
+          "draft": {
+            "default": false,
+            "description": "Create the translation as a draft (not visible to end users). Defaults to false (published).",
+            "type": "boolean"
+          }
+        },
+        "required": ["article_id", "locale", "title", "body"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "update_article_translation",
+      "title": "Update Article Translation",
+      "description": "Update article content (title, body) in a specific locale. For targeted edits on one or a few sections, prefer update_article_section — this tool replaces the FULL body and re-sends the entire article on each write. Use the article's source_locale (from get_article) for the default language, or another locale for translations.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "locale": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "draft": {
+            "type": "boolean"
+          }
+        },
+        "required": ["article_id", "locale"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_permission_groups",
+      "title": "List Permission Groups",
+      "description": "List all Guide permission groups. Use this to find the permission_group_id required when creating articles.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_article",
+      "title": "Create Help Center Article",
+      "description": "Create a new article in a section. The locale becomes the article's source_locale. Requires a permission_group_id (use list_permission_groups to find available IDs). To add content in other locales afterwards, use create_article_translation.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "section_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Article body (HTML)"
+          },
+          "permission_group_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Permission group ID (use list_permission_groups to find it)"
+          },
+          "user_segment_id": {
+            "description": "User segment ID for visibility (use list_user_segments to find it). Defaults to everyone.",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "author_id": {
+            "description": "Author user ID. Defaults to the authenticated user.",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "content_tag_ids": {
+            "description": "Content tag IDs (use list_content_tags to find them)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "locale": {
+            "type": "string"
+          },
+          "draft": {
+            "default": true,
+            "type": "boolean"
+          },
+          "promoted": {
+            "default": false,
+            "type": "boolean"
+          },
+          "label_names": {
+            "description": "Label names for search ranking (use list_labels to see existing labels)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["section_id", "title", "body", "permission_group_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "update_article",
+      "title": "Update Help Center Article",
+      "description": "Update article metadata only (draft, promoted, labels, tags, visibility, section, sort position, etc.). Does NOT update content (title, body) — use update_article_translation for that.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "draft": {
+            "type": "boolean"
+          },
+          "promoted": {
+            "type": "boolean"
+          },
+          "label_names": {
+            "description": "Label names for search ranking",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "content_tag_ids": {
+            "description": "Content tag IDs",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "user_segment_id": {
+            "description": "User segment ID for visibility",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "author_id": {
+            "description": "Author user ID",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "permission_group_id": {
+            "description": "Permission group ID",
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "section_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "position": {
+            "description": "Sort position within the section (manual ordering only; 0 = first/top). New articles default to position 0. To move an article to the END of its section, set this to one more than the highest current position: read the highest position P from list_articles with sort_by=\"position\", sort_order=\"desc\", then set position = P + 1.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_content_tags",
+      "title": "List Content Tags",
+      "description": "List all Guide content tags. Content tags are visible to end users and help them find related articles.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_content_tag",
+      "title": "Create Content Tag",
+      "description": "Create a new content tag for Guide articles. Content tags are end-user visible labels that help readers discover related articles; this returns the created tag with its id. Check list_content_tags first to avoid duplicates, then attach the new id via the content_tag_ids parameter of create_article or update_article. For internal search-ranking labels that are not shown to end users, use article labels (list_labels) instead.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Content tag name as shown to end users (e.g., \"billing\", \"getting-started\")."
+          }
+        },
+        "required": ["name"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_labels",
+      "title": "List Article Labels",
+      "description": "List all article labels. Labels improve Help Center search ranking and are not visible to end users.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_user_segments",
+      "title": "List User Segments",
+      "description": "List all user segments. User segments control article visibility (who can view). Use the ID when creating or updating articles.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_article_attachments",
+      "title": "List Article Attachments",
+      "description": "List all attachments for an article. Returns attachment metadata only (id, file name, content type, size, URL), not the file bytes; both inline and block attachments are included. This is for Help Center articles — for attachments on support tickets use get_ticket_attachments instead. Upload new files with create_article_attachment.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "ID of the Help Center article whose attachments to list."
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_article_outline",
+      "title": "Get Article Outline",
+      "description": "Return a compact outline of an article (list of sections delimited by h1/h2/h3, with word counts) for the given locale (defaults to source_locale). Includes available translations with their outdated status. Use get_article_section to fetch a specific section.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "locale": {
+            "description": "Locale of the body to outline (defaults to article source_locale)",
+            "type": "string"
+          }
+        },
+        "required": ["article_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_article_section",
+      "title": "Get Article Section",
+      "description": "Retrieve the content of a single section of an article in a given locale. Use get_article_outline first to discover section indexes. Default format=\"html\" for round-trip safety. Pass format=\"markdown\" only for human review — the Markdown representation is lossy on some structures (<pre> with <br>, tables with multi-<p> cells are kept as raw HTML to limit the damage, but do not round-trip markdown content back through update_article_section).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "locale": {
+            "type": "string",
+            "description": "Locale of the body (e.g., \"en-us\", \"fr\")"
+          },
+          "section_index": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991,
+            "description": "0-based index of the section (see get_article_outline)"
+          },
+          "format": {
+            "default": "html",
+            "description": "Output format. \"html\" (default) is round-trip safe. \"markdown\" is lossy on some HTML structures — use only for human review, not before update_article_section.",
+            "type": "string",
+            "enum": ["html", "markdown"]
+          }
+        },
+        "required": ["article_id", "locale", "section_index"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "update_article_section",
+      "title": "Update Article Section",
+      "description": "Replace the content of a single section of an article in a given locale, keeping the rest of the body intact. The server fetches the current body, replaces the targeted section, and PUTs the full reconstructed body via the Translations API. Default format=\"html\" for fidelity. Use format=\"markdown\" only when you control the input and know it does not rely on structures that round-trip poorly (code blocks with line breaks, tables with multi-paragraph cells). The section heading is preserved and is NOT part of the replaced content.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "locale": {
+            "type": "string",
+            "description": "Locale of the translation to update"
+          },
+          "section_index": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991,
+            "description": "0-based index of the section to replace (see get_article_outline)"
+          },
+          "content": {
+            "type": "string",
+            "description": "New content for the section (heading excluded). HTML by default, Markdown if format=\"markdown\"."
+          },
+          "format": {
+            "default": "html",
+            "description": "Input format. \"html\" (default) is the safe path. \"markdown\" is converted to HTML server-side but may introduce artifacts on complex content.",
+            "type": "string",
+            "enum": ["html", "markdown"]
+          }
+        },
+        "required": ["article_id", "locale", "section_index", "content"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "compare_translations",
+      "title": "Compare Article Translations",
+      "description": "Compare section structure between two locales of the same article, matched by index. Returns a compact table (one row per section) with status: \"ok\" (both present, source/target word count ratio within 25%), \"different\" (word count ratio diverges by more than 25% — size signal only, NOT a semantic divergence: two locales may legitimately differ in verbosity) or \"missing\" (section absent in target). Useful to spot structurally stale or missing sections; do not interpret \"different\" as an edit regression on its own.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "source_locale": {
+            "type": "string",
+            "description": "Source (reference) locale"
+          },
+          "target_locale": {
+            "type": "string",
+            "description": "Target locale to compare against source"
+          }
+        },
+        "required": ["article_id", "source_locale", "target_locale"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "create_article_attachment",
+      "title": "Create Article Attachment",
+      "description": "Upload an attachment to an article. Provide file content as base64-encoded string.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Article ID"
+          },
+          "file_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "File name (e.g., \"screenshot.png\")"
+          },
+          "file_base64": {
+            "type": "string",
+            "minLength": 1,
+            "description": "File content encoded as base64"
+          },
+          "content_type": {
+            "default": "application/octet-stream",
+            "description": "MIME type (e.g., \"image/png\", \"application/pdf\")",
+            "type": "string"
+          }
+        },
+        "required": ["article_id", "file_name", "file_base64"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_current_user",
+      "title": "Get Current Zendesk User",
+      "description": "Get the currently authenticated Zendesk user. Useful to verify identity and permissions.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "search_users",
+      "title": "Search Zendesk Users",
+      "description": "Search for users by name, email, or other criteria using Zendesk search query syntax. Returns total count.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Search query"
+          },
+          "per_page": {
+            "default": 100,
+            "description": "Results per page",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page": {
+            "default": 1,
+            "description": "Page number",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": ["query"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_user",
+      "title": "Get Zendesk User",
+      "description": "Retrieve a user by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "User ID"
+          }
+        },
+        "required": ["user_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "get_organization",
+      "title": "Get Zendesk Organization",
+      "description": "Retrieve an organization by ID.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "organization_id": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Organization ID"
+          }
+        },
+        "required": ["organization_id"],
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "list_organizations",
+      "title": "List Zendesk Organizations",
+      "description": "List all organizations with pagination. Returns the name and id of each organization plus basic fields; results are cursor-paginated. Use get_organization with an id for full details (tags, domains, notes), or search for query-based lookups by name. Organizations group end users and can be referenced when creating or filtering tickets.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "page_size": {
+            "default": 100,
+            "description": "Organizations per page (1-100, default 100).",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "cursor": {
+            "description": "Pagination cursor from a previous response; omit for the first page.",
+            "type": "string"
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    }
+  ]
+}

--- a/tests/functional/reports/05-strict-params.report.md
+++ b/tests/functional/reports/05-strict-params.report.md
@@ -1,0 +1,39 @@
+# Report — 05-strict-params
+
+Mode `all`, read-only off. Dumped `tools/list` into `05-strict-params.raw.json`
+(server logged `tools_registered count=38 mode=all`). PR #102 registers the
+**strict** Zod schema with the SDK, so every advertised `inputSchema` must carry
+`additionalProperties: false` — the wire-level proof that an unknown key (e.g.
+`per_page` on `list_tickets`, whose real parameter is `page_size`) is refused.
+This channel-A scenario validates the advertised schema plus the new cursor
+pagination docs. All five assertions are green.
+
+Observations (verbatim from `raw.json`):
+
+- `.tools[]` length = 38; **38 of 38** have `inputSchema.additionalProperties === false` (0 missing).
+- `list_tickets` top-level `description`:
+  `"List tickets with cursor-based pagination, sorted by most recently updated. Page size is controlled by page_size (not per_page, which is the offset-based parameter used by search_tickets); paginate by passing the returned cursor."`
+  → mentions both `page_size` and `per_page`, clarifying which to use.
+- `list_tickets.inputSchema.properties.page_size.description`:
+  `"Tickets per page (1-100, default 100)."` → non-empty.
+- `list_tickets.inputSchema.properties.cursor.description`:
+  `"Pagination cursor from a previous response; omit for the first page."` → tells the caller to omit it for the first page.
+- `list_articles.inputSchema.properties.page_size.description`:
+  `"Articles per page (1-100, default 100)."` → non-empty.
+
+```json
+{
+  "scenario": "05-strict-params",
+  "mode": "all",
+  "readOnly": false,
+  "branch": "claude/issue-100-analysis-tj9dq9",
+  "assertions": [
+    { "id": "S1", "desc": "every tools/list entry has inputSchema.additionalProperties === false (report the count of entries and how many satisfy this)", "pass": true, "actual": "38 of 38 entries have additionalProperties===false (0 missing)" },
+    { "id": "S2", "desc": "list_tickets inputSchema.properties.page_size has a non-empty description",                                                       "pass": true, "actual": "\"Tickets per page (1-100, default 100).\"" },
+    { "id": "S3", "desc": "list_tickets inputSchema.properties.cursor description tells the caller to omit it for the first page",                            "pass": true, "actual": "\"Pagination cursor from a previous response; omit for the first page.\"" },
+    { "id": "S4", "desc": "list_tickets top-level description mentions both 'page_size' and 'per_page' (clarifying which to use)",                            "pass": true, "actual": "description names page_size as the page-size control and per_page as the offset-based param used by search_tickets" },
+    { "id": "S5", "desc": "list_articles inputSchema.properties.page_size has a non-empty description",                                                       "pass": true, "actual": "\"Articles per page (1-100, default 100).\"" }
+  ],
+  "summary": "green — 38/38 tools advertise additionalProperties:false, and list_tickets/list_articles carry the documented page_size/cursor pagination params"
+}
+```

--- a/tests/functional/reports/05-strict-params.verdict.md
+++ b/tests/functional/reports/05-strict-params.verdict.md
@@ -1,0 +1,27 @@
+# Verdict — 05-strict-params
+
+Branch `claude/issue-100-analysis-tj9dq9` (PR #102). Each row re-verified against
+`reports/05-strict-params.raw.json` (not the executor's `actual` field alone).
+
+| ID | Status | Notes                                                                                                                    |
+| -- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
+| S1 | OK     | `.tools[]` length = 38; **38/38** have `inputSchema.additionalProperties === false`, 0 missing (incl. zero-param tools). |
+| S2 | OK     | `list_tickets.inputSchema.properties.page_size.description` = `"Tickets per page (1-100, default 100)."` (non-empty).    |
+| S3 | OK     | `list_tickets…cursor.description` = `"Pagination cursor from a previous response; omit for the first page."`             |
+| S4 | OK     | `list_tickets.description` contains both `page_size` and `per_page` (clarifies which controls page size).                |
+| S5 | OK     | `list_articles…page_size.description` = `"Articles per page (1-100, default 100)."` (non-empty).                         |
+
+## Summary
+
+🟢 Green — all 5 assertions pass. The strict-schema contract is confirmed at the
+wire level: every advertised `inputSchema` in `--mode all` carries
+`additionalProperties: false`, so an unknown/mistyped key (the #100 `per_page`
+case) is refused by the SDK rather than silently dropped. The cursor pagination
+parameters (`page_size`, `cursor`) are now documented on `list_tickets` and
+`list_articles`, and `list_tickets`' description disambiguates `page_size` from
+the offset-based `per_page` used by `search_tickets`.
+
+## Proposed actions
+
+None — scenario closed `OK`. Runtime rejection on `tools/call` is additionally
+covered by `tests/integration/core-scenarios.ts` (all-mode and proxy paths).

--- a/tests/functional/scenarios/05-strict-params/expected.md
+++ b/tests/functional/scenarios/05-strict-params/expected.md
@@ -1,0 +1,20 @@
+# Expected — 05-strict-params
+
+Ground truth captured from `tools/list --mode all` on branch
+`claude/issue-100-analysis-tj9dq9` (PR #102). Do not open this file as the
+executor — it is the verdict criterion.
+
+| ID | Expected |
+| -- | -------- |
+| S1 | `tools/list` returns **38** entries, and **all 38** have `inputSchema.additionalProperties === false` — including zero-parameter tools such as `get_current_user` (`inputSchema: {type:"object", properties:{}, additionalProperties:false}`). A count below 38, or any entry missing the key / not `false`, is a FAIL. (Total is allowed to drift if the tool surface changed; the load-bearing part is **every** entry having `additionalProperties:false`.) |
+| S2 | `list_tickets` → `inputSchema.properties.page_size.description` === `"Tickets per page (1-100, default 100)."` (non-empty is the bar; exact string here for reference). |
+| S3 | `list_tickets` → `inputSchema.properties.cursor.description` === `"Pagination cursor from a previous response; omit for the first page."` Must convey "omit for the first page"; the bare old value `"Pagination cursor"` is a FAIL. |
+| S4 | `list_tickets` → top-level `description` contains both the substring `page_size` and the substring `per_page`. Exact text: `"List tickets with cursor-based pagination, sorted by most recently updated. Page size is controlled by page_size (not per_page, which is the offset-based parameter used by search_tickets); paginate by passing the returned cursor."` |
+| S5 | `list_articles` → `inputSchema.properties.page_size.description` === `"Articles per page (1-100, default 100)."` (non-empty is the bar). |
+
+## Verdict rule
+
+All five OK → scenario `OK`. S1 is the load-bearing assertion (the strict
+contract); S2–S5 confirm the documentation remediation. Any FAIL → scenario
+`FAIL` with the failing IDs and a pointer to `src/server.ts` (strict
+registration) or the relevant tool schema.

--- a/tests/functional/scenarios/05-strict-params/spec.md
+++ b/tests/functional/scenarios/05-strict-params/spec.md
@@ -1,0 +1,66 @@
+---
+pr: 102
+mode: all
+read_only: false
+namespaces: []
+channels: [A]
+---
+
+# 05 — strict params + pagination docs (PR #102, issue #100)
+
+PR #102 makes the server reject unknown/mistyped tool parameters instead of
+silently dropping them, and documents the cursor pagination parameters. In
+`--mode all` the server now registers the **strict** Zod schema with the SDK, so
+every advertised `inputSchema` must carry `additionalProperties: false` — the
+wire-level proof that an unknown key (e.g. `per_page` on `list_tickets`, whose
+real parameter is `page_size`) will be refused. This scenario validates that
+contract over `tools/list`.
+
+Runtime rejection of an unknown key (`tools/call` → error) is already covered by
+the integration suite (`tests/integration/core-scenarios.ts`); this channel-A
+scenario validates the advertised schema and the new parameter docs.
+
+## Steps
+
+1. `pnpm build` if not already done.
+2. Ensure `ZENDESK_SUBDOMAIN` is exported (no Zendesk call fires — `tools/list`
+   does not authenticate).
+3. Dump:
+
+   ```sh
+   node tests/functional/bin/dump-tools-list.mjs --mode all \
+     > tests/functional/reports/05-strict-params.raw.json
+   ```
+
+4. Inspect the raw JSON:
+   - count the entries and how many have `inputSchema.additionalProperties === false`;
+   - read `list_tickets` (its `description`, and `inputSchema.properties.page_size.description`
+     and `.cursor.description`);
+   - read `list_articles` `inputSchema.properties.page_size.description`.
+5. Write the report at `tests/functional/reports/05-strict-params.report.md`,
+   filling in the `pass`/`actual` fields of the fence below from the raw JSON.
+
+## Assertions to record
+
+```json
+{
+  "scenario": "05-strict-params",
+  "mode": "all",
+  "readOnly": false,
+  "branch": "claude/issue-100-analysis-tj9dq9",
+  "assertions": [
+    { "id": "S1", "desc": "every tools/list entry has inputSchema.additionalProperties === false (report the count of entries and how many satisfy this)", "pass": null, "actual": null },
+    { "id": "S2", "desc": "list_tickets inputSchema.properties.page_size has a non-empty description",                                                       "pass": null, "actual": null },
+    { "id": "S3", "desc": "list_tickets inputSchema.properties.cursor description tells the caller to omit it for the first page",                            "pass": null, "actual": null },
+    { "id": "S4", "desc": "list_tickets top-level description mentions both 'page_size' and 'per_page' (clarifying which to use)",                            "pass": null, "actual": null },
+    { "id": "S5", "desc": "list_articles inputSchema.properties.page_size has a non-empty description",                                                       "pass": null, "actual": null }
+  ],
+  "summary": "<one-line synthesis>"
+}
+```
+
+## When done
+
+1. Update `STATE.md` (status=done, holder=leading).
+2. Commit and push.
+3. Notify.

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -160,6 +160,28 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(textOf(result)).toContain('Test User');
       });
 
+      it('rejects an unknown parameter in "all" mode instead of silently dropping it (#100)', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'list_tickets',
+          arguments: { per_page: 3 },
+        });
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toContain('per_page');
+      });
+
+      it('rejects an unknown parameter through a proxy instead of silently dropping it (#100)', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'single' }));
+        const result = await connected.client.callTool({
+          name: 'zendesk',
+          arguments: { operation: 'list_tickets', params: { per_page: 3 } },
+        });
+        expect(result.isError).toBe(true);
+        const text = textOf(result);
+        expect(text).toContain('per_page');
+        expect(text).toContain('page_size');
+      });
+
       it('surfaces a Zendesk API error as an MCP tool error', async () => {
         mswServer.use(errorHandlers.usersMeUnauthorized);
 

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -132,6 +132,27 @@ describe('createMcpServer', () => {
     expect(text).not.toContain('search_articles');
   });
 
+  it('namespace proxy dispatch rejects unknown params instead of silently dropping them (#100)', async () => {
+    // list_tickets takes `page_size`, not `per_page`. Previously a mistyped
+    // `per_page` was silently stripped and page_size defaulted to 100, returning
+    // a large unpaginated page. Strict validation must reject it loudly and point
+    // at the valid parameter names.
+    const allTools = createAllTools({ subdomain: 'x', getToken });
+    const ticketsTools = filterTools(allTools, { readOnly: false, namespaces: ['tickets'] });
+    const dispatch = buildProxyDispatch(ticketsTools, undefined);
+
+    // The throw propagates to the SDK, which wraps it as an isError result; the
+    // pure dispatch helper surfaces it as a rejection.
+    const error = await dispatch({ operation: 'list_tickets', params: { per_page: 3 } }).then(
+      () => {
+        throw new Error('expected dispatch to reject the unknown param');
+      },
+      (err: unknown) => err as Error,
+    );
+    expect(error.message).toContain('per_page');
+    expect(error.message).toContain('page_size');
+  });
+
   it('marks read-only proxies with readOnlyHint=true and a [RO] description prefix', () => {
     const server = createMcpServer(
       {

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -496,6 +496,25 @@ describe('ticket tools', () => {
       const result = await tool.handler({ page_size: 25 });
       expect(result.content[0]?.text).toContain('Test ticket');
     });
+
+    it('reports the page item count when the cursor endpoint omits count (#100)', async () => {
+      // The real /tickets endpoint returns no `count` wrapper; ensure the footer
+      // reflects the number of tickets returned rather than a misleading "Results: 0".
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets', () =>
+          HttpResponse.json({
+            tickets: [MOCK_TICKET, { ...MOCK_TICKET, id: 2 }],
+            meta: { has_more: true, after_cursor: 'NEXT' },
+          }),
+        ),
+      );
+      const tool = findTool('list_tickets');
+      const result = await tool.handler({ page_size: 25 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('Results: 2');
+      expect(text).not.toContain('Results: 0');
+      expect(text).toContain('cursor: NEXT');
+    });
   });
 
   describe('get_linked_incidents', () => {

--- a/tests/unit/utils/pagination.test.ts
+++ b/tests/unit/utils/pagination.test.ts
@@ -21,23 +21,48 @@ describe('buildCursorParams', () => {
 
 describe('extractPaginationMeta', () => {
   it('extracts meta from cursor-based response', () => {
-    const meta = extractPaginationMeta({
-      meta: { has_more: true, after_cursor: 'next123' },
-      count: 42,
-    });
+    const meta = extractPaginationMeta(
+      {
+        meta: { has_more: true, after_cursor: 'next123' },
+        count: 42,
+      },
+      3,
+    );
     expect(meta).toEqual({ has_more: true, after_cursor: 'next123', count: 42 });
   });
 
   it('falls back to next_page for offset-based pagination', () => {
-    const meta = extractPaginationMeta({
-      next_page: 'https://example.com/api?page=2',
-      count: 10,
-    });
+    const meta = extractPaginationMeta(
+      {
+        next_page: 'https://example.com/api?page=2',
+        count: 10,
+      },
+      3,
+    );
     expect(meta.has_more).toBe(true);
   });
 
+  it('falls back to the page item count when the response omits count (#100)', () => {
+    // The /tickets cursor endpoint returns no `count` wrapper, which previously
+    // surfaced as a misleading "Results: 0" footer even when a full page came back.
+    const meta = extractPaginationMeta(
+      { tickets: [], meta: { has_more: true, after_cursor: 'c' } },
+      25,
+    );
+    expect(meta.count).toBe(25);
+    expect(meta.has_more).toBe(true);
+  });
+
+  it('prefers the response count over the item count when present', () => {
+    const meta = extractPaginationMeta(
+      { count: 250, meta: { has_more: true, after_cursor: 'c' } },
+      25,
+    );
+    expect(meta.count).toBe(250);
+  });
+
   it('returns has_more false when no next_page and no meta', () => {
-    const meta = extractPaginationMeta({ next_page: null });
+    const meta = extractPaginationMeta({ next_page: null }, 0);
     expect(meta.has_more).toBe(false);
     expect(meta.after_cursor).toBeNull();
     expect(meta.count).toBe(0);

--- a/tests/unit/utils/validation.test.ts
+++ b/tests/unit/utils/validation.test.ts
@@ -33,7 +33,19 @@ describe('createStrictParamsParser', () => {
     expect(error?.message).toContain('cursor');
   });
 
-  it('still surfaces type errors on known parameters', () => {
-    expect(() => parse({ page_size: 'big' })).toThrow();
+  it('propagates the raw Zod error (not the rewritten message) for known-parameter failures', () => {
+    const error = (() => {
+      try {
+        parse({ page_size: 'big' });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
+    // A type error on a *known* field must surface the original ZodError so the
+    // SDK reports the field-level detail, not the unknown-parameter rewrite.
+    expect(error).toMatchObject({
+      issues: [expect.objectContaining({ path: ['page_size'] })],
+    });
   });
 });

--- a/tests/unit/utils/validation.test.ts
+++ b/tests/unit/utils/validation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod/v4';
+import { parseToolParams } from '../../../src/utils/validation';
+
+const schema = z.object({
+  page_size: z.number().int().min(1).max(100).default(100),
+  cursor: z.string().optional(),
+});
+
+describe('parseToolParams', () => {
+  it('returns parsed params and applies defaults for valid input', () => {
+    expect(parseToolParams(schema, { page_size: 5 })).toEqual({ page_size: 5 });
+    expect(parseToolParams(schema, {})).toEqual({ page_size: 100 });
+  });
+
+  it('rejects unknown parameters instead of silently dropping them (#100)', () => {
+    expect(() => parseToolParams(schema, { per_page: 3 })).toThrow(/per_page/);
+  });
+
+  it('names the unknown parameter and lists the valid ones', () => {
+    const error = (() => {
+      try {
+        parseToolParams(schema, { per_page: 3 });
+        return null;
+      } catch (e) {
+        return e as Error;
+      }
+    })();
+    expect(error?.message).toContain('per_page');
+    expect(error?.message).toContain('page_size');
+    expect(error?.message).toContain('cursor');
+  });
+
+  it('still surfaces type errors on known parameters', () => {
+    expect(() => parseToolParams(schema, { page_size: 'big' })).toThrow();
+  });
+});

--- a/tests/unit/utils/validation.test.ts
+++ b/tests/unit/utils/validation.test.ts
@@ -1,26 +1,28 @@
 import { describe, expect, it } from 'vitest';
 import * as z from 'zod/v4';
-import { parseToolParams } from '../../../src/utils/validation';
+import { createStrictParamsParser } from '../../../src/utils/validation';
 
-const schema = z.object({
-  page_size: z.number().int().min(1).max(100).default(100),
-  cursor: z.string().optional(),
-});
+const parse = createStrictParamsParser(
+  z.object({
+    page_size: z.number().int().min(1).max(100).default(100),
+    cursor: z.string().optional(),
+  }),
+);
 
-describe('parseToolParams', () => {
+describe('createStrictParamsParser', () => {
   it('returns parsed params and applies defaults for valid input', () => {
-    expect(parseToolParams(schema, { page_size: 5 })).toEqual({ page_size: 5 });
-    expect(parseToolParams(schema, {})).toEqual({ page_size: 100 });
+    expect(parse({ page_size: 5 })).toEqual({ page_size: 5 });
+    expect(parse({})).toEqual({ page_size: 100 });
   });
 
   it('rejects unknown parameters instead of silently dropping them (#100)', () => {
-    expect(() => parseToolParams(schema, { per_page: 3 })).toThrow(/per_page/);
+    expect(() => parse({ per_page: 3 })).toThrow(/per_page/);
   });
 
   it('names the unknown parameter and lists the valid ones', () => {
     const error = (() => {
       try {
-        parseToolParams(schema, { per_page: 3 });
+        parse({ per_page: 3 });
         return null;
       } catch (e) {
         return e as Error;
@@ -32,6 +34,6 @@ describe('parseToolParams', () => {
   });
 
   it('still surfaces type errors on known parameters', () => {
-    expect(() => parseToolParams(schema, { page_size: 'big' })).toThrow();
+    expect(() => parse({ page_size: 'big' })).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #100. `list_tickets` appeared to ignore `per_page` and returned a large unpaginated page.

Root cause: `list_tickets`' page-size parameter is `page_size` (cursor pagination), not `per_page` (which is the offset parameter used by `search_tickets`). Zod objects strip unknown keys by default, so `per_page` was silently dropped and `page_size` fell back to its default (100) → a ~100-ticket page. Separately, the cursor-based `/tickets` endpoint returns no `count` wrapper, which surfaced as a misleading `Results: 0` footer.

## Changes (all three remediations from the analysis)

1. **Strict param rejection** — unknown/mistyped parameters now fail loudly instead of being silently dropped.
   - Proxy modes (`namespace`/`single`): new `parseToolParams` helper (`src/utils/validation.ts`) strict-parses and rewrites the Zod error into `Unknown parameter(s): per_page. Valid parameters: cursor, page_size.`
   - `all` mode: registers the **strict** schema with the SDK, so the SDK rejects unknown keys and advertises `additionalProperties: false` over the wire.
2. **Pagination footer** — `extractPaginationMeta` now falls back to the returned page's item count when the response omits `count`, so the footer reflects what was actually returned instead of `Results: 0`.
3. **Documentation** — added `.describe()` for `page_size`/`cursor` on `list_tickets` and `list_articles`, and a sentence in `list_tickets` clarifying that page size is `page_size`, not `per_page`.

## Tests

- `tests/unit/utils/validation.test.ts` (new) — strict parse: defaults applied, unknown key rejected, message names the bad key + valid ones, type errors still surface.
- `tests/unit/utils/pagination.test.ts` — count fallback to page item count; response `count` still preferred when present.
- `tests/unit/tools/tickets.test.ts` — `list_tickets` reports the page item count when the cursor endpoint omits `count`.
- `tests/unit/server.test.ts` — proxy dispatch rejects an unknown param and names it.
- `tests/integration/core-scenarios.ts` — end-to-end rejection in both `all` mode (SDK strict) and proxy mode.

Full suite: 385 passing; `pnpm check` and `tsc --noEmit` clean; coverage thresholds hold.

## Compatibility note for reviewers

Strict validation changes the input contract for **every** tool, and `all` mode now advertises `additionalProperties: false`. This is more correct, but per the multi-agent compatibility rule it should be exercised by the inter-LLM functional harness (`/functional-testing`) before merge.

## Functional validation plan

**Context.** The fix is exercised by calling `mcp__zendesk-local__list_tickets` (and any other list/proxy tool) on the running server (`--mode all`). The validator's session is already on this branch with the server running and authenticated.

**Setup & prerequisites.** None beyond the ready environment. No state seeding, no probe (the change is about parameter validation and rendered footer text, both observable from formatted tool output — no raw upstream JSON needed). Capture `git rev-parse HEAD` and confirm it matches the latest pushed commit before testing.

**Scenarios.**

| id | Validates | Manipulation / call | Expected observable |
|----|-----------|---------------------|---------------------|
| V1 | Unknown param rejected (all mode) | `list_tickets` with `{ "per_page": 3 }` | Tool returns an **error** whose text mentions `per_page` (the SDK's `Unrecognized key` / `Input validation error`). NOT a large ticket list. |
| V2 | Valid param honored | `list_tickets` with `{ "page_size": 3 }` | Success; **at most 3** tickets rendered; footer shows `Results: 3` (or fewer) and, if more exist, `More available (cursor: …)`. |
| V3 | Footer no longer `Results: 0` | `list_tickets` with `{ "page_size": 100 }` (or default `{}`) on an account with tickets | Footer shows `Results: N` where N = number of tickets rendered (N > 0 when any returned), never `Results: 0` alongside a non-empty list. |
| V4 | Default still works | `list_tickets` with `{}` | Success; up to 100 tickets; no error. |
| V5 | Friendly message via proxy (if a proxy mode is reachable) | If a single/namespace proxy tool is available, call it with `operation: "list_tickets", params: { per_page: 3 }` | Error text contains both `per_page` and `page_size` (names the bad key and the valid one). If only `--mode all` is wired, mark `N/A` and note V1 covers the all-mode path. |
| V6 | Docs surface the params | Inspect the `list_tickets` tool schema (`tools/list`) | `page_size` and `cursor` carry descriptions; `page_size` says "(1-100, default 100)". |

**Long-running behaviours.** None (no timers/intervals).

**Priorities.** V1 → V2 → V3 are the user-facing regression paths (do first). V4/V5/V6 are confirmations.

**Reporting.** Post a PR comment in English: per-id `OK`/`FAIL`/`N/A` with the observed tool output (footer line for V2–V3, error text for V1/V5, schema excerpt for V6) and the tested commit SHA, plus an overall green/failing summary.

https://claude.ai/code/session_01FwAnCSHhS7a3FHLTznbHqA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwAnCSHhS7a3FHLTznbHqA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination metadata so list tools report the correct “Results” count and cursor/has-more details when the API response omits a total count (tickets, articles/help center lists, sections, organizations, and related topology lists).
* **New Features**
  * Tool calls now strictly reject unknown parameters, with clearer validation errors (including in both proxy and all-tools modes).
* **Documentation**
  * Clarified listing inputs for pagination (e.g., `page_size` vs `per_page`, and when to provide `cursor`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->