### PR TITLE
docs(agents): spell out the Glama criteria and no-regression rule for tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,15 @@ GitHub (PRs, commits, comments, code) in **English**. Chat follows the user's la
 
 ## Multi-agent compatibility — absolute rule
 
-Must work with every mainstream MCP agent; no PR may degrade one. New tools follow
-`docs/mcp-metadata.md`.
+Must work with every mainstream MCP agent; no PR may degrade one. Every **new
+tool** must meet the Glama Tool Definition Quality bar (clear purpose, usage
+guidelines, stated side effects, per-parameter `.describe()`) and keep the tool
+set coherent (naming, disambiguation, no needless duplication) — the server
+score is `60% mean + 40% min`, so one weak tool drags the whole surface down.
+Every **tool change** must keep the exposed JSON Schema (draft-07) a *superset*
+of the previous one: enrich freely, but never drop a field, loosen a type, or
+shorten an existing description. Criteria, the checklist and how to diff the
+schema: `docs/mcp-metadata.md`.
 
 ## Documentation maintenance
 

--- a/docs/mcp-metadata.md
+++ b/docs/mcp-metadata.md
@@ -16,6 +16,9 @@ contract, not a vanity metric.
 ## Glama score, in one screen
 
 The overall score is **Tool Definition Quality (70 %) + Server Coherence (30 %)**.
+The weights and dimensions below are from Glama's public methodology
+([glama.ai/mcp/methodology](https://glama.ai/mcp/methodology), retrieved
+2026-07-01) — re-check it if the score moves, as the rubric may evolve.
 
 ### Tool Definition Quality — 70 %
 

--- a/docs/mcp-metadata.md
+++ b/docs/mcp-metadata.md
@@ -64,9 +64,11 @@ How well the tools work together *as a set*. Four dimensions, weighted equally:
 
 ## No regression on a tool change
 
-Agents consume our Zod schemas as **JSON Schema draft-07** — the conversion path
-the MCP SDK uses (`zod/v4-mini` → draft-07). A change is *multi-agent-safe* only
-when the exposed schema stays a **superset** of the previous one:
+Agents consume our Zod schemas as **JSON Schema draft-07**. We author schemas
+with `zod/v4` (see `src/tools/*`); the MCP SDK serializes them to draft-07
+internally via zod v4's mini/`toJSONSchema` path — you don't import `v4-mini`
+yourself. A change is *multi-agent-safe* only when the exposed schema stays a
+**superset** of the previous one:
 
 - **Never remove or shorten** an existing param `description` or the tool
   description — a stricter agent may key off exact text. Enriching is fine.

--- a/docs/mcp-metadata.md
+++ b/docs/mcp-metadata.md
@@ -1,0 +1,80 @@
+# MCP tool metadata — Glama criteria & multi-agent safety
+
+This is the deep dive behind the **Multi-agent compatibility** rule in
+[`AGENTS.md`](../AGENTS.md). It answers two questions every tool change must
+clear:
+
+1. **New tool** — does its definition meet the quality bar the [Glama
+   score](https://glama.ai/mcp/servers/fruggr/zendesk-mcp-server) grades us on?
+2. **Tool change** — does the JSON Schema we expose to agents stay a superset of
+   what it was (no regression)?
+
+The Glama score is the badge at the top of `README.md`; it is a public,
+agent-facing signal of how usable our tools are, so we treat its criteria as a
+contract, not a vanity metric.
+
+## Glama score, in one screen
+
+The overall score is **Tool Definition Quality (70 %) + Server Coherence (30 %)**.
+
+### Tool Definition Quality — 70 %
+
+How well *each individual tool* describes itself to an AI agent. Every tool is
+scored 1–5 on six dimensions:
+
+| Dimension | Weight | What it asks |
+|---|---|---|
+| Purpose Clarity | 25 % | Is it obvious what the tool does and when to reach for it? |
+| Usage Guidelines | 20 % | Does the description say when to use it (and when not)? |
+| Behavioral Transparency | 20 % | Are side effects, mutations and failure modes stated? |
+| Parameter Semantics | 15 % | Does every param have a `.describe()` that explains meaning, format and constraints — not just restate the name? |
+| Conciseness & Structure | 10 % | Is it complete without padding? |
+| Contextual Completeness | 10 % | Enough context to call it correctly without reading the source? |
+
+**Aggregation matters:** the server-level score is **60 % mean + 40 % minimum**
+across all tools. One poorly described tool drags the whole server down, so a new
+tool is not "good enough because the average is fine" — it must stand on its own.
+
+### Server Coherence — 30 %
+
+How well the tools work together *as a set*. Four dimensions, weighted equally:
+
+- **Disambiguation** — can an agent tell two similar tools apart from their
+  descriptions? (e.g. `search` vs `search_tickets` vs `search_articles`.)
+- **Naming Consistency** — verbs, casing and namespace prefixes follow the same
+  pattern as the existing surface.
+- **Tool Count Appropriateness** — no needless proliferation; prefer an optional
+  param over a near-duplicate tool (this is why PR #110 added `attachments` to
+  the two comment tools instead of a new `upload_file` tool).
+- **Completeness** — no obvious gaps a caller would expect to exist.
+
+## Checklist for a new tool
+
+- Description leads with a **standalone first sentence** — proxy modes surface
+  only that sentence (see `AGENTS.md` → Documentation maintenance).
+- Every parameter has a meaningful `.describe()` (Parameter Semantics).
+- Description states side effects / mutations and what the tool returns
+  (Behavioral Transparency), and when to use vs. avoid it (Usage Guidelines).
+- Name matches the existing verb/prefix convention (Naming Consistency).
+- Adding a param to an existing tool beats a near-duplicate tool (Tool Count).
+- Sync the `README.md` tool tables in the same PR.
+
+## No regression on a tool change
+
+Agents consume our Zod schemas as **JSON Schema draft-07** — the conversion path
+the MCP SDK uses (`zod/v4-mini` → draft-07). A change is *multi-agent-safe* only
+when the exposed schema stays a **superset** of the previous one:
+
+- **Never remove or shorten** an existing param `description` or the tool
+  description — a stricter agent may key off exact text. Enriching is fine.
+- **Never drop** a `required` field or loosen a type in a way that changes the
+  emitted schema shape.
+- **Adding constraints is an enrichment, not a regression** — e.g. tightening
+  `z.string().min(1)` to `z.string().min(1).base64()` only *adds* `format` +
+  `pattern` to the draft-07 output and leaves the `description` byte-for-byte
+  identical (verified on PR #110). That is exactly the kind of change we want.
+
+**How to verify:** dump the tool's JSON Schema before and after the change and
+diff it. The diff must be additive only (new keys/constraints), with existing
+`description` strings unchanged. If a field disappears or a description string
+differs, it is a regression — stop and rethink.


### PR DESCRIPTION
## Summary

The review of #110 surfaced that the **Multi-agent compatibility** rule in `AGENTS.md` was too vague: it said "New tools follow `docs/mcp-metadata.md`" but (a) never named what the Glama criteria are, (b) never stated the "no regression on a tool change" rule, and (c) pointed at `docs/mcp-metadata.md`, **which did not exist** (dead reference). An agent had no way to know what "respect the Glama criteria" meant. This PR fixes that.

- Adds `docs/mcp-metadata.md` — the deep dive: the Glama score model (**Tool Definition Quality 70% + Server Coherence 30%**, with per-dimension weights and the **60%-mean / 40%-min** server aggregation), a new-tool checklist, and the JSON Schema **superset / no-regression** rule with a concrete before/after diff check (drawn from the `.base64()` enrichment verified on #110).
- Rewrites the `AGENTS.md` rule so it is self-contained (names the criteria and the schema-superset rule) and now points at a file that exists.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [x] Documentation
- [ ] Tooling / CI

## Author checklist
- [ ] `pnpm test` passes locally — N/A, docs-only change (no code touched)
- [ ] `pnpm test:coverage` meets the thresholds — N/A, docs-only
- [ ] `pnpm check` is clean (lint + format) — N/A, Markdown only
- [ ] `pnpm typecheck` passes — N/A, docs-only
- [x] I have read the diff myself, line by line
- [ ] I ran a Claude Code review on the diff and addressed its findings — N/A, prose-only
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: N/A — no tool change, documentation only

## Notes for the reviewer (human or AI)

- The Glama scoring breakdown (component weights, the six Tool Definition Quality dimensions, the four Server Coherence dimensions, and the 60/40 aggregation) is sourced from Glama's public score documentation — worth a sanity check against the current score page.
- The no-regression rule deliberately encodes the exact reasoning from your #110 review comment: enriching a schema (`.min(1)` → `.min(1).base64()`) only *adds* `format` + `pattern` to the draft-07 output and leaves the `description` byte-for-byte identical, so it is safe; the doc turns that one-off verification into a repeatable diff check.
- Docs-only, no runtime behaviour, so no functional validation plan.

https://claude.ai/code/session_01PFJGXM4bvhPDuv9vW3X82r

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFJGXM4bvhPDuv9vW3X82r)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for adding and changing tools to better preserve compatibility across agents.
  * Clarified expectations for tool descriptions, parameter details, naming consistency, and avoiding duplicate tools.
  * Added stricter rules for schema changes so updates must preserve existing capabilities while allowing only additive improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->