### PR TITLE
docs: feature-oriented descriptions (registry, npm, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen?logo=renovatebot&logoColor=white)](https://renovatebot.com)
 [![semantic-release](https://img.shields.io/badge/semantic--release-e10079?logo=semantic-release&logoColor=white)](https://github.com/semantic-release/semantic-release)
 
-**Bring Zendesk Support & the Help Center into your AI assistant.** A
-[Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets
-your assistant search articles, answer questions, and create, track and update
-tickets in plain language — **without switching apps**.
+**Bring Zendesk deep into your AI assistant.** A
+[Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for a
+two-way integration: find answers in the Help Center, **draft, update and
+translate** articles (keeping languages in sync), and **manage Support tickets**
+end to end — comments, triage and image attachments — all in plain language,
+**without switching apps**.
 
 Think of it as the [Zendesk agent for Microsoft 365 Copilot](https://support.zendesk.com/hc/en-us/articles/9958331458458-Using-the-Zendesk-agent-in-Microsoft-365-Copilot),
 but **vendor-neutral** — it drops into any MCP client (Claude Desktop, Claude

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fruggr/zendesk-mcp-server",
   "version": "2.4.0",
   "mcpName": "io.github.fruggr/zendesk-mcp-server",
-  "description": "Model Context Protocol (MCP) server for the Zendesk Support & Help Center APIs — runs locally (stdio) or as a private remote MCP server (HTTP), with per-user OAuth 2.1 PKCE authentication, read-only mode, and token-efficient section-based article editing.",
+  "description": "A Model Context Protocol (MCP) server for a deep, two-way integration between your AI assistant and Zendesk: search the Help Center and draft, update and translate articles (section by section, keeping languages in sync), and manage Support tickets end to end — comments, triage and image attachments.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/build-server-json.mjs
+++ b/scripts/build-server-json.mjs
@@ -27,10 +27,11 @@ export function buildServerJson(packageJson) {
   return {
     $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
     name: packageJson.mcpName,
-    // Standalone, <=100 chars (registry limit). Distinct from package.json's
+    // Standalone, <=100 chars (registry limit). Feature-oriented (what the
+    // assistant can do), mirroring the README. Distinct from package.json's
     // longer npm description on purpose, so it can't be derived from it.
     description:
-      'Zendesk Support & Help Center MCP server with per-user OAuth 2.1 PKCE authentication.',
+      'Draft, translate and update Help Center articles and manage Zendesk tickets from your AI assistant.',
     version: packageJson.version,
     repository: {
       url: repositoryUrl,


### PR DESCRIPTION
## Summary
The discovery descriptions led with the auth/transport mechanism (`…per-user OAuth 2.1 PKCE authentication`, `runs locally (stdio)…`) — too technical, too "how". Rewrite them to lead with the value proposition — a deep, two-way AI × Zendesk integration — across all three surfaces.

| Surface | After |
|---|---|
| **`server.json`** (generated, ≤100 chars) | `Draft, translate and update Help Center articles and manage Zendesk tickets from your AI assistant.` |
| **npm** (`package.json#description`) | `A Model Context Protocol (MCP) server for a deep, two-way integration between your AI assistant and Zendesk: search the Help Center and draft, update and translate articles (section by section, keeping languages in sync), and manage Support tickets end to end — comments, triage and image attachments.` |
| **README hero** | Rewritten concisely: find answers + draft/update/translate articles (languages in sync) + manage tickets (comments, triage, image attachments), plain language. |

Every capability named is backed by an existing tool (article create/update/section edit, translation create/update + compare, ticket create/update + comments/notes, attachments).

## Type of change
- [x] Documentation

## Author checklist
- [x] `pnpm test` passes (server.json suite: 7 passed)
- [x] `pnpm check` clean · `pnpm typecheck` passes
- [x] Generated manifest re-validated against the official schema (ajv); description 99/100 chars
- [x] Read the diff line by line

## Notes for the reviewer
- **`docs:` only** — no release is cut, so the new registry/npm descriptions propagate with the **next** `feat:`/`fix:` release (the publish step runs then). The README change is immediate.
- **GitHub repo "About"** is a repo setting (not a file) and can't be changed from here. Suggested replacement (≤350, feature-oriented): _"Bring Zendesk deep into your AI assistant: find answers and draft, update and translate Help Center articles, and manage Support tickets end to end — comments, triage and attachments — all in plain language."_

## Functional validation plan

**Context.** Copy-only change to discovery surfaces; no tool-surface or Zendesk behavior change. Validate on the branch.

| id | Validates | Command | Expected |
|----|-----------|---------|----------|
| S1 | Registry line is feature-oriented and in-limit | `node scripts/build-server-json.mjs \| jq -r '.description \| "\(.) (\(length))"'` | The new text, length ≤ 100 |
| S2 | Manifest still schema-valid | generate `server.json`, validate against the 2025-12-11 schema | valid |
| S3 | Consistency suite green | `pnpm vitest run tests/unit/server-json.test.ts` | 7 passed |
| S4 | npm/README copy reads as intended | eyeball `package.json#description` and the README hero | value-prop-first, no OAuth/transport lead |

**Reporting.** PR comment with per-id OK/FAIL + evidence and the tested SHA.

https://claude.ai/code/session_01X9LNaRC181ZmY7kCjpff1S