### PR TITLE
feat(tickets): attach files to comments and notes via the Uploads API

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ zendesk-mcp-server acme --namespace tickets
 | `list_sla_policies` | List SLA policies with filter conditions and per-priority targets (requires an admin token, or a custom role with the SLA-management permission) | read |
 | `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |
 | `update_ticket` | Update ticket status, priority, assignee, tags, custom fields | write |
-| `add_private_note` | Add an internal note (not visible to requester) | write |
-| `add_public_comment` | Add a public comment (visible to requester) | write |
+| `add_private_note` | Add an internal note (not visible to requester), optionally with file attachments | write |
+| `add_public_comment` | Add a public comment (visible to requester), optionally with file attachments | write |
 | `manage_tags` | Add or remove tags on a ticket | write |
 
 </details>

--- a/src/client/zendesk-api.ts
+++ b/src/client/zendesk-api.ts
@@ -162,6 +162,35 @@ export const fetchZendeskBinary = async (
   return { data: Buffer.from(arrayBuffer), contentType };
 };
 
+// Zendesk Uploads API: POST /uploads?filename=... with the raw file bytes as the
+// body and Content-Type set to the file's MIME type. `executeRequest` always
+// JSON-encodes, so this goes direct to fetch (like helpCenterUpload). Pass
+// `uploadToken` to aggregate another file under an existing upload token.
+export const zendeskUpload = async <T>(
+  subdomain: string,
+  token: string,
+  filename: string,
+  data: Buffer,
+  contentType: string,
+  uploadToken?: string,
+): Promise<T> => {
+  const params: Record<string, string> = { filename };
+  if (uploadToken) params['token'] = uploadToken;
+  const url = buildUrl(getBaseUrl(subdomain), '/uploads', params);
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: buildAuthHeader(token), 'Content-Type': contentType },
+    body: data,
+  });
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new ZendeskApiError(response.status, response.statusText, responseBody);
+  }
+
+  return response.json() as Promise<T>;
+};
+
 export const helpCenterUpload = async <T>(
   subdomain: string,
   token: string,

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -5,6 +5,7 @@ import {
   zendeskGet,
   zendeskPost,
   zendeskPut,
+  zendeskUpload,
 } from '../client/zendesk-api';
 import {
   DEFAULT_PAGE_SIZE,
@@ -20,6 +21,7 @@ import type {
   ZendeskSlaSideloadEntry,
   ZendeskTicket,
   ZendeskTicketAttachment,
+  ZendeskUpload,
 } from '../types';
 import {
   formatComment,
@@ -165,6 +167,35 @@ const fetchTicketSla = async (
 
 export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
   const { subdomain, getToken } = ctx;
+
+  const attachmentSchema = z.object({
+    file_name: z.string().min(1).describe('File name, e.g. "app.log" or "screenshot.png".'),
+    file_base64: z.string().min(1).describe('File content encoded as base64.'),
+    content_type: z
+      .string()
+      .default('application/octet-stream')
+      .describe('MIME type, e.g. "text/plain", "image/png", "application/pdf".'),
+  });
+  type AttachmentInput = z.infer<typeof attachmentSchema>;
+
+  // Upload each file via the Zendesk Uploads API, aggregating them under a single
+  // upload token (the token from the first upload is passed to the next), and
+  // return that token for use in a comment's `uploads` array.
+  const uploadAttachments = async (token: string, files: AttachmentInput[]): Promise<string> => {
+    let uploadToken: string | undefined;
+    for (const file of files) {
+      const { upload } = await zendeskUpload<{ upload: ZendeskUpload }>(
+        subdomain,
+        token,
+        file.file_name,
+        Buffer.from(file.file_base64, 'base64'),
+        file.content_type,
+        uploadToken,
+      );
+      uploadToken = upload.token;
+    }
+    return uploadToken as string;
+  };
 
   return [
     {
@@ -458,10 +489,15 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       namespace: 'tickets',
       readOnly: false,
       title: 'Add Private Note',
-      description: 'Add an internal note (not visible to requester) to a ticket.',
+      description:
+        'Add an internal note (not visible to requester) to a ticket, optionally with file attachments (uploaded via the Zendesk Uploads API and carried on the note).',
       inputSchema: z.object({
         ticket_id: z.number().int().describe('Ticket ID'),
         body: z.string().min(1).describe('Note content'),
+        attachments: z
+          .array(attachmentSchema)
+          .optional()
+          .describe('Files to attach to this note (base64-encoded content).'),
       }),
       annotations: {
         readOnlyHint: false,
@@ -470,12 +506,22 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         openWorldHint: true,
       },
       handler: async (params) => {
-        const { ticket_id, body } = params as { ticket_id: number; body: string };
+        const { ticket_id, body, attachments } = params as {
+          ticket_id: number;
+          body: string;
+          attachments?: AttachmentInput[];
+        };
         const token = await getToken();
+        const uploads = attachments?.length
+          ? [await uploadAttachments(token, attachments)]
+          : undefined;
         await zendeskPut(subdomain, token, `/tickets/${ticket_id}`, {
-          ticket: { comment: { body, public: false } },
+          ticket: { comment: { body, public: false, ...(uploads && { uploads }) } },
         });
-        return { content: [{ type: 'text', text: `Private note added to ticket #${ticket_id}.` }] };
+        const suffix = attachments?.length ? ` with ${attachments.length} attachment(s)` : '';
+        return {
+          content: [{ type: 'text', text: `Private note added to ticket #${ticket_id}${suffix}.` }],
+        };
       },
     },
     {
@@ -483,10 +529,15 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       namespace: 'tickets',
       readOnly: false,
       title: 'Add Public Comment',
-      description: 'Add a public comment (visible to requester) to a ticket.',
+      description:
+        'Add a public comment (visible to requester) to a ticket, optionally with file attachments (uploaded via the Zendesk Uploads API and carried on the comment).',
       inputSchema: z.object({
         ticket_id: z.number().int().describe('Ticket ID'),
         body: z.string().min(1).describe('Comment content'),
+        attachments: z
+          .array(attachmentSchema)
+          .optional()
+          .describe('Files to attach to this comment (base64-encoded content).'),
       }),
       annotations: {
         readOnlyHint: false,
@@ -495,13 +546,23 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         openWorldHint: true,
       },
       handler: async (params) => {
-        const { ticket_id, body } = params as { ticket_id: number; body: string };
+        const { ticket_id, body, attachments } = params as {
+          ticket_id: number;
+          body: string;
+          attachments?: AttachmentInput[];
+        };
         const token = await getToken();
+        const uploads = attachments?.length
+          ? [await uploadAttachments(token, attachments)]
+          : undefined;
         await zendeskPut(subdomain, token, `/tickets/${ticket_id}`, {
-          ticket: { comment: { body, public: true } },
+          ticket: { comment: { body, public: true, ...(uploads && { uploads }) } },
         });
+        const suffix = attachments?.length ? ` with ${attachments.length} attachment(s)` : '';
         return {
-          content: [{ type: 'text', text: `Public comment added to ticket #${ticket_id}.` }],
+          content: [
+            { type: 'text', text: `Public comment added to ticket #${ticket_id}${suffix}.` },
+          ],
         };
       },
     },

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -173,6 +173,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
     file_base64: z.string().min(1).describe('File content encoded as base64.'),
     content_type: z
       .string()
+      .min(1)
       .default('application/octet-stream')
       .describe('MIME type, e.g. "text/plain", "image/png", "application/pdf".'),
   });

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -173,7 +173,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
 
   const attachmentSchema = z.object({
     file_name: z.string().min(1).describe('File name, e.g. "app.log" or "screenshot.png".'),
-    file_base64: z.string().min(1).describe('File content encoded as base64.'),
+    file_base64: z.string().min(1).base64().describe('File content encoded as base64.'),
     content_type: z
       .string()
       .min(1)

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -70,7 +70,10 @@ const fetchAllTicketComments = async (
     const response = await zendeskGet<{
       comments: ZendeskComment[];
       meta?: { has_more: boolean; after_cursor: string };
-    }>(subdomain, token, `/tickets/${ticketId}/comments`, buildCursorParams(MAX_PAGE_SIZE, cursor));
+    }>(subdomain, token, `/tickets/${ticketId}/comments`, {
+      ...buildCursorParams(MAX_PAGE_SIZE, cursor),
+      include_inline_images: 'true',
+    });
     all.push(...response.comments);
     pages += 1;
     if (!response.meta?.has_more || !response.meta?.after_cursor) break;
@@ -235,6 +238,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
             subdomain,
             token,
             `/tickets/${ticket_id}/comments`,
+            { include_inline_images: 'true' },
           );
           text += `\n\n---\n# Comments\n\n${comments.map(formatComment).join('\n\n')}`;
         }

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -201,6 +201,9 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
     return uploadToken as string;
   };
 
+  const formatAttachmentSuffix = (count?: number): string =>
+    count ? ` with ${count} attachment(s)` : '';
+
   return [
     {
       name: 'get_ticket',
@@ -523,7 +526,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         await zendeskPut(subdomain, token, `/tickets/${ticket_id}`, {
           ticket: { comment: { body, public: false, ...(uploads && { uploads }) } },
         });
-        const suffix = attachments?.length ? ` with ${attachments.length} attachment(s)` : '';
+        const suffix = formatAttachmentSuffix(attachments?.length);
         return {
           content: [{ type: 'text', text: `Private note added to ticket #${ticket_id}${suffix}.` }],
         };
@@ -563,7 +566,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         await zendeskPut(subdomain, token, `/tickets/${ticket_id}`, {
           ticket: { comment: { body, public: true, ...(uploads && { uploads }) } },
         });
-        const suffix = attachments?.length ? ` with ${attachments.length} attachment(s)` : '';
+        const suffix = formatAttachmentSuffix(attachments?.length);
         return {
           content: [
             { type: 'text', text: `Public comment added to ticket #${ticket_id}${suffix}.` },

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,13 @@ export interface ZendeskComment {
   attachments?: ZendeskTicketAttachment[];
 }
 
+export interface ZendeskUpload {
+  token: string;
+  expires_at: string;
+  attachment: ZendeskTicketAttachment;
+  attachments: ZendeskTicketAttachment[];
+}
+
 export interface ZendeskUser {
   id: number;
   name: string;

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -149,6 +149,23 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(textOf(result)).toContain('Test User');
       });
 
+      it('uploads and attaches a file when posting a public comment', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'add_public_comment',
+          arguments: {
+            ticket_id: 1,
+            body: 'See attached',
+            attachments: [
+              { file_name: 'a.log', file_base64: 'aGVsbG8=', content_type: 'text/plain' },
+            ],
+          },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('with 1 attachment(s)');
+      });
+
       it('dispatches through the single proxy at runtime', async () => {
         connected = await harness.connect(makeConfig({ mode: 'single' }));
         const result = await connected.client.callTool({

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -224,6 +224,15 @@ export const MOCK_COMMENT = {
   ],
 };
 
+// Uploads API response (POST /uploads). The token is what gets carried on a
+// comment via comment.uploads; subsequent files aggregate under it via ?token=.
+export const MOCK_UPLOAD = {
+  token: 'mock-upload-token',
+  expires_at: '2026-01-01T01:00:00Z',
+  attachment: MOCK_TICKET_ATTACHMENT_PDF,
+  attachments: [MOCK_TICKET_ATTACHMENT_PDF],
+};
+
 // OAuth token endpoint used by the browser PKCE flow. Opt-in per test via
 // mswServer.use() so the OAuth roundtrip mock stays centralized here too.
 export const oauthTokenHandler = http.post('https://testsubdomain.zendesk.com/oauth/tokens', () =>
@@ -315,6 +324,7 @@ export const handlers = [
   http.put(`${BASE}/tickets/:id`, ({ params }) =>
     HttpResponse.json({ ticket: { ...MOCK_TICKET, id: Number(params['id']), status: 'solved' } }),
   ),
+  http.post(`${BASE}/uploads`, () => HttpResponse.json({ upload: MOCK_UPLOAD })),
 
   // SLA policies — the real endpoint returns the full config list with no
   // `count` wrapper, so omit it here to exercise the array-length fallback.

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -553,6 +553,26 @@ describe('ticket tools', () => {
       expect(comment['public']).toBe(true);
     });
 
+    it('rejects an attachment with an empty content_type', () => {
+      const tool = findTool('add_public_comment');
+      const result = tool.inputSchema.safeParse({
+        ticket_id: 1,
+        body: 'x',
+        attachments: [{ file_name: 'a.txt', file_base64: 'aGk=', content_type: '' }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('defaults content_type when omitted on an attachment', () => {
+      const tool = findTool('add_public_comment');
+      const parsed = tool.inputSchema.parse({
+        ticket_id: 1,
+        body: 'x',
+        attachments: [{ file_name: 'a.txt', file_base64: 'aGk=' }],
+      }) as { attachments: Array<{ content_type: string }> };
+      expect(parsed.attachments[0]?.content_type).toBe('application/octet-stream');
+    });
+
     it('aggregates multiple files under a single upload token', async () => {
       const uploadReqs: { filename: string | null; token: string | null }[] = [];
       let putBody: Record<string, unknown> | undefined;

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -589,6 +589,18 @@ describe('ticket tools', () => {
       expect(result.success).toBe(false);
     });
 
+    it('rejects an attachment whose file_base64 is not valid base64', () => {
+      const tool = findTool('add_public_comment');
+      const result = tool.inputSchema.safeParse({
+        ticket_id: 1,
+        body: 'x',
+        attachments: [
+          { file_name: 'a.txt', file_base64: 'not base64!!', content_type: 'text/plain' },
+        ],
+      });
+      expect(result.success).toBe(false);
+    });
+
     it('defaults content_type when omitted on an attachment', () => {
       const tool = findTool('add_public_comment');
       const parsed = tool.inputSchema.parse({

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -2,7 +2,7 @@ import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createTicketTools } from '../../../src/tools/tickets';
-import { MOCK_SLA_SIDELOAD, MOCK_TICKET } from '../../msw-handlers';
+import { MOCK_SLA_SIDELOAD, MOCK_TICKET, MOCK_UPLOAD } from '../../msw-handlers';
 import { mswServer } from '../../setup';
 
 const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
@@ -480,6 +480,38 @@ describe('ticket tools', () => {
       const result = await tool.handler({ ticket_id: 1, body: 'Internal note' });
       expect(result.content[0]?.text).toContain('Private note added');
     });
+
+    it('uploads and attaches a file to the note (kept private)', async () => {
+      let putBody: Record<string, unknown> | undefined;
+      mswServer.use(
+        http.put(
+          'https://testsubdomain.zendesk.com/api/v2/tickets/:id',
+          async ({ request, params }) => {
+            putBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ ticket: { ...MOCK_TICKET, id: Number(params['id']) } });
+          },
+        ),
+      );
+      const tool = findTool('add_private_note');
+      const result = await tool.handler({
+        ticket_id: 1,
+        body: 'Internal note',
+        attachments: [
+          {
+            file_name: 'trace.log',
+            file_base64: Buffer.from('boom').toString('base64'),
+            content_type: 'text/plain',
+          },
+        ],
+      });
+      expect(result.content[0]?.text).toContain('with 1 attachment(s)');
+      const comment = (putBody?.['ticket'] as Record<string, unknown>)['comment'] as Record<
+        string,
+        unknown
+      >;
+      expect(comment['uploads']).toEqual(['mock-upload-token']);
+      expect(comment['public']).toBe(false);
+    });
   });
 
   describe('add_public_comment', () => {
@@ -487,6 +519,78 @@ describe('ticket tools', () => {
       const tool = findTool('add_public_comment');
       const result = await tool.handler({ ticket_id: 1, body: 'Public reply' });
       expect(result.content[0]?.text).toContain('Public comment added');
+    });
+
+    it('uploads and attaches a file to the comment', async () => {
+      let putBody: Record<string, unknown> | undefined;
+      mswServer.use(
+        http.put(
+          'https://testsubdomain.zendesk.com/api/v2/tickets/:id',
+          async ({ request, params }) => {
+            putBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ ticket: { ...MOCK_TICKET, id: Number(params['id']) } });
+          },
+        ),
+      );
+      const tool = findTool('add_public_comment');
+      const result = await tool.handler({
+        ticket_id: 1,
+        body: 'See attached',
+        attachments: [
+          {
+            file_name: 'a.log',
+            file_base64: Buffer.from('hello').toString('base64'),
+            content_type: 'text/plain',
+          },
+        ],
+      });
+      expect(result.content[0]?.text).toContain('with 1 attachment(s)');
+      const comment = (putBody?.['ticket'] as Record<string, unknown>)['comment'] as Record<
+        string,
+        unknown
+      >;
+      expect(comment['uploads']).toEqual(['mock-upload-token']);
+      expect(comment['public']).toBe(true);
+    });
+
+    it('aggregates multiple files under a single upload token', async () => {
+      const uploadReqs: { filename: string | null; token: string | null }[] = [];
+      let putBody: Record<string, unknown> | undefined;
+      mswServer.use(
+        http.post('https://testsubdomain.zendesk.com/api/v2/uploads', ({ request }) => {
+          const url = new URL(request.url);
+          uploadReqs.push({
+            filename: url.searchParams.get('filename'),
+            token: url.searchParams.get('token'),
+          });
+          return HttpResponse.json({ upload: MOCK_UPLOAD });
+        }),
+        http.put(
+          'https://testsubdomain.zendesk.com/api/v2/tickets/:id',
+          async ({ request, params }) => {
+            putBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ ticket: { ...MOCK_TICKET, id: Number(params['id']) } });
+          },
+        ),
+      );
+      const tool = findTool('add_public_comment');
+      const b64 = Buffer.from('x').toString('base64');
+      await tool.handler({
+        ticket_id: 1,
+        body: 'multi',
+        attachments: [
+          { file_name: 'a.txt', file_base64: b64, content_type: 'text/plain' },
+          { file_name: 'b.txt', file_base64: b64, content_type: 'text/plain' },
+        ],
+      });
+      expect(uploadReqs).toHaveLength(2);
+      expect(uploadReqs[0]?.token).toBeNull();
+      expect(uploadReqs[1]?.token).toBe('mock-upload-token');
+      const comment = (putBody?.['ticket'] as Record<string, unknown>)['comment'] as Record<
+        string,
+        unknown
+      >;
+      expect(comment['uploads']).toEqual(['mock-upload-token']);
     });
   });
 

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -78,6 +78,19 @@ describe('ticket tools', () => {
       expect(result.content[0]?.text).toContain('This is a comment');
     });
 
+    it('requests inline images when include_comments is set', async () => {
+      let inlineParam: string | null = null;
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments', ({ request }) => {
+          inlineParam = new URL(request.url).searchParams.get('include_inline_images');
+          return HttpResponse.json({ comments: [] });
+        }),
+      );
+      const tool = findTool('get_ticket');
+      await tool.handler({ ticket_id: 1, include_comments: true });
+      expect(inlineParam).toBe('true');
+    });
+
     it('has readOnly annotation', () => {
       const tool = findTool('get_ticket');
       expect(tool.annotations.readOnlyHint).toBe(true);
@@ -85,6 +98,19 @@ describe('ticket tools', () => {
   });
 
   describe('get_ticket_attachments', () => {
+    it('requests inline images from the comments endpoint', async () => {
+      let inlineParam: string | null = null;
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments', ({ request }) => {
+          inlineParam = new URL(request.url).searchParams.get('include_inline_images');
+          return HttpResponse.json({ comments: [] });
+        }),
+      );
+      const tool = findTool('get_ticket_attachments');
+      await tool.handler({ ticket_id: 1 });
+      expect(inlineParam).toBe('true');
+    });
+
     it('returns image content for image attachments', async () => {
       const tool = findTool('get_ticket_attachments');
       const result = await tool.handler({ ticket_id: 1 });


### PR DESCRIPTION
## Summary

Add ticket attachment support to the comment tools. `add_public_comment` and
`add_private_note` gain an optional `attachments` parameter (base64-encoded
files); the handler uploads each file through the Zendesk Uploads API and carries
the resulting token on the comment via `comment.uploads`, so the created
comment/note ships the file(s).

This PR also fixes the read side (issue #15): `get_ticket_attachments` and
`get_ticket(include_comments)` now pass `include_inline_images=true` when listing
comments, so images embedded inline in a comment body (drag-and-drop /
paste-from-clipboard) are surfaced as attachments. Without the flag Zendesk omits
them from the comment attachments array, making them invisible. The two topics
are bundled here at the maintainer-author's request given the one-line nature of
the inline fix.

Closes #106. Closes #15.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally (391 tests)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed (README tool table)
- [x] If this PR adds an MCP tool: N/A — no new tool, only a new optional param on two existing tools

## Notes for the reviewer (human or AI)

Design choices, all verified against the Zendesk Uploads API docs:

- **All-in-one, not token-juggling.** Rather than a separate `upload_file` tool
  returning a token plus an `uploads: [token]` param, the caller passes files
  directly and the handler does upload + aggregation + association internally.
  Simplest caller UX; no 60-minute token expiry leaked to the LLM.
- **Base64 only** (no local file path), consistent with `create_article_attachment`
  and required for the HTTP transport where the server can't read a client-side path.
- **`update_ticket` intentionally not extended.** Zendesk has no direct ticket
  attachment — a file always rides a comment (`comment.uploads`). `update_ticket`
  posts no comment, so attachments live on the two comment tools only.
- **Multi-file aggregation** under a single upload token via the `?token=` query
  param on subsequent uploads (`POST /uploads?filename=...&token=...`).
- **New `zendeskUpload` client helper** for a raw-binary POST: `executeRequest`
  always JSON-encodes, so the Uploads API (raw bytes + file MIME `Content-Type`)
  needs a direct `fetch`, mirroring the existing `helpCenterUpload`.

No new behavior was invented: field names (`comment.uploads`), the 60-minute token
validity, and the aggregation mechanism are all from the Uploads API reference.
Live-validated end-to-end on a real ticket (upload → `comment.uploads` →
`get_ticket_attachments` confirms the file), in addition to the unit + integration
tests.

**Author-side code review (high effort) — findings and disposition:**

- *Fixed* — `content_type` accepted an explicit empty string (the schema default
  only fills a missing field), which would have sent an empty `Content-Type`
  header. Added `.min(1)`, matching `file_name` / `file_base64`, plus two schema
  tests. (commit `fix(tickets): reject empty content_type ...`)
- *Deferred (out of scope)* — the two comment handlers share ~90% of their logic,
  and `attachmentSchema` overlaps with `create_article_attachment`'s schema. Both
  are pre-existing shapes; folding them into a `public: boolean` factory or a
  shared exported schema is a cross-cutting refactor beyond this feature's scope
  (repo's "scope discipline" rule). Happy to open a follow-up if desired.
- *Not a defect* — `uploadAttachments` uses `return uploadToken as string`; both
  callers are guarded by `attachments?.length`, so the empty-array path is
  unreachable (verifier verdict: PLAUSIBLE, not confirmed). The assertion is
  documented in a code comment.

## Functional validation plan

**Context.** The feature adds an optional `attachments` array to two tools:
`mcp__zendesk-local__add_public_comment` and `mcp__zendesk-local__add_private_note`.
Each entry is `{ file_name, file_base64, content_type }`. The handler uploads the
file(s) via the Zendesk Uploads API and attaches them to the created comment/note.
Observe the result with `mcp__zendesk-local__get_ticket_attachments`. No other tool
exercises this code; `update_ticket` deliberately does not.

**Setup & prerequisites.** The environment is already on the PR branch with the
`zendesk-local` MCP server running and authenticated (real Zendesk round-trips
work). Record the tested commit: `git rev-parse HEAD`. Create a throwaway ticket to
avoid polluting real data:
`mcp__zendesk-local__create_ticket { "subject": "attach-validation", "description": "scratch" }`
and note its id as `TID`. Ready-to-use base64 payloads (plain text): `"hello"` =
`aGVsbG8=` (5 bytes), `"world!"` = `d29ybGQh` (6 bytes). A credential/egress error is
a `BLOCKED` finding, not a setup task.

**Scenarios.**

| id | Validates | Manipulation / call | Expected observable |
|----|-----------|---------------------|---------------------|
| S1 | Private note with one attachment | `add_private_note { ticket_id: TID, body: "note+file", attachments: [{ file_name: "s1.txt", file_base64: "aGVsbG8=", content_type: "text/plain" }] }` | Returns text `Private note added to ticket #TID with 1 attachment(s).` |
| S2 | Public comment with one attachment | `add_public_comment { ticket_id: TID, body: "reply+file", attachments: [{ file_name: "s2.txt", file_base64: "aGVsbG8=", content_type: "text/plain" }] }` | Returns text `Public comment added to ticket #TID with 1 attachment(s).` |
| S3 | Attachment actually lands on the ticket | `get_ticket_attachments { ticket_id: TID }` | Lists `s1.txt` and `s2.txt`, each `text/plain`, `5 bytes`, with a `fruggr.zendesk.com/attachments/token/.../?name=...` URL |
| S4 | Multi-file aggregation under one token | `add_public_comment { ticket_id: TID, body: "two files", attachments: [{ file_name: "a.txt", file_base64: "aGVsbG8=", content_type: "text/plain" }, { file_name: "b.txt", file_base64: "d29ybGQh", content_type: "text/plain" }] }` then `get_ticket_attachments { ticket_id: TID }` | Return text says `with 2 attachment(s).`; the two new files `a.txt` (5 bytes) and `b.txt` (6 bytes) both appear on the ticket |
| S5 | No-attachment path unchanged | `add_private_note { ticket_id: TID, body: "plain note" }` | Returns `Private note added to ticket #TID.` with **no** `with N attachment(s)` suffix |
| S6 | Strict input validation | `add_public_comment { ticket_id: TID, body: "x", attachments: [{ file_name: "c.txt" }] }` (missing `file_base64`) | Tool error naming the missing required field; nothing posted |
| S7 | Inline comment images surfaced (#15) | On a ticket whose comment body has an image pasted/dragged inline (create one in the Zendesk UI, or reuse an existing ticket, and note its id `IID`): `get_ticket_attachments { ticket_id: IID }` | The inline image appears among the returned attachments/images (it was previously omitted). `get_ticket { ticket_id: IID, include_comments: true }` also lists it under the comment's attachments |

**Long-running behaviours.** None. The feature is synchronous (upload then PUT in
the same call); the 60-minute token validity is never waited on. Multi-file
aggregation and the no-attachment path are also covered by unit tests in
`tests/unit/tools/tickets.test.ts` and the wire round-trip by
`tests/integration/core-scenarios.ts`.

**Priorities.** S1, S2, S3 are the real user-facing paths — do them first. S4 covers
aggregation, S5 guards against regression, S6 is defensive.

**Reporting.** Post a PR comment (English): per-id `OK`/`FAIL`/`BLOCKED` with the
observed evidence (returned tool text, the `get_ticket_attachments` listing), the
tested commit SHA, and an overall green/failing summary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now add file attachments when creating private notes and public comments on tickets.
  * Ticket comments can now include multiple attachments, with upload status reflected in the response.

* **Bug Fixes**
  * Ticket comment views now include inline images when comments are fetched.
  * Attachment inputs are now validated more strictly, including file type and base64 content.

* **Documentation**
  * Updated the tool documentation to mention optional attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->