### PR TITLE
test(release): guard conventionalcommits preset rendering against breaking majors

### DIFF
--- a/tests/unit/release-notes-preset-render.test.ts
+++ b/tests/unit/release-notes-preset-render.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs';
+import { beforeAll, describe, expect, it } from 'vitest';
+// @ts-expect-error - plain JS semantic-release plugin, no type declarations
+import { generateNotes } from '../../scripts/release-notes-collapsed.js';
+
+/**
+ * End-to-end guard for the release-notes pipeline.
+ *
+ * Unlike `release-notes-collapsed.test.ts` (which feeds hand-written markdown to
+ * the pure `collapseInternalSections` helper), this test drives the REAL
+ * `conventional-changelog-conventionalcommits` preset through
+ * `@semantic-release/release-notes-generator` with the exact `presetConfig` that
+ * ships in `.releaserc.json`, then through our collapsing wrapper.
+ *
+ * It is a deliberate compatibility canary: the conventionalcommits preset must
+ * stay on a generation whose `writerOpts` the pinned `release-notes-generator`
+ * (and its `conventional-changelog-writer`) can render. A preset major that
+ * switches the rendering API — e.g. v10's Handlebars → render-functions change,
+ * which needs `conventional-changelog-writer@9` while the plugin still depends on
+ * `@^8` — silently produces notes containing only the version header. These
+ * assertions fail loudly in that case instead of shipping empty changelogs.
+ */
+
+// The collapsing plugin is the 2nd `.releaserc.json` plugin entry: [path, options].
+const rc = JSON.parse(readFileSync(new URL('../../.releaserc.json', import.meta.url), 'utf8')) as {
+  plugins: Array<unknown>;
+};
+const pluginConfig = (
+  rc.plugins.find(
+    (p): p is [string, Record<string, unknown>] =>
+      Array.isArray(p) && String(p[0]).includes('release-notes-collapsed'),
+  ) as [string, Record<string, unknown>]
+)[1];
+
+const commit = (hash: string, message: string) => ({
+  hash,
+  message,
+  author: { name: 'Test', email: 'test@example.com' },
+  committerDate: '2026-06-27T00:00:00Z',
+});
+
+const context = {
+  commits: [
+    commit('aaaaaaa', 'feat(tickets): add bulk update tool'),
+    commit('bbbbbbb', 'fix(auth): handle expired token refresh'),
+    commit('ccccccc', 'docs(readme): document the new flag'),
+    commit('ddddddd', 'chore(deps): bump a dependency'),
+    commit('eeeeeee', 'ci: pin an action sha'),
+  ],
+  lastRelease: { version: '1.0.0', gitTag: 'v1.0.0', gitHead: '0000000' },
+  nextRelease: { version: '1.1.0', gitTag: 'v1.1.0', type: 'minor', gitHead: 'eeeeeee' },
+  options: { repositoryUrl: 'https://github.com/fruggr/zendesk-mcp-server' },
+  cwd: process.cwd(),
+  env: {},
+  logger: { log: () => {}, error: () => {} },
+};
+
+describe('release notes preset rendering (compatibility canary)', () => {
+  let notes: string;
+  beforeAll(async () => {
+    notes = await generateNotes(pluginConfig, context);
+  });
+
+  it('renders public sections from the conventionalcommits preset', () => {
+    // The whole point: the preset must actually render commit sections, not just
+    // the `## [version]` header. An incompatible preset generation yields only
+    // the header, so these would be missing.
+    expect(notes).toContain('### Features');
+    expect(notes).toContain('### Bug Fixes');
+    expect(notes).toContain('add bulk update tool');
+  });
+
+  it('keeps internal types in the changelog, collapsed inside a <details> block', () => {
+    // Internal types must still be rendered (so they can be collapsed) and tucked
+    // behind the <details> panel, after the public sections.
+    expect(notes).toContain('<details>');
+    const detailsIdx = notes.indexOf('<details>');
+    expect(notes.indexOf('### Features')).toBeLessThan(detailsIdx);
+    expect(notes.indexOf('### Chores')).toBeGreaterThan(detailsIdx);
+    expect(notes.indexOf('### Continuous Integration')).toBeGreaterThan(detailsIdx);
+  });
+});


### PR DESCRIPTION
## Summary
Adds an end-to-end compatibility canary for the release-notes pipeline. The existing `release-notes-collapsed.test.ts` only exercises the pure string post-processing on hand-written markdown, so it cannot detect a preset major that changes the rendering API. This test drives the **real** `conventionalcommits` preset through `generateNotes` with the shipping `.releaserc.json` `presetConfig`, then asserts that public sections render and internal types collapse into the `<details>` block.

This was uncovered while analysing #103 (`conventional-changelog-conventionalcommits` v9 → v10): v10 silently produces **empty** release notes (only the version header) with the current semantic-release toolchain.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [x] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally (387 tests)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [ ] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed (test-only; no tool-surface change)
- [x] If this PR adds an MCP tool: it is documented in `README.md` (n/a)

## Notes for the reviewer (human or AI)
**Why this matters / what it caught.** Bumping `conventional-changelog-conventionalcommits` to v10 (see #103) breaks release-notes rendering: v10 replaced Handlebars templates with render functions and now requires `conventional-changelog-writer@9`, while `@semantic-release/release-notes-generator` (incl. the latest 14.1.1) still depends on `@^8`. Result: `generateNotes` emits only the `## [version]` header — Features, Bug Fixes, BREAKING CHANGES all vanish. Version detection (`commit-analyzer`) is unaffected, so a release would still fire but with an empty CHANGELOG/Release — a silent regression.

**Canary proof:**
- `conventional-changelog-conventionalcommits@9.3.1` → both assertions pass.
- `@10.2.0` → both fail (notes reduced to the header).

**Scope.** Test-only, no runtime-observable behaviour change to the server, so no separate functional validation plan. The test reads the live `.releaserc.json` `presetConfig` so it tracks the real shipping config rather than a copy.

**Follow-up (not in this PR).** #103 should be held/closed until `@semantic-release/release-notes-generator` ships a `conventional-changelog-writer@9` / render-function build. Keep `conventionalcommits` < 10 until then.

https://claude.ai/code/session_01VS3x2Sz7fthxnbkU2pAhBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VS3x2Sz7fthxnbkU2pAhBk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a compatibility test for release notes rendering to ensure key public sections still appear as expected.
  * Verified feature and bug-fix content is rendered correctly, while lower-priority sections remain collapsed in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->