### PR TITLE
feat(help-center): paginate and filter list_content_tags (#132)

### DIFF
--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -43,7 +43,7 @@ out every `write` tool before the proxies are built.
 | `list_article_translations` | List available translations for an article | read |
 | `list_article_attachments` | List attachments on an article | read |
 | `list_permission_groups` | List Guide permission groups (needed to create articles) | read |
-| `list_content_tags` | List Guide content tags (end-user visible) | read |
+| `list_content_tags` | List Guide content tags (end-user visible), cursor-paginated with name-prefix filter and sort | read |
 | `list_labels` | List article labels (search ranking, not user-visible) | read |
 | `list_user_segments` | List user segments (article visibility) | read |
 | `compare_translations` | Section-level diff between two locales of an article | read |

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -780,7 +780,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'List Content Tags',
       description:
-        'List Guide content tags, which are end-user-visible labels that help readers find related articles. Results are cursor-paginated (follow the returned cursor to enumerate the full, deliberately small referential) and sorted by name by default. Pass name_prefix to look a tag up by the start of its name — do this before create_content_tag to reuse an existing tag rather than fragment the taxonomy. For internal, non-end-user search labels, see list_labels instead.',
+        'List Guide content tags, which are end-user-visible labels that help readers find related articles. Results are cursor-paginated (follow the returned cursor to enumerate the full list) and sorted by name by default. Pass name_prefix to look a tag up by the start of its name — do this before create_content_tag to reuse an existing tag rather than fragment the taxonomy. For internal, non-end-user search labels, see list_labels instead.',
       inputSchema: z.object({
         name_prefix: z
           .string()
@@ -792,7 +792,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         sort_by: z
           .enum(['name', 'id'])
           .default('name')
-          .describe('Field to sort by; "name" (the default) lists the referential alphabetically.'),
+          .describe('Field to sort by; "name" (the default) lists tags alphabetically.'),
         sort_order: z
           .enum(['asc', 'desc'])
           .default('asc')

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -780,23 +780,67 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'List Content Tags',
       description:
-        'List all Guide content tags. Content tags are visible to end users and help them find related articles.',
-      inputSchema: z.object({}),
+        'List Guide content tags, which are end-user-visible labels that help readers find related articles. Results are cursor-paginated (follow the returned cursor to enumerate the full, deliberately small referential) and sorted by name by default. Pass name_prefix to look a tag up by the start of its name — do this before create_content_tag to reuse an existing tag rather than fragment the taxonomy. For internal, non-end-user search labels, see list_labels instead.',
+      inputSchema: z.object({
+        name_prefix: z
+          .string()
+          .min(1)
+          .optional()
+          .describe(
+            'Return only content tags whose name starts with this prefix (case-insensitive, prefix match — not a substring or fuzzy search). Use the full name to check whether a specific tag already exists before creating it.',
+          ),
+        sort: z
+          .enum(['name', '-name', 'id', '-id'])
+          .default('name')
+          .describe(
+            'Ordering of results: "name"/"id" ascending, "-name"/"-id" descending. Defaults to "name" so the referential lists alphabetically.',
+          ),
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Content tags per page (1-100, default 100).'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response; omit for the first page.'),
+      }),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
         openWorldHint: true,
       },
-      handler: async () => {
+      handler: async (params) => {
+        const { name_prefix, sort, page_size, cursor } = params as {
+          name_prefix?: string;
+          sort: string;
+          page_size: number;
+          cursor?: string;
+        };
         const token = await getToken();
-        const response = await zendeskGet<{ records: ZendeskContentTag[]; count: number }>(
+        const p: Record<string, string> = { ...buildCursorParams(page_size, cursor), sort };
+        if (name_prefix) p['filter[name_prefix]'] = name_prefix;
+        const response = await zendeskGet<ZendeskListResponse<ZendeskContentTag>>(
           subdomain,
           token,
           '/guide/content_tags',
+          p,
         );
+        const records = response.records ?? [];
         return {
-          content: [{ type: 'text', text: formatList(response.records ?? [], formatContentTag) }],
+          content: [
+            {
+              type: 'text',
+              text: formatList(
+                records,
+                formatContentTag,
+                extractPaginationMeta(response, records.length),
+              ),
+            },
+          ],
         };
       },
     },
@@ -806,7 +850,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Create Content Tag',
       description:
-        'Create a new content tag for Guide articles. Content tags are end-user visible labels that help readers discover related articles; this returns the created tag with its id. Check list_content_tags first to avoid duplicates, then attach the new id via the content_tag_ids parameter of create_article or update_article. For internal search-ranking labels that are not shown to end users, use article labels (list_labels) instead.',
+        'Create a new content tag for Guide articles. Content tags are end-user visible labels that help readers discover related articles; this returns the created tag with its id. Check list_content_tags first (filter by name_prefix) to avoid duplicates, then attach the new id via the content_tag_ids parameter of create_article or update_article. For internal search-ranking labels that are not shown to end users, use article labels (list_labels) instead.',
       inputSchema: z.object({
         name: z
           .string()

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -789,12 +789,14 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           .describe(
             'Return only content tags whose name starts with this prefix (prefix match — not a substring or fuzzy search). Use the full name to check whether a specific tag already exists before creating it.',
           ),
-        sort: z
-          .enum(['name', '-name', 'id', '-id'])
+        sort_by: z
+          .enum(['name', 'id'])
           .default('name')
-          .describe(
-            'Ordering of results: "name"/"id" ascending, "-name"/"-id" descending. Defaults to "name" so the referential lists alphabetically.',
-          ),
+          .describe('Field to sort by; "name" (the default) lists the referential alphabetically.'),
+        sort_order: z
+          .enum(['asc', 'desc'])
+          .default('asc')
+          .describe('Sort direction: ascending or descending.'),
         page_size: z
           .number()
           .int()
@@ -814,13 +816,18 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         openWorldHint: true,
       },
       handler: async (params) => {
-        const { name_prefix, sort, page_size, cursor } = params as {
+        const { name_prefix, sort_by, sort_order, page_size, cursor } = params as {
           name_prefix?: string;
-          sort: string;
+          sort_by: string;
+          sort_order: string;
           page_size: number;
           cursor?: string;
         };
         const token = await getToken();
+        // /guide/content_tags takes a single `sort` param, `-` prefix for
+        // descending; the tool surface keeps the sort_by/sort_order convention
+        // shared with the sibling list tools and translates to the wire format.
+        const sort = `${sort_order === 'desc' ? '-' : ''}${sort_by}`;
         const p: Record<string, string> = { ...buildCursorParams(page_size, cursor), sort };
         if (name_prefix) p['filter[name_prefix]'] = name_prefix;
         const response = await zendeskGet<ZendeskListResponse<ZendeskContentTag>>(

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -787,7 +787,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           .min(1)
           .optional()
           .describe(
-            'Return only content tags whose name starts with this prefix (case-insensitive, prefix match — not a substring or fuzzy search). Use the full name to check whether a specific tag already exists before creating it.',
+            'Return only content tags whose name starts with this prefix (prefix match — not a substring or fuzzy search). Use the full name to check whether a specific tag already exists before creating it.',
           ),
         sort: z
           .enum(['name', '-name', 'id', '-id'])

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,7 @@ export interface PaginationMeta {
 
 export interface ZendeskListResponse<T> {
   results?: T[];
+  records?: T[];
   tickets?: T[];
   users?: T[];
   organizations?: T[];

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -199,6 +199,31 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(text).toContain('page_size');
       });
 
+      it('lists content tags with defaults applied and filters by name prefix (#132)', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+
+        // No arguments: the schema defaults (sort=name, page_size=100) are
+        // applied by the SDK, so the full referential comes back enumerable.
+        const all = await connected.client.callTool({
+          name: 'list_content_tags',
+          arguments: {},
+        });
+        expect(all.isError).toBeFalsy();
+        const allText = textOf(all);
+        expect(allText).toContain('ai');
+        expect(allText).toContain('mistral');
+
+        // name_prefix narrows the listing to a single tag.
+        const filtered = await connected.client.callTool({
+          name: 'list_content_tags',
+          arguments: { name_prefix: 'mi' },
+        });
+        expect(filtered.isError).toBeFalsy();
+        const filteredText = textOf(filtered);
+        expect(filteredText).toContain('mistral');
+        expect(filteredText).not.toContain('scanner');
+      });
+
       it('surfaces a Zendesk API error as an MCP tool error', async () => {
         mswServer.use(errorHandlers.usersMeUnauthorized);
 

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -501,12 +501,11 @@ export const handlers = [
     if (prefix) {
       records = records.filter((t) => t.name.startsWith(prefix));
     }
-    const desc = sort.startsWith('-');
-    const key = desc ? sort.slice(1) : sort;
-    records.sort((a, b) =>
-      key === 'id' ? a.id.localeCompare(b.id) : a.name.localeCompare(b.name),
-    );
-    if (desc) records.reverse();
+    // The tool forwards `sort` to Zendesk untouched, so the mock only needs to
+    // order enough for tests to assert wiring: name ascending, reversed by the
+    // `-` prefix (covers the -name path). Other keys fall back to name order.
+    records.sort((a, b) => a.name.localeCompare(b.name));
+    if (sort.startsWith('-')) records.reverse();
     return HttpResponse.json({ records, meta: { has_more: false, after_cursor: '' } });
   }),
   http.post(`${BASE}/guide/content_tags`, async ({ request }) => {

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -154,6 +154,31 @@ export const MOCK_CONTENT_TAG = {
   updated_at: '2026-01-02T00:00:00Z',
 };
 
+// A small referential covering the sort/filter cases exercised by the tests:
+// `ai` and `mistral` are the tags whose absence #132 could not confirm, and the
+// listing spans past `debug mode` (the alphabetical point the old cap stopped at).
+export const MOCK_CONTENT_TAGS = [
+  {
+    id: 'ct_010',
+    name: 'ai',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+  },
+  {
+    id: 'ct_011',
+    name: 'debug mode',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+  },
+  {
+    id: 'ct_012',
+    name: 'mistral',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+  },
+  MOCK_CONTENT_TAG,
+];
+
 export const MOCK_LABEL = {
   id: 9001,
   name: 'getting-started',
@@ -269,6 +294,15 @@ export const manyCategoriesHandler = http.get(`${HC_BASE}/categories`, () =>
     categories: [MOCK_CATEGORY],
     meta: { has_more: true, after_cursor: 'next-page-cursor' },
     count: 250,
+  }),
+);
+
+// Opt-in override: a content-tag referential larger than one page, so the tool's
+// cursor handling and the "More available" footer can be exercised (#132).
+export const manyContentTagsHandler = http.get(`${BASE}/guide/content_tags`, () =>
+  HttpResponse.json({
+    records: [MOCK_CONTENT_TAG],
+    meta: { has_more: true, after_cursor: 'next-page-cursor' },
   }),
 );
 
@@ -455,10 +489,24 @@ export const handlers = [
     HttpResponse.json({ permission_groups: [MOCK_PERMISSION_GROUP], count: 1 }),
   ),
 
-  // Guide - Content Tags
-  http.get(`${BASE}/guide/content_tags`, () =>
-    HttpResponse.json({ records: [MOCK_CONTENT_TAG], count: 1 }),
-  ),
+  // Guide - Content Tags. Honours filter[name_prefix], sort and cursor
+  // pagination the way the real endpoint does so the tool's params are exercised.
+  http.get(`${BASE}/guide/content_tags`, ({ request }) => {
+    const url = new URL(request.url);
+    const prefix = url.searchParams.get('filter[name_prefix]')?.toLowerCase();
+    const sort = url.searchParams.get('sort') ?? 'name';
+    let records = [...MOCK_CONTENT_TAGS];
+    if (prefix) {
+      records = records.filter((t) => t.name.toLowerCase().startsWith(prefix));
+    }
+    const desc = sort.startsWith('-');
+    const key = desc ? sort.slice(1) : sort;
+    records.sort((a, b) =>
+      key === 'id' ? a.id.localeCompare(b.id) : a.name.localeCompare(b.name),
+    );
+    if (desc) records.reverse();
+    return HttpResponse.json({ records, meta: { has_more: false, after_cursor: '' } });
+  }),
   http.post(`${BASE}/guide/content_tags`, async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
     const tag = body['content_tag'] as Record<string, unknown> | undefined;

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -493,11 +493,13 @@ export const handlers = [
   // pagination the way the real endpoint does so the tool's params are exercised.
   http.get(`${BASE}/guide/content_tags`, ({ request }) => {
     const url = new URL(request.url);
-    const prefix = url.searchParams.get('filter[name_prefix]')?.toLowerCase();
+    // Prefix match kept case-sensitive: the real endpoint's casing is
+    // unverified, so the mock does not encode a case-insensitive assumption.
+    const prefix = url.searchParams.get('filter[name_prefix]');
     const sort = url.searchParams.get('sort') ?? 'name';
     let records = [...MOCK_CONTENT_TAGS];
     if (prefix) {
-      records = records.filter((t) => t.name.toLowerCase().startsWith(prefix));
+      records = records.filter((t) => t.name.startsWith(prefix));
     }
     const desc = sort.startsWith('-');
     const key = desc ? sort.slice(1) : sort;

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -2,7 +2,7 @@ import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createHelpCenterTools } from '../../../src/tools/help-center';
-import { MOCK_ARTICLE } from '../../msw-handlers';
+import { MOCK_ARTICLE, manyContentTagsHandler } from '../../msw-handlers';
 import { mswServer } from '../../setup';
 
 const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
@@ -257,11 +257,34 @@ describe('help center tools', () => {
   });
 
   describe('list_content_tags', () => {
-    it('lists content tags', async () => {
+    it('lists content tags sorted by name', async () => {
       const tool = findTool('list_content_tags');
-      const result = await tool.handler({});
-      expect(result.content[0]?.text).toContain('scanner');
-      expect(result.content[0]?.text).toContain('ct_001');
+      const result = await tool.handler({ sort: 'name', page_size: 100 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('scanner');
+      expect(text).toContain('ct_001');
+      // The tags #132 could not confirm are now enumerable.
+      expect(text).toContain('ai');
+      expect(text).toContain('mistral');
+      // Ascending alphabetical order: `ai` sorts before `mistral`.
+      expect(text.indexOf('ai')).toBeLessThan(text.indexOf('mistral'));
+    });
+
+    it('filters by name prefix', async () => {
+      const tool = findTool('list_content_tags');
+      const result = await tool.handler({ name_prefix: 'mi', sort: 'name', page_size: 100 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('mistral');
+      expect(text).not.toContain('scanner');
+    });
+
+    it('surfaces the pagination cursor when more results remain', async () => {
+      mswServer.use(manyContentTagsHandler);
+      const tool = findTool('list_content_tags');
+      const result = await tool.handler({ sort: 'name', page_size: 1 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('More available');
+      expect(text).toContain('next-page-cursor');
     });
   });
 

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -257,22 +257,33 @@ describe('help center tools', () => {
   });
 
   describe('list_content_tags', () => {
-    it('lists content tags sorted by name', async () => {
+    it('lists content tags sorted by name ascending, spanning past the old cap', async () => {
       const tool = findTool('list_content_tags');
-      const result = await tool.handler({ sort: 'name', page_size: 100 });
+      const result = await tool.handler({ sort_by: 'name', sort_order: 'asc', page_size: 100 });
       const text = result.content[0]?.text ?? '';
       expect(text).toContain('scanner');
       expect(text).toContain('ct_001');
-      // The tags #132 could not confirm are now enumerable.
-      expect(text).toContain('ai');
-      expect(text).toContain('mistral');
-      // Ascending alphabetical order: `ai` sorts before `mistral`.
-      expect(text.indexOf('ai')).toBeLessThan(text.indexOf('mistral'));
+      // The tags #132 could not confirm are now enumerable, and the listing
+      // reaches past `debug mode` (the alphabetical point the old cap stopped at).
+      expect(text.indexOf('ai')).toBeLessThan(text.indexOf('debug mode'));
+      expect(text.indexOf('debug mode')).toBeLessThan(text.indexOf('mistral'));
+    });
+
+    it('reverses order for descending sort', async () => {
+      const tool = findTool('list_content_tags');
+      const result = await tool.handler({ sort_by: 'name', sort_order: 'desc', page_size: 100 });
+      const text = result.content[0]?.text ?? '';
+      expect(text.indexOf('mistral')).toBeLessThan(text.indexOf('ai'));
     });
 
     it('filters by name prefix', async () => {
       const tool = findTool('list_content_tags');
-      const result = await tool.handler({ name_prefix: 'mi', sort: 'name', page_size: 100 });
+      const result = await tool.handler({
+        name_prefix: 'mi',
+        sort_by: 'name',
+        sort_order: 'asc',
+        page_size: 100,
+      });
       const text = result.content[0]?.text ?? '';
       expect(text).toContain('mistral');
       expect(text).not.toContain('scanner');
@@ -281,7 +292,7 @@ describe('help center tools', () => {
     it('surfaces the pagination cursor when more results remain', async () => {
       mswServer.use(manyContentTagsHandler);
       const tool = findTool('list_content_tags');
-      const result = await tool.handler({ sort: 'name', page_size: 1 });
+      const result = await tool.handler({ sort_by: 'name', sort_order: 'asc', page_size: 1 });
       const text = result.content[0]?.text ?? '';
       expect(text).toContain('More available');
       expect(text).toContain('next-page-cursor');


### PR DESCRIPTION
## Summary
`list_content_tags` called `GET /guide/content_tags` with **no parameters**, so it returned only Zendesk's default first page (~10 tags, alphabetically capped) with no cursor, count or name filter — making it impossible to enumerate the full content-tag list or check whether a tag already existed before creating one (issue #132). This PR aligns the tool with the repo's standard cursor-list pattern and exposes the endpoint's native controls: `page_size` + `cursor`, `name_prefix` filtering (`filter[name_prefix]`), and `sort_by`/`sort_order` (default `name` ascending).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`

## Notes for the reviewer (human or AI)
- **No new tool** — `list_content_tags` is modified in place, so tool counts are unchanged. The exposed JSON Schema stays a **superset** of the previous one: only optional/defaulted params were added and descriptions were enriched, never dropped or shortened.
- **Sort surface follows the house convention** — `sort_by` (`name`/`id`) + `sort_order` (`asc`/`desc`), same as `list_articles`. The handler translates them to the endpoint's single `sort` param (`-name` for descending); the wire format doesn't leak onto the tool surface.
- **Behaviour worth noting:** the tool now always sends `page[size]=100` and `sort=name`. Setting `page[size]` is exactly what lifts the old ~10-tag default cap; the default sort makes the listing deterministic.
- **`name_prefix` is a prefix match, not substring** — that's the only name filter the Zendesk endpoint offers (`filter[name_prefix]`). Its case sensitivity is not documented by Zendesk, so the description makes no claim and the mock stays case-sensitive; the live casing is checked by scenario S4 below.
- Cursor pagination provides no reliable total, so the footer reports the returned page size and, when `has_more`, the next cursor (via the shared `extractPaginationMeta`, which also fixes the misleading `Results: 0`, cf. #100).
- Added `records?` to `ZendeskListResponse<T>` so the response types through the shared pagination helper (content tags wrap their collection under `records`, unlike other endpoints).

## Functional validation plan

### Context
The change is entirely in `list_content_tags` (`src/tools/help-center.ts`). Exercise it by calling the `mcp__zendesk-local__list_content_tags` tool against the live fruggr Help Center. `create_content_tag` is only touched in its description (points at `name_prefix`); no other tool changes behaviour.

Capture the commit under test: `git rev-parse HEAD` (expect the tip of `claude/issue-132-vnzxma`).

### Setup & prerequisites
None beyond the ready environment — the running server is already authenticated against the fruggr Help Center. All scenarios are read-only listing calls; **do not create any content tag**. If a call returns an auth/egress error, report it as `BLOCKED` (do not attempt to fix credentials).

Note: the fruggr content-tag list is live data. The issue references `ai`, `mistral` and a listing that historically stopped at `debug mode` — use those as reference points but assert on *behaviour* (ordering, filtering, cursor), not on an exact fixed set.

### Scenarios
| id | Validates | Manipulation / call | Expected observable |
|----|-----------|---------------------|---------------------|
| S1 | Full enumeration beyond the old cap | `list_content_tags` with no args | Returns more than ~10 tags **or** a `More available (cursor: …)` footer; tags sorting past `debug mode` (e.g. `mistral`, `scanner`) are present. No error. |
| S2 | Default sort is ascending by name | same call as S1 | Tag names appear in ascending alphabetical order (e.g. an `a…` tag precedes an `m…` tag). |
| S3 | Descending sort | `list_content_tags` with `{ "sort_order": "desc" }` | Order is reversed vs S2 (alphabetically descending). |
| S4 | `name_prefix` exact-existence check (+ live casing) | `list_content_tags` with `{ "name_prefix": "ai" }` then `{ "name_prefix": "mistral" }` | Each returns only tags whose name starts with the prefix (confirms `ai`/`mistral` exist); unrelated tags (e.g. `scanner`) absent. This is the workflow #132 could not perform. Note whether the match appears case-sensitive. |
| S5 | `name_prefix` with no match | `list_content_tags` with `{ "name_prefix": "zzz-nonexistent" }` | Empty result (no tag lines), no error — a *reliable* "absent" signal rather than a guess. |
| S6 | Cursor pagination round-trip | `list_content_tags` with `{ "page_size": 1 }`; if footer shows a cursor, call again with `{ "page_size": 1, "cursor": "<that cursor>" }` | First call returns 1 tag + a next cursor; second call returns a *different* tag. Walking the cursor eventually yields `has_more: false` (no footer cursor). |
| S7 | Invalid input rejected | `list_content_tags` with `{ "sort_by": "bogus" }` | Tool error (enum validation), not a silently ignored param. |

### Long-running behaviours
None — no time-based behaviour. Pagination/filter/sort are already covered by unit tests (`tests/unit/tools/help-center.test.ts`) and an integration roundtrip (`tests/integration/core-scenarios.ts`); S1–S7 confirm the same behaviour against live data.

### Priorities
Do **S1** and **S4** first — they are the exact user-facing paths from the issue (enumerate everything; check a tag exists by name). Then S6 (cursor), then S2/S3/S5/S7.

### Reporting instructions
Post a PR comment (English) with a per-id verdict (`OK`/`FAIL`/`BLOCKED`) and the observed evidence (the relevant lines of tool output) for each of S1–S7, plus an overall green/failing summary and the commit SHA tested.
