### PR TITLE
fix(tools): state outcomes on article write tools and harden the quality gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ zendesk-mcp-server acme --namespace tickets
 | `update_article_translation` | Update an article's translation (full body) | write |
 | `update_article_section` | Replace a single section of an article | write |
 | `create_content_tag` | Create a new Guide content tag | write |
-| `create_article_attachment` | Upload an attachment to an article | write |
+| `create_article_attachment` | Upload a file to a Help Center article (returns the created attachment) | write |
 
 </details>
 

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -605,7 +605,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Create Help Center Article',
       description:
-        "Create a new article in a section. The locale becomes the article's source_locale. Requires a permission_group_id (use list_permission_groups to find available IDs). To add content in other locales afterwards, use create_article_translation.",
+        "Create a new article in a section and return the created article with its id. The locale becomes the article's source_locale. Requires a permission_group_id (use list_permission_groups to find available IDs). To add content in other locales afterwards, use create_article_translation.",
       inputSchema: z.object({
         section_id: z
           .number()
@@ -690,7 +690,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Update Help Center Article',
       description:
-        'Update article metadata only (draft, promoted, labels, tags, visibility, section, sort position, etc.). Does NOT update content (title, body) — use update_article_translation for that.',
+        'Update article metadata only (draft, promoted, labels, tags, visibility, section, sort position, etc.) and return the updated article. Does NOT update content (title, body) — use update_article_translation for that.',
       inputSchema: z.object({
         article_id: z
           .number()
@@ -1200,15 +1200,27 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Create Article Attachment',
       description:
-        'Upload an attachment to an article. Provide file content as base64-encoded string.',
+        "Upload a file to a Help Center article and return the created attachment (its id, file name, content type, size and content URL). Not idempotent: calling it again uploads another copy rather than replacing the previous one. This is for article assets — for files on support tickets use get_ticket_attachments, and to see an article's existing attachments use list_article_attachments.",
       inputSchema: z.object({
         article_id: z.number().int().describe(ARTICLE_ID_DESC),
-        file_name: z.string().min(1).describe('File name (e.g., "screenshot.png")'),
-        file_base64: z.string().min(1).describe('File content encoded as base64'),
+        file_name: z
+          .string()
+          .min(1)
+          .describe(
+            'Name to store the file under, including its extension (e.g. "screenshot.png"); used as the download name.',
+          ),
+        file_base64: z
+          .string()
+          .min(1)
+          .describe(
+            "The file's raw bytes as a base64-encoded string; the server decodes them before upload.",
+          ),
         content_type: z
           .string()
           .default('application/octet-stream')
-          .describe('MIME type (e.g., "image/png", "application/pdf")'),
+          .describe(
+            'MIME type of the file, e.g. "image/png" or "application/pdf". Defaults to application/octet-stream when omitted.',
+          ),
       }),
       annotations: {
         readOnlyHint: false,

--- a/tests/unit/tools/tool-quality.test.ts
+++ b/tests/unit/tools/tool-quality.test.ts
@@ -74,7 +74,7 @@ const novelTokenCount = (name: string, description: string): number => {
 // the backstop requires a result/return marker, not any verb. Intentionally NOT
 // surfaced in the failure message (teach the goal, not the trick).
 const OUTCOME =
-  /\b(returns?|returned|replaces?|replaced|overwrites?|appended?|appends|emails?|no-op|idempotent|the (?:created|updated|new|resulting)\b)/i;
+  /\b(?:returns?|returned|replaces?|replaced|overwrites?|appends?|appended|emails?|no-op|idempotent|the (?:created|updated|new|resulting))\b/i;
 
 const countSentences = (text: string): number =>
   text

--- a/tests/unit/tools/tool-quality.test.ts
+++ b/tests/unit/tools/tool-quality.test.ts
@@ -66,10 +66,15 @@ const novelTokenCount = (name: string, description: string): number => {
   return novel.size;
 };
 
-// A write tool must tell the caller what it changes / returns. Backstop list of
-// effect verbs — intentionally NOT surfaced in the failure message.
-const EFFECT =
-  /\b(returns?|replaces?|creates?|updates?|deletes?|adds?|removes?|sets?|posts?|uploads?|no-op|idempotent|overwrites?|changes?)\b/i;
+// A write tool must disclose its OUTCOME — what it returns or the concrete
+// resulting state — not merely restate its action. A bare action verb (a tool
+// named create_article_attachment described as "Upload an attachment…") passes
+// RULE B and looks fine, yet says nothing an annotation/name doesn't already
+// imply, which is exactly what Glama scores 2/5 on Behavioral Transparency. So
+// the backstop requires a result/return marker, not any verb. Intentionally NOT
+// surfaced in the failure message (teach the goal, not the trick).
+const OUTCOME =
+  /\b(returns?|returned|replaces?|replaced|overwrites?|appended?|appends|emails?|no-op|idempotent|the (?:created|updated|new|resulting)\b)/i;
 
 const countSentences = (text: string): number =>
   text
@@ -130,15 +135,17 @@ describe('tool definition quality gate', () => {
     fail(problems);
   });
 
-  it('RULE C — every write tool states its effect or return value', () => {
+  it('RULE C — every write tool states its return value or resulting state', () => {
     const problems: string[] = [];
     for (const tool of tools) {
-      if (!tool.readOnly && !EFFECT.test(tool.description)) {
+      if (!tool.readOnly && !OUTCOME.test(tool.description)) {
         problems.push(
-          `❌ ${tool.name} — write tool (readOnly=false) whose description does not state what it\n` +
-            `   changes or returns: "${tool.description}"\n` +
-            `   Glama "Behavioral Transparency" (20%): a mutation's side effects must be explicit.\n` +
-            `   Fix: say what is created/updated/removed and what comes back, like ${EFFECT_EXEMPLAR}. See ${DOC}.`,
+          `❌ ${tool.name} — write tool (readOnly=false) whose description names an action but not\n` +
+            `   its outcome: "${tool.description}"\n` +
+            `   Glama "Behavioral Transparency" (20%): a mutation must disclose what it returns and\n` +
+            `   the resulting state — restating the action (the tool name) earns no credit.\n` +
+            `   Fix: state what comes back and any side effect (idempotency, duplicates), like\n` +
+            `   ${EFFECT_EXEMPLAR}. See ${DOC}.`,
         );
       }
     }


### PR DESCRIPTION
## Summary
The v2.6 Glama re-scan gave every tool an A **except `create_article_attachment`** (2.9, grade C — Behavior 2/5, Completeness 2/5, Usage Guidelines 2/5). This PR fixes that tool and closes the gap that let it through.

**Why it slipped through** (all three layers missed it):
- **Gate RULE C** only required an effect *verb* — `"Upload an attachment…"` matched, so the tool passed even though the description disclosed no return value, idempotency, or context.
- **CodeRabbit** reviews only the diff; this tool's description wasn't in the enrichment diff (it only received the shared `ARTICLE_ID_DESC` constant), so its depth was never re-examined.
- **Functional validation** (H21) confirmed the tool is *callable* first-try — a different axis from Glama's description-depth score.

## Changes
- **`create_article_attachment`** — state the returned attachment (id, name, type, size, content URL), that it is **not idempotent** (re-upload creates a duplicate), the **article-vs-ticket** distinction, and pointers to `get_ticket_attachments` / `list_article_attachments`; enrich `file_name` / `file_base64` / `content_type`.
- **Harden gate RULE C** (`tests/unit/tools/tool-quality.test.ts`) — a write tool must now disclose its **outcome** (return value / resulting state), not just an action verb. This deterministically catches the `create_article_attachment` class.
- **`create_article` / `update_article`** — brought up to the hardened rule by stating they return the created/updated article (a Behavioral-Transparency gain regardless).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [x] Documentation
- [x] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally (408 passed; hardened gate green)
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line

## Notes for the reviewer (human or AI)
- **No handler/behavior change** beyond description/param strings and one test rule. Schema shapes unchanged.
- **Honest limitation:** the deterministic gate raises a floor; it cannot reproduce Glama's Completeness/Usage *depth* judgment. RULE C now catches "action stated, outcome omitted", but the durable guard against pre-existing thin tools is a **whole-surface** review (CodeRabbit reviews only diffs) or a periodic per-tool TDQS self-score by the functional agent. Noted for follow-up.

https://claude.ai/code/session_01WR9DB2M31evb1BiUk6891H

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR9DB2M31evb1BiUk6891H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified user-facing Help Center tool descriptions to better state what each action returns (including created article and attachment details).
  * Expanded guidance for attachment upload inputs (file name, file data, and content type) with clearer wording and examples.

* **Chores**
  * Tightened quality checks for write tool descriptions to require explicit disclosure of returned values or resulting state, improving transparency for end-user-facing metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->