### PR TITLE
docs: restructure README + extract reference docs + surface multimodal attachments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,8 +28,9 @@ reviews:
         - The Zod schema validates all inputs and matches the handler's usage.
         - The first sentence of the tool description reads as a self-contained
           summary (proxy modes only surface that first sentence).
-        - Any new, renamed, or removed tool is reflected in README.md and
-          AGENTS.md (tool tables and per-namespace counts).
+        - Any new, renamed, or removed tool is reflected in the tool tables in
+          docs/mcp-tools-reference.md, and in AGENTS.md / README.md when a whole
+          namespace or per-namespace count changes.
 
         Score each tool definition against Glama's TDQS rubric
         (github.com/glama-ai/tool-definition-quality-score). Core rule: a

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 - [ ] I have read the diff myself, line by line
 - [ ] I ran a Claude Code review on the diff and addressed its findings
 - [ ] Documentation is updated where needed
-- [ ] If this PR adds an MCP tool: it is documented in `README.md`
+- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
 
 ## Notes for the reviewer (human or AI)
 <!-- Points worth attention, design choices to validate, alternatives ruled out -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,9 @@ schema: `docs/mcp-metadata.md`.
 
 ## Documentation maintenance
 
-Any change to the tool surface syncs the `README.md` tool tables in the same PR.
+Any change to the tool surface syncs the tool tables in
+`docs/mcp-tools-reference.md` (and, if a whole namespace appears or disappears,
+the namespace list in the `README.md` "Available tools" section) in the same PR.
 Prose and section headers are deliberately count-free (no per-section
 `(N tools)` or global tool totals) — don't reintroduce hardcoded counts, they
 only go stale. Exact counts still live where they're load-bearing: namespace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,10 @@ browser PKCE via `token-store.ts`. HTTP: per-session bearer captured from
 credential — insufficiently secure, doesn't scale to multi-user/remote); the
 rationale lives in `README.md` ("What this server does *not* do").
 
-Setup, CLI flags, env vars and auth flows live in `README.md`; manual tool
-testing in `docs/live-testing.md`.
+Local setup and auth flows live in `README.md`; CLI flags and env vars in
+`docs/configuration.md`; remote HTTP deployment in `docs/http-deployment.md`;
+troubleshooting in `docs/troubleshooting.md`; manual tool testing in
+`docs/live-testing.md`.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,46 @@ the mechanical issues; understanding the change is non-negotiable.
 
 External contributions follow the same standard.
 
+## Development setup
+
+### Toolchain
+
+| Tool | Version | Source of truth |
+| ---- | ------- | ---------------- |
+| Node | 24 | [`.nvmrc`](.nvmrc) — read by `nvm`, `fnm`, `mise`, `asdf`, `volta` |
+| pnpm | 11 | [`package.json#packageManager`](package.json) (pinned with a corepack integrity hash) |
+
+The toolchain (Node 24 + pnpm 11) is used to build, lint, type-check and
+test the project. The **published package** still runs on Node 20+ (see
+`engines.node`); a dedicated CI job installs the packed tarball on Node 20
+and runs the smoke test to keep that promise honest.
+
+```bash
+# Clone, install, build
+git clone https://github.com/fruggr/zendesk-mcp-server.git
+cd zendesk-mcp-server && pnpm install && pnpm build
+node dist/index.js <your-subdomain>
+
+# Dev mode, OAuth (browser opens on first tool call)
+pnpm dev -- <your-subdomain> --mode all
+
+# Dev mode, HTTP transport (OAuth bearer from the MCP client)
+pnpm dev -- <your-subdomain> --transport http --port 3000 --public-url http://localhost:3000
+
+# Build / typecheck / lint / test
+pnpm build && pnpm typecheck && pnpm check && pnpm test
+```
+
+To test a PR branch without publishing to npm — the `prepare` script builds on install:
+
+```bash
+npx -y github:fruggr/zendesk-mcp-server <your-subdomain>
+npx -y github:fruggr/zendesk-mcp-server#my-feature-branch <your-subdomain>
+```
+
+Architecture, code style, submission bar and release workflow live in
+[`AGENTS.md`](AGENTS.md).
+
 ## Opening a pull request
 
 1. Fork the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ The same checklist appears on the
 - [ ] Documentation is updated if behavior or the tool surface changed
       (see [Documentation maintenance](AGENTS.md#documentation-maintenance)
       in `AGENTS.md`).
-- [ ] If a new MCP tool was added, it is documented in `README.md`.
+- [ ] If a new MCP tool was added, it is documented in
+      `docs/mcp-tools-reference.md`.
 
 ## Code standards
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ the right tools on your behalf:
   priority or assignee, or mark it solved.
 - **Summarize a ticket for reporting or a quick decision** — pull the details and
   the full comment thread and get the gist in a sentence.
+- **Read the screenshots and photos attached to a ticket** — error dialogs, UI
+  captures or product photos are handed to your assistant's own model as images,
+  so it can describe them or act on what they show.
 - **Search and triage your queue in plain language** — "show me my open tickets
   about billing from this week."
 - **Draft and maintain knowledge-base articles** — write a new article, or revise
@@ -53,12 +56,32 @@ differently:
 - **Two deployment shapes, same auth story** — Run it on your laptop as a stdio MCP server (Claude Desktop / Claude Code / VS Code) or deploy it as a private remote MCP server with one user, one Zendesk session per HTTP request.
 - **Context-friendly tool modes** — Expose every operation as its own tool, group them into namespace proxies, or collapse to a single unified tool. Tools are segmented into namespaces you can selectively enable, so each context loads only the surface it needs.
 - **Section-based article editing** — For large Help Center articles, read and rewrite one section at a time (parsed by h1/h2/h3 headings) instead of shuffling the full HTML body through the assistant. Reduces tokens by 10–100× on targeted edits.
+- **Native multimodal attachments** — ticket images are delivered as native MCP image content for the **client's own model** to analyze: no server-side vision model, **no extra API key**, fully vendor-neutral (see [Attachments & vision](#attachments--vision)).
 - **Read-only mode** — Restrict the server to read operations only, ideal for assistants that should never modify data.
 - **Lean stack** — Built on the official `@modelcontextprotocol/sdk` plus `zod`.
 
 Under the hood it speaks to the **Zendesk Support & Help Center (Guide) APIs**,
 runs locally over **stdio** or as a private **remote MCP server** over HTTP, and
 ships fine-grained tool-visibility controls — the specifics are below.
+
+### Attachments & vision
+
+Ticket image attachments are returned as **native MCP multimodal content**, so the
+assistant's own model (Claude, GPT, Gemini, …) sees the pixels directly. There is
+no server-side vision model and **no extra API key** — the opposite of servers
+that expose an `analyze_ticket_images`-style tool calling a vision model with the
+operator's own key.
+
+| | This server | Server-side-analysis alternatives |
+|---|---|---|
+| Who sees the image | The **client's own model** receives the pixels as multimodal input | The **server** calls a vision model with **its own API key** |
+| Extra dependencies | None | Vision-model API key + billing on the server |
+| Vendor neutrality | ✅ Full | ❌ Locked to one provider |
+
+Non-image attachments come back as text references. The per-image size cap and the
+number of embedded images are **configurable** — see
+[`ZENDESK_MAX_ATTACHMENT_BYTES`](docs/configuration.md#zendesk_max_attachment_bytes)
+and [`ZENDESK_MAX_EMBEDDED_IMAGES`](docs/configuration.md#zendesk_max_embedded_images).
 
 ## When to use this server
 
@@ -261,298 +284,39 @@ Add to your `.vscode/mcp.json`:
 
 ## Quick start: remote (HTTP)
 
-> 🧪 **Experimental.** The HTTP transport is shipped but has not yet been
-> exercised end-to-end against a real Zendesk tenant from every supported
-> MCP client. Local stdio is the supported path. Until this notice is
-> removed, expect rough edges around OAuth discovery behind reverse
-> proxies, CORS with browser clients, and 401 / refresh flows — please
-> open an issue with the symptoms you hit.
+> 🧪 **Experimental.** The HTTP transport is shipped but not yet exercised
+> end-to-end against a real Zendesk tenant from every MCP client — local stdio is
+> the supported path.
 
-Deploy a private MCP server for **one** Zendesk account. Every MCP client connecting to the server presents its **own** user's OAuth bearer in `Authorization:` — the server never sees a shared admin key.
+You can also deploy a private remote MCP server for **one** Zendesk account, where
+every MCP client presents its **own** user's OAuth bearer in `Authorization:` (the
+server never sees a shared admin key). The full guide — OAuth setup, `--public-url`
+behind a reverse proxy, per-platform config, discovery endpoints, MCP client
+wiring, CORS and operator responsibilities — is in
+**[docs/http-deployment.md](docs/http-deployment.md)**.
 
-### Zendesk OAuth setup
+## Configuration
 
-Same procedure as the [local quick start](#zendesk-oauth-setup), with one difference: the **Redirect URL** must match the callback your MCP client uses — provided by the client itself, e.g. `https://claude.ai/oauth/callback` for claude.ai on the web. Check your client's docs.
-
-### Run the server
-
-```bash
-zendesk-mcp-server <your-subdomain> --transport http --port 3000 \
-  --public-url https://mcp.example.com
-# stderr: Zendesk MCP server running via http on 0.0.0.0:3000
-```
-
-### Public URL
-
-`--public-url` (or `PUBLIC_URL=…`) is the URL **clients use to reach you**. It's what gets advertised in the OAuth discovery metadata as the canonical resource identifier (RFC 8707). When the server is behind a TLS reverse proxy — Azure App Service, Heroku, Fly.io, Cloudflare Tunnel, nginx, Caddy… — the bind host and the public URL differ, and spec-compliant MCP clients will refuse the connection if the metadata advertises the wrong resource. Without it the server boots in a degraded mode and prints a warning.
-
-| Platform | Recommended setup |
-|---|---|
-| **Azure App Service** | Startup command: `PUBLIC_URL="https://$WEBSITE_HOSTNAME" zendesk-mcp-server $ZENDESK_SUBDOMAIN --transport http --port $PORT` |
-| **Heroku / Fly / Cloud Run** | `PUBLIC_URL=https://<your-app>.<provider>.app` in the env / config |
-| **Caddy / nginx / Traefik in front of a VM** | `PUBLIC_URL=https://mcp.example.com` |
-| **Local dev (no proxy)** | `--host 127.0.0.1 --port 3000` — the resource URL is derived automatically (the wildcard `0.0.0.0` is what triggers the warning) |
-
-### Authentication on every request
-
-`Authorization: Bearer …` is required on **every** `/mcp` request — a session id alone is never accepted as a credential. The most recent bearer presented on a session is the one used for Zendesk calls, so a client refreshing its token mid-session just works.
-
-### Verify discovery endpoints
-
-Served by the HTTP transport in `src/transports/http.ts`:
-
-```bash
-curl -s http://localhost:3000/.well-known/oauth-protected-resource
-# → { "authorization_servers": ["https://<subdomain>.zendesk.com"], ... }
-
-curl -s http://localhost:3000/.well-known/oauth-authorization-server
-# → { "issuer": "https://<subdomain>.zendesk.com", "authorization_endpoint": "...", ... }
-
-curl -s -i http://localhost:3000/healthz   # → 200 OK
-```
-
-### MCP client wiring
-
-Every major MCP client supports remote servers over Streamable HTTP and handles the OAuth 2.1 PKCE discovery flow natively — paste the URL, sign in once, you're connected. Replace `https://mcp.example.com` below with your deployed origin.
-
-<details>
-<summary><strong>Claude Code (CLI)</strong></summary>
-
-```bash
-claude mcp add zendesk --transport http https://mcp.example.com/mcp
-```
-
-</details>
-
-<details>
-<summary><strong>Claude Desktop</strong></summary>
-
-**Settings → Connectors → + Add custom connector**, paste `https://mcp.example.com/mcp`, click **Connect**. Claude Desktop drives the OAuth flow in your browser on first call.
-
-</details>
-
-<details>
-<summary><strong>claude.ai (web)</strong></summary>
-
-**Settings → Connectors → Add custom connector**, same URL. The OAuth flow runs in the same tab.
-
-</details>
-
-<details>
-<summary><strong>VS Code (GitHub Copilot / Continue / Cline)</strong></summary>
-
-Add to your `.vscode/mcp.json`:
-
-```json
-{
-  "servers": {
-    "zendesk": {
-      "type": "http",
-      "url": "https://mcp.example.com/mcp"
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Cursor, Windsurf</strong></summary>
-
-Both expose an MCP settings UI that accepts a remote URL. Paste `https://mcp.example.com/mcp` and sign in when prompted.
-
-</details>
-
-<details>
-<summary><strong>Zed</strong></summary>
-
-Zed added native OAuth 2.0 + PKCE for Streamable HTTP MCP servers in 2026 ([zed-industries/zed#51768](https://github.com/zed-industries/zed/pull/51768)). Configure the remote server in your Zed settings; on first use Zed opens a loopback browser callback to complete the flow.
-
-If you're on an older Zed build that predates that change, fall back to [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local shim that does the OAuth flow on your machine and proxies the session:
-
-```json
-{
-  "context_servers": {
-    "zendesk": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.example.com/mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-On the first call the MCP client fetches the discovery metadata, performs the OAuth 2.1 PKCE flow against Zendesk on behalf of the **end user**, and sends the resulting access token as a `Bearer` to the server. Each subsequent tool call runs with that user's Zendesk permissions.
-
-### CORS
-
-The HTTP transport ships a default CORS allowlist that covers today's major **browser-based** MCP clients out of the box (ordered by user base): `chatgpt.com`, `claude.ai`, `gemini.google.com`, `copilot.microsoft.com`, `perplexity.ai`, `chat.mistral.ai`, `grok.com`, plus `chat.openai.com`. Localhost on any port (MCP Inspector, dev pages) is also always allowed.
-
-**Native MCP clients** (Claude Desktop / Claude Code CLI / Cursor / VS Code / Zed) send no `Origin` header — CORS doesn't apply to them, they work regardless.
-
-To allow an additional browser origin (custom dashboard, internal portal), pass `--cors-origin` (repeatable) or set `CORS_ORIGIN` as a comma-separated list:
-
-```bash
-zendesk-mcp-server acme --transport http --port 3000 \
-  --cors-origin https://internal-dashboard.example.com \
-  --cors-origin https://team-portal.example.com
-```
-
-The defaults are always applied — your additions extend them, they don't replace them.
-
-### Operator responsibilities
-
-This server provides the MCP transport and the OAuth discovery metadata. The operator is still responsible for:
-
-- **TLS termination** (put the server behind a reverse proxy like Caddy / nginx / Cloudflare Tunnel)
-- **Network exposure & firewall** (the server binds `0.0.0.0` by default — choose carefully)
-- **Process supervision** (systemd, Docker, fly.io, your hosting provider's runner — none is shipped here)
-
-## CLI reference
-
-```
-zendesk-mcp-server <subdomain> [options]
-
-Options:
-  --mode <mode>           single | namespace (default) | all
-  --namespace <ns>        Filter by namespace (repeatable): tickets, help_center, users
-  --tool <name>           Filter by tool name (repeatable, forces --mode all)
-  --read-only             Only expose read operations
-  --no-topology           Disable the Help Center structural context
-                          (instructions + zendesk-hc://topology resource)
-  --log-level <level>     debug | info (default) | warn | error
-  --transport <t>         stdio (default) | http
-  --host <host>           HTTP bind host (default: 0.0.0.0)
-  --port <port>           HTTP bind port (default: 3000; 0 = OS-assigned)
-  --public-url <url>      Public URL clients use to reach the server (HTTP mode,
-                          required behind a TLS reverse proxy)
-  --cors-origin <url>     Extra browser origin allowed by CORS (repeatable;
-                          adds to the default allowlist of major web MCP
-                          clients + localhost-any-port)
-  --callback-port <port>  Local OAuth callback port for stdio (default 27439)
-```
-
-`--namespace` and `--read-only` are applied before the proxies are registered, so they narrow the surface in every mode — in the default `namespace` mode, `--namespace help_center` registers a single proxy (`zendesk_help_center`) instead of three.
-
-**Examples:**
-
-```bash
-# Local single-tool mode — minimal context, every operation in one tool
-zendesk-mcp-server acme --mode single
-
-# Read-only tickets only
-zendesk-mcp-server acme --read-only --namespace tickets
-
-# Cherry-pick specific tools
-zendesk-mcp-server acme --tool get_ticket --tool search_tickets --tool get_current_user
-
-# Remote HTTP, read-only Help Center surface
-zendesk-mcp-server acme --transport http --port 8080 \
-  --namespace help_center --read-only
-```
-
-## Environment variables
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `ZENDESK_SUBDOMAIN` | yes (or CLI arg) | — | Zendesk subdomain (e.g., `acme` for acme.zendesk.com) |
-| `ZENDESK_OAUTH_CLIENT_ID` | no | `<subdomain>_zendesk` | OAuth client identifier |
-| `ZENDESK_OAUTH_CALLBACK_PORT` | no | `27439` | Local port for the OAuth browser callback (also `--callback-port`). Must match the redirect URL registered in Zendesk. **stdio only**. |
-| `ZENDESK_TOKEN_FILE` | no | OS config dir | Path to the persisted OAuth token file (`0600`). |
-| `TRANSPORT` | no | `stdio` | `stdio` or `http` |
-| `HOST` | no | `0.0.0.0` | HTTP bind host |
-| `PORT` | no | `3000` | HTTP bind port (`0` to let the OS pick) |
-| `PUBLIC_URL` | recommended in HTTP behind a proxy | derived from host:port | Public URL advertised in OAuth discovery metadata |
-| `CORS_ORIGIN` | no | — | Comma-separated browser origins added to the default CORS allowlist |
-| `LOG_LEVEL` | no | `info` | Log verbosity (`debug` surfaces the full OAuth flow trace) |
+The complete reference for the CLI flags (`--mode`, `--namespace`, `--read-only`,
+`--transport`, `--public-url`, …) and the environment variables (`ZENDESK_SUBDOMAIN`,
+`ZENDESK_TOKEN_FILE`, `PUBLIC_URL`, the attachment-vision caps, …) lives in
+**[docs/configuration.md](docs/configuration.md)** — with a per-variable anchor so
+you can deep-link a specific setting.
 
 The server uses per-user OAuth 2.1 PKCE for every transport (local stdio and remote HTTP). There is no static API-token mode — see [What this server does *not* do](#what-this-server-does-not-do).
 
 ## Troubleshooting
 
-### The browser doesn't open during OAuth login
-
-The OAuth flow opens your default browser on the first tool call. The first call
-fails fast with a message that includes the authorize URL, so even if the
-browser can't open (common in sandboxed or remote desktop environments) you can
-open that URL manually — it's also printed to the server's stderr. Sign in, then
-retry the request.
-
-To collect diagnostics, restart with `LOG_LEVEL=debug`. The server then emits
-structured logs through **two channels**, so they're reachable on any MCP client:
-
-- **stderr** — captured to a log file by every mainstream client.
-- **MCP logging notifications** (`notifications/message`) — surfaced by clients
-  that support the `logging` capability.
-
-When the browser fails to open, look for the `oauth_browser_open_failed` event:
-it reports the underlying error, the platform, and which environment markers are
-present (no secrets, tokens, or env values are ever logged).
-
-### The OAuth callback port is already in use
-
-The sign-in flow runs a short-lived local server on port `27439` to receive the
-callback. If that port is taken, the first tool call fails with a message saying
-so (and logs `oauth_callback_listen_failed`). Pick a free port with
-`ZENDESK_OAUTH_CALLBACK_PORT=<port>` (or `--callback-port <port>`), and register
-the matching `http://localhost:<port>/callback` redirect URL in your Zendesk
-OAuth client.
-
-### I have to re-authenticate every time
-
-The OAuth token is persisted to an owner-only file in your OS config dir and
-reused across restarts, so this shouldn't happen. If it does, check that the file
-is writable (`ZENDESK_TOKEN_FILE` to relocate it) and look for
-`token_persist_failed` in the logs.
-
-Where each client writes the server's stderr:
-
-| Client | Log location |
-|--------|--------------|
-| Claude Desktop (macOS) | `~/Library/Logs/Claude/mcp-server-*.log` |
-| Claude Desktop (Windows) | `%APPDATA%\Claude\logs\mcp-server-*.log` |
-| Claude Code | `claude --debug`, or the session logs |
-| Cursor / VS Code / Cline | the extension's MCP output/log panel |
+Browser not opening during OAuth login, the callback port already in use, having
+to re-authenticate every time, and where each client writes the server's stderr
+are covered in **[docs/troubleshooting.md](docs/troubleshooting.md)**. Restart
+with `LOG_LEVEL=debug` for the full OAuth flow trace.
 
 ## Development
 
-### Toolchain
-
-| Tool | Version | Source of truth |
-| ---- | ------- | ---------------- |
-| Node | 24 | [`.nvmrc`](.nvmrc) — read by `nvm`, `fnm`, `mise`, `asdf`, `volta` |
-| pnpm | 11 | [`package.json#packageManager`](package.json) (pinned with a corepack integrity hash) |
-
-The toolchain (Node 24 + pnpm 11) is used to build, lint, type-check and
-test the project. The **published package** still runs on Node 20+ (see
-`engines.node`); a dedicated CI job installs the packed tarball on Node 20
-and runs the smoke test to keep that promise honest.
-
-```bash
-# Clone, install, build
-git clone https://github.com/fruggr/zendesk-mcp-server.git
-cd zendesk-mcp-server && pnpm install && pnpm build
-node dist/index.js <your-subdomain>
-
-# Dev mode, OAuth (browser opens on first tool call)
-pnpm dev -- <your-subdomain> --mode all
-
-# Dev mode, HTTP transport (OAuth bearer from the MCP client)
-pnpm dev -- <your-subdomain> --transport http --port 3000 --public-url http://localhost:3000
-
-# Build / typecheck / lint / test
-pnpm build && pnpm typecheck && pnpm check && pnpm test
-```
-
-To test a PR branch without publishing to npm — the `prepare` script builds on install:
-
-```bash
-npx -y github:fruggr/zendesk-mcp-server <your-subdomain>
-npx -y github:fruggr/zendesk-mcp-server#my-feature-branch <your-subdomain>
-```
-
-Contributor conventions (architecture, code style, submission bar, release workflow) live in [`AGENTS.md`](AGENTS.md).
+Setting up the repo, the toolchain (Node 24 + pnpm 11), dev mode and how to test
+a PR branch are covered in **[CONTRIBUTING.md](CONTRIBUTING.md#development-setup)**.
+Architecture and code-style conventions live in [`AGENTS.md`](AGENTS.md).
 
 ## Inspiration & related projects
 

--- a/README.md
+++ b/README.md
@@ -120,75 +120,13 @@ zendesk-mcp-server acme --namespace tickets
 
 ## Available tools
 
-<details>
-<summary><strong>Tickets</strong></summary>
+The tools are grouped into four namespaces — **Tickets**, **Help Center**,
+**Users & Organizations**, and **Search** — each of which you can enable
+selectively with `--namespace` (see [Tool modes](#tool-modes)).
 
-| Tool | Description | Mode |
-|------|-------------|------|
-| `get_ticket` | Retrieve a ticket by ID with optional comments and its live SLA state (resolved via a scoped search) | read |
-| `get_ticket_attachments` | Download ticket attachments (images as base64, others as references) | read |
-| `search_tickets` | Search tickets using Zendesk query syntax, with per-result SLA state | read |
-| `list_tickets` | List tickets with cursor-based pagination | read |
-| `get_linked_incidents` | Get incidents linked to a problem ticket | read |
-| `list_sla_policies` | List SLA policies with filter conditions and per-priority targets (requires an admin token, or a custom role with the SLA-management permission) | read |
-| `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |
-| `update_ticket` | Update ticket status, priority, assignee, tags, custom fields | write |
-| `add_private_note` | Add an internal note (not visible to requester), optionally with file attachments | write |
-| `add_public_comment` | Add a public comment (visible to requester), optionally with file attachments | write |
-| `manage_tags` | Add or remove tags on a ticket | write |
-
-</details>
-
-<details>
-<summary><strong>Help Center</strong></summary>
-
-| Tool | Description | Mode |
-|------|-------------|------|
-| `search_articles` | Full-text search across Help Center articles | read |
-| `get_article` | Retrieve article by ID with full HTML body | read |
-| `get_article_outline` | Compact outline of an article (sections + available translations) | read |
-| `get_article_section` | Retrieve a single section (html or markdown) | read |
-| `list_categories` | List all Help Center categories | read |
-| `list_sections` | List sections, optionally filtered by category | read |
-| `list_articles` | List articles with sorting and translation info | read |
-| `list_article_translations` | List available translations for an article | read |
-| `list_article_attachments` | List attachments on an article | read |
-| `list_permission_groups` | List Guide permission groups (needed to create articles) | read |
-| `list_content_tags` | List Guide content tags (end-user visible) | read |
-| `list_labels` | List article labels (search ranking, not user-visible) | read |
-| `list_user_segments` | List user segments (article visibility) | read |
-| `compare_translations` | Section-level diff between two locales of an article | read |
-| `create_article` | Create a new article in a section | write |
-| `update_article` | Update article metadata (draft, labels, tags, visibility, section, sort position) | write |
-| `create_article_translation` | Create a translation for an article | write |
-| `update_article_translation` | Update an article's translation (full body) | write |
-| `update_article_section` | Replace a single section of an article | write |
-| `create_content_tag` | Create a new Guide content tag | write |
-| `create_article_attachment` | Upload a file to a Help Center article (returns the created attachment) | write |
-
-</details>
-
-<details>
-<summary><strong>Users & Organizations</strong></summary>
-
-| Tool | Description | Mode |
-|------|-------------|------|
-| `get_current_user` | Get the authenticated user (verify identity) | read |
-| `search_users` | Search users by name, email, or query syntax | read |
-| `get_user` | Retrieve a user by ID | read |
-| `get_organization` | Retrieve an organization by ID | read |
-| `list_organizations` | List all organizations with pagination | read |
-
-</details>
-
-<details>
-<summary><strong>Search</strong></summary>
-
-| Tool | Description | Mode |
-|------|-------------|------|
-| `search` | Unified search across tickets, users, and organizations | read |
-
-</details>
+The full tool-by-tool reference — every tool with its description and its
+`read`/`write` mode — lives in
+**[docs/mcp-tools-reference.md](docs/mcp-tools-reference.md)**.
 
 ## Help Center context (instructions + resources)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,9 +5,11 @@ flags and the environment variables. Each variable has its own anchor, so you ca
 deep-link a specific setting (e.g.
 [`docs/configuration.md#zendesk_max_attachment_bytes`](#zendesk_max_attachment_bytes)).
 
-CLI flags take precedence over the matching environment variable. The server uses
-per-user OAuth 2.1 PKCE for every transport — there is no static API-token mode
-(see [What this server does *not* do](../README.md#what-this-server-does-not-do)).
+CLI flags generally take precedence over the matching environment variable; the
+exception is `--cors-origin`, which is additive and *extends* `CORS_ORIGIN`
+rather than replacing it. The server uses per-user OAuth 2.1 PKCE for every
+transport — there is no static API-token mode (see
+[What this server does *not* do](../README.md#what-this-server-does-not-do)).
 
 ## CLI reference
 
@@ -33,7 +35,7 @@ Options:
   --callback-port <port>  Local OAuth callback port for stdio (default 27439)
 ```
 
-`--namespace` and `--read-only` are applied before the proxies are registered, so they narrow the surface in every mode — in the default `namespace` mode, `--namespace help_center` registers a single proxy (`zendesk_help_center`) instead of three.
+`--namespace` and `--read-only` are applied before the proxies are registered, so they narrow the surface in every mode — in the default `namespace` mode, `--namespace help_center` registers a single proxy (`zendesk_help_center`) instead of the full set of namespace proxies.
 
 **Examples:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,124 @@
+# Configuration — CLI flags & environment variables
+
+Full reference for configuring the [Zendesk MCP Server](../README.md): the CLI
+flags and the environment variables. Each variable has its own anchor, so you can
+deep-link a specific setting (e.g.
+[`docs/configuration.md#zendesk_max_attachment_bytes`](#zendesk_max_attachment_bytes)).
+
+CLI flags take precedence over the matching environment variable. The server uses
+per-user OAuth 2.1 PKCE for every transport — there is no static API-token mode
+(see [What this server does *not* do](../README.md#what-this-server-does-not-do)).
+
+## CLI reference
+
+```
+zendesk-mcp-server <subdomain> [options]
+
+Options:
+  --mode <mode>           single | namespace (default) | all
+  --namespace <ns>        Filter by namespace (repeatable): tickets, help_center, users
+  --tool <name>           Filter by tool name (repeatable, forces --mode all)
+  --read-only             Only expose read operations
+  --no-topology           Disable the Help Center structural context
+                          (instructions + zendesk-hc://topology resource)
+  --log-level <level>     debug | info (default) | warn | error
+  --transport <t>         stdio (default) | http
+  --host <host>           HTTP bind host (default: 0.0.0.0)
+  --port <port>           HTTP bind port (default: 3000; 0 = OS-assigned)
+  --public-url <url>      Public URL clients use to reach the server (HTTP mode,
+                          required behind a TLS reverse proxy)
+  --cors-origin <url>     Extra browser origin allowed by CORS (repeatable;
+                          adds to the default allowlist of major web MCP
+                          clients + localhost-any-port)
+  --callback-port <port>  Local OAuth callback port for stdio (default 27439)
+```
+
+`--namespace` and `--read-only` are applied before the proxies are registered, so they narrow the surface in every mode — in the default `namespace` mode, `--namespace help_center` registers a single proxy (`zendesk_help_center`) instead of three.
+
+**Examples:**
+
+```bash
+# Local single-tool mode — minimal context, every operation in one tool
+zendesk-mcp-server acme --mode single
+
+# Read-only tickets only
+zendesk-mcp-server acme --read-only --namespace tickets
+
+# Cherry-pick specific tools
+zendesk-mcp-server acme --tool get_ticket --tool search_tickets --tool get_current_user
+
+# Remote HTTP, read-only Help Center surface
+zendesk-mcp-server acme --transport http --port 8080 \
+  --namespace help_center --read-only
+```
+
+## Environment variables
+
+### `ZENDESK_SUBDOMAIN`
+**Required:** yes (or the CLI `<subdomain>` argument) · **Default:** —
+
+Zendesk subdomain (e.g. `acme` for `acme.zendesk.com`).
+
+### `ZENDESK_OAUTH_CLIENT_ID`
+**Required:** no · **Default:** `<subdomain>_zendesk`
+
+OAuth client identifier.
+
+### `ZENDESK_OAUTH_CALLBACK_PORT`
+**Required:** no · **Default:** `27439`
+
+Local port for the OAuth browser callback (also `--callback-port`). Must match the redirect URL registered in Zendesk. **stdio only.**
+
+### `ZENDESK_TOKEN_FILE`
+**Required:** no · **Default:** OS config dir
+
+Path to the persisted OAuth token file (`0600`).
+
+### `TRANSPORT`
+**Required:** no · **Default:** `stdio`
+
+`stdio` or `http`.
+
+### `HOST`
+**Required:** no · **Default:** `0.0.0.0`
+
+HTTP bind host.
+
+### `PORT`
+**Required:** no · **Default:** `3000`
+
+HTTP bind port (`0` to let the OS pick).
+
+### `PUBLIC_URL`
+**Required:** recommended in HTTP behind a proxy · **Default:** derived from `host:port`
+
+Public URL advertised in OAuth discovery metadata. See [Public URL](http-deployment.md#public-url).
+
+### `CORS_ORIGIN`
+**Required:** no · **Default:** —
+
+Comma-separated browser origins added to the default CORS allowlist.
+
+### `LOG_LEVEL`
+**Required:** no · **Default:** `info`
+
+Log verbosity (`debug` surfaces the full OAuth flow trace).
+
+### `ZENDESK_MAX_ATTACHMENT_BYTES`
+**Required:** no · **Default:** `5242880` (5 MB)
+
+Per-image size cap for inline (multimodal) ticket attachments. Images larger than this are returned as text references instead of embedded image content. The default is aligned with the Anthropic vision API per-image limit.
+
+### `ZENDESK_MAX_EMBEDDED_IMAGES`
+**Required:** no · **Default:** `10`
+
+Maximum number of images embedded as native image content in a single tool call. Remaining images are returned as text references.
+
+### `ZENDESK_MAX_COMMENT_PAGES`
+**Required:** no · **Default:** `10`
+
+Hard cap on the number of comment pages fetched when collecting a ticket's attachments (raise it for tickets with very long comment threads).
+
+---
+
+← Back to the [README](../README.md).

--- a/docs/http-deployment.md
+++ b/docs/http-deployment.md
@@ -1,0 +1,159 @@
+# Remote HTTP deployment — Zendesk MCP Server
+
+How to deploy the [Zendesk MCP Server](../README.md) as a private remote MCP
+server over HTTP. For running it locally over stdio (the default, supported
+path), see [Quick start: local](../README.md#quick-start-local-stdio).
+
+> 🧪 **Experimental.** The HTTP transport is shipped but has not yet been
+> exercised end-to-end against a real Zendesk tenant from every supported
+> MCP client. Local stdio is the supported path. Until this notice is
+> removed, expect rough edges around OAuth discovery behind reverse
+> proxies, CORS with browser clients, and 401 / refresh flows — please
+> open an issue with the symptoms you hit.
+
+Deploy a private MCP server for **one** Zendesk account. Every MCP client connecting to the server presents its **own** user's OAuth bearer in `Authorization:` — the server never sees a shared admin key.
+
+## Zendesk OAuth setup
+
+Same procedure as the [local quick start](../README.md#zendesk-oauth-setup), with one difference: the **Redirect URL** must match the callback your MCP client uses — provided by the client itself, e.g. `https://claude.ai/oauth/callback` for claude.ai on the web. Check your client's docs.
+
+## Run the server
+
+```bash
+zendesk-mcp-server <your-subdomain> --transport http --port 3000 \
+  --public-url https://mcp.example.com
+# stderr: Zendesk MCP server running via http on 0.0.0.0:3000
+```
+
+## Public URL
+
+`--public-url` (or `PUBLIC_URL=…`) is the URL **clients use to reach you**. It's what gets advertised in the OAuth discovery metadata as the canonical resource identifier (RFC 8707). When the server is behind a TLS reverse proxy — Azure App Service, Heroku, Fly.io, Cloudflare Tunnel, nginx, Caddy… — the bind host and the public URL differ, and spec-compliant MCP clients will refuse the connection if the metadata advertises the wrong resource. Without it the server boots in a degraded mode and prints a warning.
+
+| Platform | Recommended setup |
+|---|---|
+| **Azure App Service** | Startup command: `PUBLIC_URL="https://$WEBSITE_HOSTNAME" zendesk-mcp-server $ZENDESK_SUBDOMAIN --transport http --port $PORT` |
+| **Heroku / Fly / Cloud Run** | `PUBLIC_URL=https://<your-app>.<provider>.app` in the env / config |
+| **Caddy / nginx / Traefik in front of a VM** | `PUBLIC_URL=https://mcp.example.com` |
+| **Local dev (no proxy)** | `--host 127.0.0.1 --port 3000` — the resource URL is derived automatically (the wildcard `0.0.0.0` is what triggers the warning) |
+
+## Authentication on every request
+
+`Authorization: Bearer …` is required on **every** `/mcp` request — a session id alone is never accepted as a credential. The most recent bearer presented on a session is the one used for Zendesk calls, so a client refreshing its token mid-session just works.
+
+## Verify discovery endpoints
+
+Served by the HTTP transport in `src/transports/http.ts`:
+
+```bash
+curl -s http://localhost:3000/.well-known/oauth-protected-resource
+# → { "authorization_servers": ["https://<subdomain>.zendesk.com"], ... }
+
+curl -s http://localhost:3000/.well-known/oauth-authorization-server
+# → { "issuer": "https://<subdomain>.zendesk.com", "authorization_endpoint": "...", ... }
+
+curl -s -i http://localhost:3000/healthz   # → 200 OK
+```
+
+## MCP client wiring
+
+Every major MCP client supports remote servers over Streamable HTTP and handles the OAuth 2.1 PKCE discovery flow natively — paste the URL, sign in once, you're connected. Replace `https://mcp.example.com` below with your deployed origin.
+
+<details>
+<summary><strong>Claude Code (CLI)</strong></summary>
+
+```bash
+claude mcp add zendesk --transport http https://mcp.example.com/mcp
+```
+
+</details>
+
+<details>
+<summary><strong>Claude Desktop</strong></summary>
+
+**Settings → Connectors → + Add custom connector**, paste `https://mcp.example.com/mcp`, click **Connect**. Claude Desktop drives the OAuth flow in your browser on first call.
+
+</details>
+
+<details>
+<summary><strong>claude.ai (web)</strong></summary>
+
+**Settings → Connectors → Add custom connector**, same URL. The OAuth flow runs in the same tab.
+
+</details>
+
+<details>
+<summary><strong>VS Code (GitHub Copilot / Continue / Cline)</strong></summary>
+
+Add to your `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "zendesk": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp"
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><strong>Cursor, Windsurf</strong></summary>
+
+Both expose an MCP settings UI that accepts a remote URL. Paste `https://mcp.example.com/mcp` and sign in when prompted.
+
+</details>
+
+<details>
+<summary><strong>Zed</strong></summary>
+
+Zed added native OAuth 2.0 + PKCE for Streamable HTTP MCP servers in 2026 ([zed-industries/zed#51768](https://github.com/zed-industries/zed/pull/51768)). Configure the remote server in your Zed settings; on first use Zed opens a loopback browser callback to complete the flow.
+
+If you're on an older Zed build that predates that change, fall back to [`mcp-remote`](https://github.com/geelen/mcp-remote) as a local shim that does the OAuth flow on your machine and proxies the session:
+
+```json
+{
+  "context_servers": {
+    "zendesk": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.example.com/mcp"]
+    }
+  }
+}
+```
+
+</details>
+
+On the first call the MCP client fetches the discovery metadata, performs the OAuth 2.1 PKCE flow against Zendesk on behalf of the **end user**, and sends the resulting access token as a `Bearer` to the server. Each subsequent tool call runs with that user's Zendesk permissions.
+
+## CORS
+
+The HTTP transport ships a default CORS allowlist that covers today's major **browser-based** MCP clients out of the box (ordered by user base): `chatgpt.com`, `claude.ai`, `gemini.google.com`, `copilot.microsoft.com`, `perplexity.ai`, `chat.mistral.ai`, `grok.com`, plus `chat.openai.com`. Localhost on any port (MCP Inspector, dev pages) is also always allowed.
+
+**Native MCP clients** (Claude Desktop / Claude Code CLI / Cursor / VS Code / Zed) send no `Origin` header — CORS doesn't apply to them, they work regardless.
+
+To allow an additional browser origin (custom dashboard, internal portal), pass `--cors-origin` (repeatable) or set `CORS_ORIGIN` as a comma-separated list:
+
+```bash
+zendesk-mcp-server acme --transport http --port 3000 \
+  --cors-origin https://internal-dashboard.example.com \
+  --cors-origin https://team-portal.example.com
+```
+
+The defaults are always applied — your additions extend them, they don't replace them.
+
+## Operator responsibilities
+
+This server provides the MCP transport and the OAuth discovery metadata. The operator is still responsible for:
+
+- **TLS termination** (put the server behind a reverse proxy like Caddy / nginx / Cloudflare Tunnel)
+- **Network exposure & firewall** (the server binds `0.0.0.0` by default — choose carefully)
+- **Process supervision** (systemd, Docker, fly.io, your hosting provider's runner — none is shipped here)
+
+See also [Configuration](configuration.md) for the full CLI and environment-variable reference.
+
+---
+
+← Back to the [README](../README.md).

--- a/docs/mcp-metadata.md
+++ b/docs/mcp-metadata.md
@@ -60,7 +60,7 @@ How well the tools work together *as a set*. Four dimensions, weighted equally:
   (Behavioral Transparency), and when to use vs. avoid it (Usage Guidelines).
 - Name matches the existing verb/prefix convention (Naming Consistency).
 - Adding a param to an existing tool beats a near-duplicate tool (Tool Count).
-- Sync the `README.md` tool tables in the same PR.
+- Sync the `docs/mcp-tools-reference.md` tool tables in the same PR.
 
 ## How this is enforced (floor + ceiling)
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -15,7 +15,7 @@ out every `write` tool before the proxies are built.
 | Tool | Description | Mode |
 |------|-------------|------|
 | `get_ticket` | Retrieve a ticket by ID with optional comments and its live SLA state (resolved via a scoped search) | read |
-| `get_ticket_attachments` | Download ticket attachments (images as base64, others as references) | read |
+| `get_ticket_attachments` | Download ticket attachments — images delivered as native multimodal content for the client's own model to analyze; oversize/over-limit images and non-images come back as text references | read |
 | `search_tickets` | Search tickets using Zendesk query syntax, with per-result SLA state | read |
 | `list_tickets` | List tickets with cursor-based pagination | read |
 | `get_linked_incidents` | Get incidents linked to a problem ticket | read |

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -1,0 +1,84 @@
+# MCP tools reference — Zendesk MCP Server
+
+The complete tool-by-tool reference for the [Zendesk MCP Server](../README.md),
+grouped by namespace. Each tool is exposed according to the active `--mode`
+(`all` exposes every tool individually; `namespace` and `single` wrap them in
+proxies) — see [Tool modes](../README.md#tool-modes) in the README for how modes
+and the `--namespace` / `--tool` filters shape the surface.
+
+The **Mode** column marks each tool as `read` or `write`; `--read-only` filters
+out every `write` tool before the proxies are built.
+
+<details>
+<summary><strong>Tickets</strong></summary>
+
+| Tool | Description | Mode |
+|------|-------------|------|
+| `get_ticket` | Retrieve a ticket by ID with optional comments and its live SLA state (resolved via a scoped search) | read |
+| `get_ticket_attachments` | Download ticket attachments (images as base64, others as references) | read |
+| `search_tickets` | Search tickets using Zendesk query syntax, with per-result SLA state | read |
+| `list_tickets` | List tickets with cursor-based pagination | read |
+| `get_linked_incidents` | Get incidents linked to a problem ticket | read |
+| `list_sla_policies` | List SLA policies with filter conditions and per-priority targets (requires an admin token, or a custom role with the SLA-management permission) | read |
+| `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |
+| `update_ticket` | Update ticket status, priority, assignee, tags, custom fields | write |
+| `add_private_note` | Add an internal note (not visible to requester), optionally with file attachments | write |
+| `add_public_comment` | Add a public comment (visible to requester), optionally with file attachments | write |
+| `manage_tags` | Add or remove tags on a ticket | write |
+
+</details>
+
+<details>
+<summary><strong>Help Center</strong></summary>
+
+| Tool | Description | Mode |
+|------|-------------|------|
+| `search_articles` | Full-text search across Help Center articles | read |
+| `get_article` | Retrieve article by ID with full HTML body | read |
+| `get_article_outline` | Compact outline of an article (sections + available translations) | read |
+| `get_article_section` | Retrieve a single section (html or markdown) | read |
+| `list_categories` | List all Help Center categories | read |
+| `list_sections` | List sections, optionally filtered by category | read |
+| `list_articles` | List articles with sorting and translation info | read |
+| `list_article_translations` | List available translations for an article | read |
+| `list_article_attachments` | List attachments on an article | read |
+| `list_permission_groups` | List Guide permission groups (needed to create articles) | read |
+| `list_content_tags` | List Guide content tags (end-user visible) | read |
+| `list_labels` | List article labels (search ranking, not user-visible) | read |
+| `list_user_segments` | List user segments (article visibility) | read |
+| `compare_translations` | Section-level diff between two locales of an article | read |
+| `create_article` | Create a new article in a section | write |
+| `update_article` | Update article metadata (draft, labels, tags, visibility, section, sort position) | write |
+| `create_article_translation` | Create a translation for an article | write |
+| `update_article_translation` | Update an article's translation (full body) | write |
+| `update_article_section` | Replace a single section of an article | write |
+| `create_content_tag` | Create a new Guide content tag | write |
+| `create_article_attachment` | Upload a file to a Help Center article (returns the created attachment) | write |
+
+</details>
+
+<details>
+<summary><strong>Users & Organizations</strong></summary>
+
+| Tool | Description | Mode |
+|------|-------------|------|
+| `get_current_user` | Get the authenticated user (verify identity) | read |
+| `search_users` | Search users by name, email, or query syntax | read |
+| `get_user` | Retrieve a user by ID | read |
+| `get_organization` | Retrieve an organization by ID | read |
+| `list_organizations` | List all organizations with pagination | read |
+
+</details>
+
+<details>
+<summary><strong>Search</strong></summary>
+
+| Tool | Description | Mode |
+|------|-------------|------|
+| `search` | Unified search across tickets, users, and organizations | read |
+
+</details>
+
+---
+
+← Back to the [README](../README.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,53 @@
+# Troubleshooting — Zendesk MCP Server
+
+Common issues running the [Zendesk MCP Server](../README.md) and how to diagnose
+them. See also [Configuration](configuration.md) for the flags and environment
+variables referenced below.
+
+## The browser doesn't open during OAuth login
+
+The OAuth flow opens your default browser on the first tool call. The first call
+fails fast with a message that includes the authorize URL, so even if the
+browser can't open (common in sandboxed or remote desktop environments) you can
+open that URL manually — it's also printed to the server's stderr. Sign in, then
+retry the request.
+
+To collect diagnostics, restart with `LOG_LEVEL=debug`. The server then emits
+structured logs through **two channels**, so they're reachable on any MCP client:
+
+- **stderr** — captured to a log file by every mainstream client.
+- **MCP logging notifications** (`notifications/message`) — surfaced by clients
+  that support the `logging` capability.
+
+When the browser fails to open, look for the `oauth_browser_open_failed` event:
+it reports the underlying error, the platform, and which environment markers are
+present (no secrets, tokens, or env values are ever logged).
+
+## The OAuth callback port is already in use
+
+The sign-in flow runs a short-lived local server on port `27439` to receive the
+callback. If that port is taken, the first tool call fails with a message saying
+so (and logs `oauth_callback_listen_failed`). Pick a free port with
+`ZENDESK_OAUTH_CALLBACK_PORT=<port>` (or `--callback-port <port>`), and register
+the matching `http://localhost:<port>/callback` redirect URL in your Zendesk
+OAuth client.
+
+## I have to re-authenticate every time
+
+The OAuth token is persisted to an owner-only file in your OS config dir and
+reused across restarts, so this shouldn't happen. If it does, check that the file
+is writable (`ZENDESK_TOKEN_FILE` to relocate it) and look for
+`token_persist_failed` in the logs.
+
+Where each client writes the server's stderr:
+
+| Client | Log location |
+|--------|--------------|
+| Claude Desktop (macOS) | `~/Library/Logs/Claude/mcp-server-*.log` |
+| Claude Desktop (Windows) | `%APPDATA%\Claude\logs\mcp-server-*.log` |
+| Claude Code | `claude --debug`, or the session logs |
+| Cursor / VS Code / Cline | the extension's MCP output/log panel |
+
+---
+
+← Back to the [README](../README.md).

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,17 @@ export const DEFAULT_PAGE_SIZE = 100;
 export const MAX_PAGE_SIZE = 100;
 export const TOKEN_CACHE_TTL_MS = 5 * 60 * 1000;
 
+// Read a positive-integer override from the environment, falling back to a safe
+// default. Unchecked Number() coercion is unsafe here: an empty string yields 0
+// and a typo yields NaN, either of which would silently break the guardrail that
+// relies on the value. Missing/empty/non-finite/non-positive values fall back.
+const positiveIntEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
 // TTL for the per-session Help Center topology cache (zendesk-hc://topology).
 // The tenant's structure (locales, category/section tree, segments) changes
 // rarely, so a short TTL keeps a session's repeated reads cheap without going
@@ -21,17 +32,15 @@ export const DEFAULT_CALLBACK_PORT = 27439;
 // returned as text references instead of base64 image content blocks. The
 // default is aligned with the Anthropic vision API per-image limit; override
 // via ZENDESK_MAX_ATTACHMENT_BYTES (bytes).
-export const MAX_ATTACHMENT_BYTES = Number(
-  process.env['ZENDESK_MAX_ATTACHMENT_BYTES'] ?? 5 * 1024 * 1024,
-);
+export const MAX_ATTACHMENT_BYTES = positiveIntEnv('ZENDESK_MAX_ATTACHMENT_BYTES', 5 * 1024 * 1024);
 
 // Maximum number of images embedded as base64 in a single tool call. Remaining
 // images are returned as text references. Override via ZENDESK_MAX_EMBEDDED_IMAGES.
-export const MAX_EMBEDDED_IMAGE_COUNT = Number(process.env['ZENDESK_MAX_EMBEDDED_IMAGES'] ?? 10);
+export const MAX_EMBEDDED_IMAGE_COUNT = positiveIntEnv('ZENDESK_MAX_EMBEDDED_IMAGES', 10);
 
 // Hard cap on comment pages fetched when collecting ticket attachments.
 // Overridable via ZENDESK_MAX_COMMENT_PAGES for tickets with many comments.
-export const MAX_COMMENT_PAGES = Number(process.env['ZENDESK_MAX_COMMENT_PAGES'] ?? 10);
+export const MAX_COMMENT_PAGES = positiveIntEnv('ZENDESK_MAX_COMMENT_PAGES', 10);
 
 // Thresholds used to nudge callers toward section-scoped article tools
 // (get_article_outline / get_article_section / update_article_section)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,13 +18,16 @@ export const TOPOLOGY_TTL_MS = 5 * 60 * 1000;
 export const DEFAULT_CALLBACK_PORT = 27439;
 
 // Per-attachment cap for inline image content. Images larger than this are
-// returned as text references instead of base64 image content blocks.
-// Aligned with the Anthropic vision API per-image limit.
-export const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+// returned as text references instead of base64 image content blocks. The
+// default is aligned with the Anthropic vision API per-image limit; override
+// via ZENDESK_MAX_ATTACHMENT_BYTES (bytes).
+export const MAX_ATTACHMENT_BYTES = Number(
+  process.env['ZENDESK_MAX_ATTACHMENT_BYTES'] ?? 5 * 1024 * 1024,
+);
 
-// Maximum number of images embedded as base64 in a single tool call.
-// Remaining images are returned as text references.
-export const MAX_EMBEDDED_IMAGE_COUNT = 10;
+// Maximum number of images embedded as base64 in a single tool call. Remaining
+// images are returned as text references. Override via ZENDESK_MAX_EMBEDDED_IMAGES.
+export const MAX_EMBEDDED_IMAGE_COUNT = Number(process.env['ZENDESK_MAX_EMBEDDED_IMAGES'] ?? 10);
 
 // Hard cap on comment pages fetched when collecting ticket attachments.
 // Overridable via ZENDESK_MAX_COMMENT_PAGES for tickets with many comments.

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -103,7 +103,8 @@ const collectAttachmentBlocks = async (
 
     let skipReason: string | null = null;
     if (attachment.size > MAX_ATTACHMENT_BYTES) {
-      skipReason = 'skipped: exceeds 5 MB per-image limit';
+      const limitMb = +(MAX_ATTACHMENT_BYTES / (1024 * 1024)).toFixed(2);
+      skipReason = `skipped: exceeds ${limitMb} MB per-image limit`;
     } else if (embeddedCount >= MAX_EMBEDDED_IMAGE_COUNT) {
       skipReason = `skipped: max ${MAX_EMBEDDED_IMAGE_COUNT} embedded images reached`;
     }

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from 'msw';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createTicketTools } from '../../../src/tools/tickets';
 import { MOCK_SLA_SIDELOAD, MOCK_TICKET, MOCK_UPLOAD } from '../../msw-handlers';
@@ -425,6 +425,90 @@ describe('ticket tools', () => {
     it('has readOnly annotation', () => {
       const tool = findTool('get_ticket_attachments');
       expect(tool.annotations.readOnlyHint).toBe(true);
+    });
+
+    describe('env-configurable guardrails', () => {
+      // The caps are read from process.env at module load, so overrides must be
+      // stubbed before a fresh import of the tool module.
+      afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+      });
+
+      const loadAttachmentsTool = async () => {
+        const { createTicketTools } = await import('../../../src/tools/tickets');
+        const tool = createTicketTools(ctx).find((t) => t.name === 'get_ticket_attachments');
+        if (!tool) throw new Error('get_ticket_attachments not found');
+        return tool;
+      };
+
+      it('honors ZENDESK_MAX_EMBEDDED_IMAGES', async () => {
+        vi.resetModules();
+        vi.stubEnv('ZENDESK_MAX_EMBEDDED_IMAGES', '2');
+        const manyImages = Array.from({ length: 12 }, (_, i) => ({
+          id: 41000 + i,
+          file_name: `img-${i}.png`,
+          content_url: `https://testsubdomain.zendesk.com/attachments/token/abc/?name=img-${i}.png`,
+          content_type: 'image/png',
+          size: 1024,
+          inline: false,
+        }));
+        mswServer.use(
+          http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments', () =>
+            HttpResponse.json({
+              comments: [
+                {
+                  id: 1,
+                  body: '',
+                  author_id: 1,
+                  public: true,
+                  created_at: '2026-01-01T00:00:00Z',
+                  attachments: manyImages,
+                },
+              ],
+            }),
+          ),
+        );
+        const tool = await loadAttachmentsTool();
+        const result = await tool.handler({ ticket_id: 1 });
+        const imageBlocks = result.content.filter((c) => c.type === 'image');
+        expect(imageBlocks).toHaveLength(2);
+        expect(getAllText(result)).toContain('skipped: max 2 embedded images reached');
+      });
+
+      it('honors ZENDESK_MAX_ATTACHMENT_BYTES (with a dynamic skip message)', async () => {
+        vi.resetModules();
+        vi.stubEnv('ZENDESK_MAX_ATTACHMENT_BYTES', String(2 * 1024 * 1024));
+        const midImage = {
+          id: 71000,
+          file_name: 'mid.png',
+          content_url: 'https://testsubdomain.zendesk.com/attachments/token/mid/?name=mid.png',
+          content_type: 'image/png',
+          size: 3 * 1024 * 1024,
+          inline: false,
+        };
+        mswServer.use(
+          http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments', () =>
+            HttpResponse.json({
+              comments: [
+                {
+                  id: 1,
+                  body: '',
+                  author_id: 1,
+                  public: true,
+                  created_at: '2026-01-01T00:00:00Z',
+                  attachments: [midImage],
+                },
+              ],
+            }),
+          ),
+        );
+        const tool = await loadAttachmentsTool();
+        const result = await tool.handler({ ticket_id: 1 });
+        const imageBlocks = result.content.filter((c) => c.type === 'image');
+        expect(imageBlocks).toHaveLength(0);
+        expect(getAllText(result)).toContain('exceeds 2 MB per-image limit');
+      });
     });
   });
 

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -476,6 +476,43 @@ describe('ticket tools', () => {
         expect(getAllText(result)).toContain('skipped: max 2 embedded images reached');
       });
 
+      it('falls back to the default cap when the override is empty or non-numeric', async () => {
+        vi.resetModules();
+        // Empty string is not caught by `??`; a raw Number() would yield 0 and
+        // skip every image. It must fall back to the 10-image default instead.
+        vi.stubEnv('ZENDESK_MAX_EMBEDDED_IMAGES', '');
+        vi.stubEnv('ZENDESK_MAX_ATTACHMENT_BYTES', 'not-a-number');
+        const manyImages = Array.from({ length: 12 }, (_, i) => ({
+          id: 42000 + i,
+          file_name: `img-${i}.png`,
+          content_url: `https://testsubdomain.zendesk.com/attachments/token/abc/?name=img-${i}.png`,
+          content_type: 'image/png',
+          size: 1024,
+          inline: false,
+        }));
+        mswServer.use(
+          http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments', () =>
+            HttpResponse.json({
+              comments: [
+                {
+                  id: 1,
+                  body: '',
+                  author_id: 1,
+                  public: true,
+                  created_at: '2026-01-01T00:00:00Z',
+                  attachments: manyImages,
+                },
+              ],
+            }),
+          ),
+        );
+        const tool = await loadAttachmentsTool();
+        const result = await tool.handler({ ticket_id: 1 });
+        const imageBlocks = result.content.filter((c) => c.type === 'image');
+        expect(imageBlocks).toHaveLength(10);
+        expect(getAllText(result)).toContain('skipped: max 10 embedded images reached');
+      });
+
       it('honors ZENDESK_MAX_ATTACHMENT_BYTES (with a dynamic skip message)', async () => {
         vi.resetModules();
         vi.stubEnv('ZENDESK_MAX_ATTACHMENT_BYTES', String(2 * 1024 * 1024));

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -442,17 +442,7 @@ describe('ticket tools', () => {
         return tool;
       };
 
-      it('honors ZENDESK_MAX_EMBEDDED_IMAGES', async () => {
-        vi.resetModules();
-        vi.stubEnv('ZENDESK_MAX_EMBEDDED_IMAGES', '2');
-        const manyImages = Array.from({ length: 12 }, (_, i) => ({
-          id: 41000 + i,
-          file_name: `img-${i}.png`,
-          content_url: `https://testsubdomain.zendesk.com/attachments/token/abc/?name=img-${i}.png`,
-          content_type: 'image/png',
-          size: 1024,
-          inline: false,
-        }));
+      const mockCommentAttachments = (attachments: Array<Record<string, unknown>>) => {
         mswServer.use(
           http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments', () =>
             HttpResponse.json({
@@ -463,12 +453,28 @@ describe('ticket tools', () => {
                   author_id: 1,
                   public: true,
                   created_at: '2026-01-01T00:00:00Z',
-                  attachments: manyImages,
+                  attachments,
                 },
               ],
             }),
           ),
         );
+      };
+
+      const buildImages = (count: number) =>
+        Array.from({ length: count }, (_, i) => ({
+          id: 41000 + i,
+          file_name: `img-${i}.png`,
+          content_url: `https://testsubdomain.zendesk.com/attachments/token/abc/?name=img-${i}.png`,
+          content_type: 'image/png',
+          size: 1024,
+          inline: false,
+        }));
+
+      it('honors ZENDESK_MAX_EMBEDDED_IMAGES', async () => {
+        vi.resetModules();
+        vi.stubEnv('ZENDESK_MAX_EMBEDDED_IMAGES', '2');
+        mockCommentAttachments(buildImages(12));
         const tool = await loadAttachmentsTool();
         const result = await tool.handler({ ticket_id: 1 });
         const imageBlocks = result.content.filter((c) => c.type === 'image');
@@ -482,30 +488,7 @@ describe('ticket tools', () => {
         // skip every image. It must fall back to the 10-image default instead.
         vi.stubEnv('ZENDESK_MAX_EMBEDDED_IMAGES', '');
         vi.stubEnv('ZENDESK_MAX_ATTACHMENT_BYTES', 'not-a-number');
-        const manyImages = Array.from({ length: 12 }, (_, i) => ({
-          id: 42000 + i,
-          file_name: `img-${i}.png`,
-          content_url: `https://testsubdomain.zendesk.com/attachments/token/abc/?name=img-${i}.png`,
-          content_type: 'image/png',
-          size: 1024,
-          inline: false,
-        }));
-        mswServer.use(
-          http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments', () =>
-            HttpResponse.json({
-              comments: [
-                {
-                  id: 1,
-                  body: '',
-                  author_id: 1,
-                  public: true,
-                  created_at: '2026-01-01T00:00:00Z',
-                  attachments: manyImages,
-                },
-              ],
-            }),
-          ),
-        );
+        mockCommentAttachments(buildImages(12));
         const tool = await loadAttachmentsTool();
         const result = await tool.handler({ ticket_id: 1 });
         const imageBlocks = result.content.filter((c) => c.type === 'image');
@@ -516,30 +499,16 @@ describe('ticket tools', () => {
       it('honors ZENDESK_MAX_ATTACHMENT_BYTES (with a dynamic skip message)', async () => {
         vi.resetModules();
         vi.stubEnv('ZENDESK_MAX_ATTACHMENT_BYTES', String(2 * 1024 * 1024));
-        const midImage = {
-          id: 71000,
-          file_name: 'mid.png',
-          content_url: 'https://testsubdomain.zendesk.com/attachments/token/mid/?name=mid.png',
-          content_type: 'image/png',
-          size: 3 * 1024 * 1024,
-          inline: false,
-        };
-        mswServer.use(
-          http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments', () =>
-            HttpResponse.json({
-              comments: [
-                {
-                  id: 1,
-                  body: '',
-                  author_id: 1,
-                  public: true,
-                  created_at: '2026-01-01T00:00:00Z',
-                  attachments: [midImage],
-                },
-              ],
-            }),
-          ),
-        );
+        mockCommentAttachments([
+          {
+            id: 71000,
+            file_name: 'mid.png',
+            content_url: 'https://testsubdomain.zendesk.com/attachments/token/mid/?name=mid.png',
+            content_type: 'image/png',
+            size: 3 * 1024 * 1024,
+            inline: false,
+          },
+        ]);
         const tool = await loadAttachmentsTool();
         const result = await tool.handler({ ticket_id: 1 });
         const imageBlocks = result.content.filter((c) => c.type === 'image');


### PR DESCRIPTION
## Summary
Restructures the README so it stays focused on **what the server does + the local quick start**, and moves the operational/reference material into dedicated docs. Also surfaces native multimodal attachment analysis as a differentiator (**Closes #118**) and makes the vision guardrails configurable.

Extractions:
- Per-tool tables → `docs/mcp-tools-reference.md` (initial step of this PR)
- Remote HTTP deployment → `docs/http-deployment.md`
- CLI flags + environment variables → `docs/configuration.md` (per-variable anchors for deep-linking)
- Troubleshooting → `docs/troubleshooting.md`
- Development setup → `CONTRIBUTING.md`

The README keeps short stub sections; the `Troubleshooting` / `Development` / `Quick start: remote (HTTP)` headings are preserved so existing inbound anchors still resolve.

#118: adds a bullet in *What your assistant can do* and *How it's different*, plus an **Attachments & vision** note (client's own model sees the pixels — no server-side LLM, no extra API key, vendor-neutral), and rewrites the `get_ticket_attachments` tool-reference row from a transport detail into a capability.

## Type of change
- [ ] Bug fix
- [x] New feature (vision guardrails become env-configurable — `feat:`)
- [x] Refactor (no external behavior change)
- [x] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally (410 tests)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` produces a clean bundle
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If a new MCP tool was added, it is documented in `docs/mcp-tools-reference.md` — N/A, no new tool

## Notes for the reviewer (human or AI)
- **`feat:` — vision guardrails configurable.** `MAX_ATTACHMENT_BYTES` / `MAX_EMBEDDED_IMAGE_COUNT` were hardcoded; they now read `ZENDESK_MAX_ATTACHMENT_BYTES` / `ZENDESK_MAX_EMBEDDED_IMAGES` (mirroring the existing `ZENDESK_MAX_COMMENT_PAGES` pattern), and the oversize skip message is derived from the effective limit instead of a hardcoded "5 MB". Covered by two new TDD tests in `tests/unit/tools/tickets.test.ts` (env-override → effective bound changes + dynamic message).
- **Anchor strategy.** No inbound `#anchor` links were broken: extracted sections either kept their heading (stub) or had no inbound links (CLI/env → merged into a `Configuration` stub). Verified every `](#…)` target and every cross-file `../README.md#…` / `docs/*` link resolves.
- **Count-free.** No `(N tools)` counts reintroduced (per the docs-maintenance rule).
- **#118 is docs + the small config `feat:`** — no server-side vision, no new tool, no LLM dependency added (that would break the vendor-neutral positioning the issue highlights).

https://claude.ai/code/session_01EAW6fTRofFZtKFPq5DWVCx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new documentation pages for server configuration, HTTP deployment, troubleshooting, and a full tool-by-tool MCP reference.
  * Updated the README to expand attachments/vision guidance and link to the dedicated tool documentation.

* **Bug Fixes**
  * Oversized image/attachment skip messages now reflect the configured per-image size limit.
  * Image and comment guardrails are now safely configurable via environment variables with proper fallbacks.

* **Documentation**
  * Updated contributor/review guidance and PR templates to reference the dedicated MCP tools reference doc.

* **Tests**
  * Added unit coverage for environment-driven guardrail behavior and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->