### PR TITLE
feat(help-center): add archive_article tool (#133)

### DIFF
--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -49,6 +49,7 @@ out every `write` tool before the proxies are built.
 | `compare_translations` | Section-level diff between two locales of an article | read |
 | `create_article` | Create a new article in a section | write |
 | `update_article` | Update article metadata (draft, labels, tags, visibility, section, sort position) | write |
+| `archive_article` | Archive (soft-delete) an article; recoverable only via the Guide admin UI | write |
 | `create_article_translation` | Create a translation for an article | write |
 | `update_article_translation` | Update an article's translation (full body) | write |
 | `update_article_section` | Replace a single section of an article | write |

--- a/src/client/zendesk-api.ts
+++ b/src/client/zendesk-api.ts
@@ -142,6 +142,11 @@ export const helpCenterPut = <T>(
   return executeRequest<T>(url, token, { method: 'PUT', body });
 };
 
+export const helpCenterDelete = <T>(subdomain: string, token: string, path: string): Promise<T> => {
+  const url = buildUrl(getHelpCenterBaseUrl(subdomain), path);
+  return executeRequest<T>(url, token, { method: 'DELETE' });
+};
+
 export const fetchZendeskBinary = async (
   subdomain: string,
   token: string,

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod/v4';
 import {
+  helpCenterDelete,
   helpCenterGet,
   helpCenterPost,
   helpCenterPut,
@@ -770,6 +771,46 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         return {
           content: [
             { type: 'text', text: `Article #${article.id} updated.\n\n${formatArticle(article)}` },
+          ],
+        };
+      },
+    },
+    {
+      name: 'archive_article',
+      namespace: 'help_center',
+      readOnly: false,
+      title: 'Archive Help Center Article',
+      description:
+        'Archive (soft-delete) a Help Center article: it is removed from the Help Center but can be restored from the Guide admin UI. Returns a confirmation message; the article and all its translations become invisible to end users. This is the only removal the Zendesk API offers — permanent deletion is not available via the API (do it from the Guide admin UI). To only hide an article temporarily while keeping it in the knowledge base, use update_article with draft: true (unpublish) instead. Guarded by a required confirm flag.',
+      inputSchema: z.object({
+        article_id: z.number().int().describe(ARTICLE_ID_DESC),
+        confirm: z
+          .boolean()
+          .describe(
+            'Explicit safety guard: must be set to true to archive the article. Any other value refuses the operation without calling Zendesk.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { article_id, confirm } = params as { article_id: number; confirm: boolean };
+        if (confirm !== true) {
+          throw new Error(
+            'Archiving is guarded: pass confirm: true to archive (soft-delete) this article. No changes were made.',
+          );
+        }
+        const token = await getToken();
+        await helpCenterDelete(subdomain, token, `/articles/${article_id}`);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Article #${article_id} archived (soft-deleted). It is removed from the Help Center; restore it from the Guide admin UI if needed.`,
+            },
           ],
         };
       },

--- a/tests/functional/scenarios/04-all-baseline/expected.md
+++ b/tests/functional/scenarios/04-all-baseline/expected.md
@@ -4,7 +4,7 @@
 
 ## Expected values
 
-- **A1.** `tools.length === 37`. Breakdown: 10 ticket tools + 21 Help Center
+- **A1.** `tools.length === 38`. Breakdown: 10 ticket tools + 22 Help Center
   tools + 5 user/organization tools + 1 unified search tool. If the count
   drifts, update the documentation listed in `AGENTS.md` "Documentation
   maintenance" before running.

--- a/tests/functional/scenarios/04-all-baseline/spec.md
+++ b/tests/functional/scenarios/04-all-baseline/spec.md
@@ -35,7 +35,7 @@ own `annotations` object intact (PR #53 must not regress flat mode).
   "readOnly": false,
   "branch": "claude/laughing-lovelace-HmZOn",
   "assertions": [
-    { "id": "A1", "desc": "tools/list returns exactly 37 entries",                                   "pass": null, "actual": null },
+    { "id": "A1", "desc": "tools/list returns exactly 38 entries",                                   "pass": null, "actual": null },
     { "id": "A2", "desc": "every entry has a non-empty annotations object",                          "pass": null, "actual": null },
     { "id": "A3", "desc": "every entry has openWorldHint=true",                                      "pass": null, "actual": null },
     { "id": "A4", "desc": "get_current_user has readOnlyHint=true and destructiveHint=false",        "pass": null, "actual": null },

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -134,6 +134,7 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(names).toContain('get_current_user');
         expect(names).not.toContain('create_ticket');
         expect(names).not.toContain('update_ticket');
+        expect(names).not.toContain('archive_article');
       });
     });
 
@@ -222,6 +223,17 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         const filteredText = textOf(filtered);
         expect(filteredText).toContain('mistral');
         expect(filteredText).not.toContain('scanner');
+      });
+
+      it('archives a Help Center article over the wire when confirmed', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'archive_article',
+          arguments: { article_id: 5000, confirm: true },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('Article #5000 archived');
       });
 
       it('surfaces a Zendesk API error as an MCP tool error', async () => {

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -483,6 +483,8 @@ export const handlers = [
       article: { ...MOCK_ARTICLE, id: Number(params['id']), ...update },
     });
   }),
+  // Archive Article (soft-delete): Zendesk responds 204 No Content.
+  http.delete(`${HC_BASE}/articles/:id`, () => new HttpResponse(null, { status: 204 })),
 
   // Guide - Permission Groups
   http.get(`${BASE}/guide/permission_groups`, () =>

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -65,7 +65,7 @@ describe('groupByNamespace', () => {
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
     expect(ticketCount).toBe(12); // 11 ticket tools + 1 search
-    expect(hcCount).toBe(21);
+    expect(hcCount).toBe(22);
     expect(userCount).toBe(5);
   });
 });

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -263,12 +263,9 @@ describe('help center tools', () => {
       expect(result.content[0]?.text).toContain('Article #5000 archived');
     });
 
-    it('refuses and does not call the API when confirm is false', async () => {
-      mswServer.use(
-        http.delete(`${HC_BASE}/articles/:id`, () =>
-          HttpResponse.json({ error: 'should not be called' }, { status: 500 }),
-        ),
-      );
+    it('refuses without archiving when confirm is false', async () => {
+      // The default MSW handler returns 204, so a regressed guard would let the
+      // call succeed and this assertion would fail — no extra override needed.
       const tool = findTool('archive_article');
       await expect(tool.handler({ article_id: 5000, confirm: false })).rejects.toThrow(/confirm/i);
     });

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -16,8 +16,8 @@ const findTool = (name: string) => {
 };
 
 describe('help center tools', () => {
-  it('creates 21 tools', () => {
-    expect(createHelpCenterTools(ctx)).toHaveLength(21);
+  it('creates 22 tools', () => {
+    expect(createHelpCenterTools(ctx)).toHaveLength(22);
   });
 
   describe('search_articles', () => {
@@ -253,6 +253,43 @@ describe('help center tools', () => {
       expect(tool.inputSchema.parse({ article_id: 5000, position: 3 })).toMatchObject({
         position: 3,
       });
+    });
+  });
+
+  describe('archive_article', () => {
+    it('archives the article when confirm is true', async () => {
+      const tool = findTool('archive_article');
+      const result = await tool.handler({ article_id: 5000, confirm: true });
+      expect(result.content[0]?.text).toContain('Article #5000 archived');
+    });
+
+    it('refuses and does not call the API when confirm is false', async () => {
+      mswServer.use(
+        http.delete(`${HC_BASE}/articles/:id`, () =>
+          HttpResponse.json({ error: 'should not be called' }, { status: 500 }),
+        ),
+      );
+      const tool = findTool('archive_article');
+      await expect(tool.handler({ article_id: 5000, confirm: false })).rejects.toThrow(/confirm/i);
+    });
+
+    it('requires confirm in the schema', () => {
+      const tool = findTool('archive_article');
+      expect(() => tool.inputSchema.parse({ article_id: 5000 })).toThrow();
+      expect(tool.inputSchema.parse({ article_id: 5000, confirm: true })).toMatchObject({
+        confirm: true,
+      });
+    });
+
+    it('is annotated as a destructive write operation', () => {
+      const tool = findTool('archive_article');
+      expect(tool.readOnly).toBe(false);
+      expect(tool.annotations.destructiveHint).toBe(true);
+    });
+
+    it('points callers to update_article draft for a plain unpublish', () => {
+      const tool = findTool('archive_article');
+      expect(tool.description).toContain('update_article');
     });
   });
 


### PR DESCRIPTION
## Summary
Adds an `archive_article` Help Center tool that soft-deletes an obsolete article via `DELETE /api/v2/help_center/articles/{id}`, closing the gap described in #133. Zendesk **archives** (rather than permanently deletes) the article, so it remains recoverable from the Guide admin UI — permanent deletion is UI-only and not exposed by the API, which inherently satisfies the issue's safety concern. The operation is guarded by a required `confirm` flag.

Closes #133.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`

## Notes for the reviewer (human or AI)
- **Why "archive", not "delete":** the Zendesk API `DELETE` endpoint is a *soft-delete* (recoverable from the Guide UI); there is no API for permanent deletion. Naming the tool `archive_article` reflects the real, reversible behaviour rather than implying an irreversible delete.
- **Unpublish is already covered:** `update_article` with `draft: true` reverts an article to draft. This PR only adds the missing removal path; the description steers callers who just want to hide an article toward `update_article`.
- **Confirmation guard:** rather than introduce a bespoke confirmation-token subsystem, the tool requires a `confirm: true` parameter — the handler refuses (throws, no API call) otherwise — and is annotated `destructiveHint: true` for MCP clients.
- **Reused infra:** new `helpCenterDelete` helper mirrors `helpCenterPut`; `executeRequest` already returns `{}` on a 204.
- **Code review:** ran a parallel-agent review of the diff — no correctness findings; one conventions finding (stale hardcoded tool counts in the `04-all-baseline` functional scenario) was fixed in commit `10555ec`.

## Functional validation plan

### Context
The feature is the new `archive_article` MCP tool (namespace `help_center`). Exercise it by calling `mcp__zendesk-local__archive_article` directly against the running server. Under the hood it issues a single `DELETE /api/v2/help_center/articles/{article_id}` to the Help Center API; Zendesk responds `204 No Content` and the article moves to the Archived state (recoverable in the Guide admin UI). The `confirm` guard is enforced in the handler *before* any network call.

Paths that do **not** exercise this code: ticket/user tools, and the `update_article` unpublish path (`draft: true`) — that is a separate, pre-existing behaviour.

### Setup & prerequisites
No build/checkout/auth setup — the environment is already on the branch with an authenticated server. Just capture the commit under test with `git rev-parse HEAD` and name it in the report.

Use a **throwaway draft article** for the destructive scenario so nothing user-visible is lost: create one first with `mcp__zendesk-local__create_article` (any section from the `zendesk-hc://topology` resource, `draft: true`), note its returned id, then archive that id. After archiving, confirm it is gone from `list_articles`; restore it from the Guide admin UI if you want to leave the tenant pristine (or just leave it archived — it is a throwaway).

If archiving is blocked by permissions/egress, report it as `BLOCKED` (do not attempt to reconfigure credentials).

### Scenarios
| id | Validates | Manipulation / call | Expected observable |
|----|-----------|---------------------|---------------------|
| S1 | Confirm guard blocks without a network call | Call `archive_article` with `article_id` = any real id and `confirm: false` | Tool returns an **error** whose message mentions confirmation (matches `/confirm/i`); the article is **not** archived (still present in `list_articles`). |
| S2 | Confirm guard blocks when omitted | Call `archive_article` with only `article_id` (no `confirm`) | Schema-level rejection: tool errors because `confirm` is required. No change to the article. |
| S3 | Happy path archives a throwaway draft | Create a throwaway draft via `create_article`; call `archive_article` with that draft's id and `confirm: true` | Success text `Article #<id> archived (soft-deleted)…`. The id no longer appears in `list_articles` for its section. |
| S4 | Unknown article surfaces an API error | Call `archive_article` with `article_id: 999999999` and `confirm: true` (nonexistent id) | Tool errors with a `404` / "Resource not found" style message (from `ZendeskApiError`), not a crash. |
| S5 | Read-only mode hides the tool | If a read-only surface is inspectable, confirm `archive_article` is absent from the read-only tool list | `archive_article` not listed under `--read-only` (already asserted in integration tests). |

### Long-running behaviours
None — the operation is a single synchronous API call. No timers or intervals involved.

### Priorities
Do **S1** and **S3** first (the core user-facing guard + happy path). S2/S4 are edge hardening; S5 is a filter sanity check already covered by automated tests.

### Reporting instructions
Post a PR comment (English) with, for each id S1–S5: `OK` / `FAIL` / `BLOCKED`, the exact tool call made, and the observed output (success/error text, and the `list_articles` before/after evidence for S3). Finish with an overall green/failing summary and the commit SHA tested.

https://claude.ai/code/session_01C2FCHgBcXPnnif5CUq4fzK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Help Center action to archive articles with a required confirmation step.
  * Users now see a confirmation message after an article is archived.

* **Bug Fixes**
  * Help Center tool counts and listings now reflect the additional action across scenarios and tests.
  * Read-only mode no longer exposes the archive action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->