### PR TITLE
docs: lead npm description with the differentiator, fit npm snippet budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 [![semantic-release](https://img.shields.io/badge/semantic--release-e10079?logo=semantic-release&logoColor=white)](https://github.com/semantic-release/semantic-release)
 
 **Bring Zendesk deep into your AI assistant.** A
-[Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for a
-two-way integration: find answers in the Help Center, **draft, update and
-translate** articles (keeping languages in sync), and **manage Support tickets**
-end to end — comments, triage and image attachments — all in plain language,
+[Model Context Protocol](https://modelcontextprotocol.io) (MCP) server: find
+answers in the Help Center, **draft, update and translate** articles (keeping
+languages in sync), and **manage Support tickets** end to end — comments, triage
+and image attachments — all in plain language,
 **without switching apps**.
 
 Think of it as the [Zendesk agent for Microsoft 365 Copilot](https://support.zendesk.com/hc/en-us/articles/9958331458458-Using-the-Zendesk-agent-in-Microsoft-365-Copilot),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fruggr/zendesk-mcp-server",
   "version": "2.8.0",
   "mcpName": "io.github.fruggr/zendesk-mcp-server",
-  "description": "A Model Context Protocol (MCP) server for a deep, two-way integration between your AI assistant and Zendesk: search the Help Center and draft, update and translate articles (section by section, keeping languages in sync), and manage Support tickets end to end — comments, triage and image attachments.",
+  "description": "Deep Zendesk MCP server for your AI assistant: search, draft, update and translate Help Center articles and manage Support tickets end to end — comments, triage and image attachments.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
The `package.json#description` was ~300 chars and got truncated mid-sentence in npm listing snippets (`…manage Support tickets end to`), hiding the differentiator behind a clause npm cuts. This rewrites it to fit under npm's snippet budget (186 bytes incl. jq newline, < 200) and lead with **"Deep Zendesk MCP server for your AI assistant"**, surfacing the MCP / AI / assistant discovery terms first. The README first paragraph is aligned by dropping the now-redundant "two-way integration" clause so both surfaces tell the same story without duplicating wording. Closes #113.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [x] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [ ] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` (n/a — no tool change)

## Notes for the reviewer (human or AI)

Metadata-only change; no runtime surface. Design choices:
- **Lead with the differentiator, not a subordinate clause.** "Deep Zendesk MCP server" is now the first thing npm shows, before any clause that could be trimmed.
- **Dropped the "two-way" label** (per author request): the read+write story is carried by the verbs — *search* (read) then *draft, update, translate, manage* (write) — which is clearer in a short snippet than the "two-way" jargon.
- **`server.json`** keeps its own shorter, feature-oriented variant (`scripts/build-server-json.mjs`) — deliberately distinct (Lot 4), left untouched, tells the same story.
- **GitHub repo description** already leads with the same "deep" message and no "two-way" jargon, so no drift there.

### Functional validation plan (for an independent validator)

This lot has no runtime-observable behaviour — validation is metadata/consistency:

1. **Snippet budget.** `jq -r .description package.json | wc -c` → expect **< 200** (currently reports 186).
2. **Differentiator leads & reads-when-trimmed.** Read `package.json#description`. Confirm the first clause is "Deep Zendesk MCP server for your AI assistant" and that truncating the string at ~150 chars still yields a coherent sentence. Confirm the terms **MCP**, **AI**, **assistant** all appear in the leading portion.
3. **Cross-surface consistency, no verbatim copy.** Compare `package.json#description`, the README first paragraph (`README.md:11-16`), and the GitHub repo description. They must carry the same core message ("Deep … MCP server", find/draft/update/translate/manage) with phrasing adapted per surface — **not** an identical copy. Confirm "two-way" no longer appears in either the npm description or the README first paragraph.
4. **Green build.** `pnpm check`, `pnpm typecheck`, `pnpm test` all pass.

Post the report as a PR comment (English).

https://claude.ai/code/session_015iXekzTtGWcgPgxhaxj5yg

---
_Generated by [Claude Code](https://claude.ai/code/session_015iXekzTtGWcgPgxhaxj5yg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project’s README tagline with clearer, more direct wording about searching for answers, drafting/updating/translating articles, and managing support tickets.
  * Refined the package description to better reflect the same capabilities in a concise, user-friendly way.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->