### PR TITLE
chore(coderabbit): review src/tools against the Glama quality rubric

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,6 +30,21 @@ reviews:
           summary (proxy modes only surface that first sentence).
         - Any new, renamed, or removed tool is reflected in README.md and
           AGENTS.md (tool tables and per-namespace counts).
+
+        Judge each tool definition against the Glama Tool Definition Quality
+        rubric (docs/mcp-metadata.md). tests/unit/tools/tool-quality.test.ts is
+        the deterministic FLOOR (param descriptions exist and aren't name
+        restatements, description is >1 sentence, write tools state their
+        effect); you are the CEILING that judgment can't be automated. Flag:
+        - descriptions or `.describe()` that pass the gate but add no real
+          guidance — e.g. text padded only to clear the length/token check,
+          without meaning, format, constraints, or when-to-use-vs-a-sibling.
+        - side effects, mutations, return values or failure modes left implicit
+          on a tool that has them (Behavioral Transparency).
+        - factual claims about Zendesk API behavior that look unverified or wrong
+          (e.g. how tags, locales, or pagination actually behave server-side).
+        - two similar tools an agent couldn't tell apart from their descriptions
+          alone (Disambiguation).
     - path: 'tests/**'
       instructions: |
         Zendesk API calls in tests must go through MSW handlers in


### PR DESCRIPTION
## Summary
Extends the existing `src/tools/**` `path_instructions` in `.coderabbit.yaml` so CodeRabbit scores each MCP tool definition against the six Glama Tool Definition Quality dimensions and flags what a static check can't (padded-but-empty descriptions, implicit side effects, unverified Zendesk API claims, indistinguishable siblings).

This is the **judgment "ceiling"** that complements the deterministic floor test in #117. It is split into its own PR **on purpose**: for OSS repos CodeRabbit ignores config changes coming from a PR head and only applies the config from the **base branch**, so the rule only takes effect once it lands on `main`. Merging this first activates the ceiling for every subsequent PR — including #117's next re-review.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [x] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally (config-only change, no code touched)
- [x] `pnpm check` is clean (lint + format)
- [x] I have read the diff myself, line by line
- [x] Documentation is updated where needed (the floor/ceiling model is documented in `docs/mcp-metadata.md` in #117)

## Notes for the reviewer (human or AI)
- **Config-only, one file.** No source, schema, or behavior change; `chore:` type → no semantic-release version bump.
- Depends conceptually on #117 (the floor test + `docs/mcp-metadata.md`), but has no code dependency — it can merge in either order. If this lands first, the identical `.coderabbit.yaml` lines in #117 become a no-op on that branch (same content, no conflict).

https://claude.ai/code/session_01WR9DB2M31evb1BiUk6891H

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR9DB2M31evb1BiUk6891H)_