### PR TITLE
docs(registry): document deprecating the io.github.fruggr entry

### DIFF
--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -65,6 +65,42 @@ each new version automatically.
 - **Resilience.** The publish is retried a few times to absorb npm propagation
   lag (the registry validates by fetching the freshly published npm tarball).
 
+### Deprecating a registry entry (one-off)
+
+Deprecation is **not** a `server.json` field — the manifest schema has no
+publisher-settable `status`; `status` (`active` / `deprecated` / `deleted`) is
+registry-managed lifecycle metadata. It is set out-of-band with the `mcp-publisher`
+`status` subcommand (present in the pinned `1.7.9`), so this is a manual step, not part
+of `release.yml`.
+
+Retiring the `io.github.fruggr/zendesk-mcp-server` name in favour of
+`io.fruggr/zendesk-mcp-server` means the old entry must be flagged deprecated **before**
+`mcpName` changes in `package.json`: the registry proves npm ownership via `mcpName`, a
+package maps to exactly one name, so once `mcpName` flips the ownership proof for the old
+name is gone and its entry can no longer be edited.
+
+A `fruggr`-org member runs, locally:
+
+```sh
+# authenticate as the io.github.fruggr namespace owner (interactive, org-based;
+# release.yml's github-oidc login is CI-only and needs the Actions id-token)
+mcp-publisher login github
+
+# mark every version of the old entry deprecated, pointing at the new name
+mcp-publisher status \
+  --status deprecated \
+  --all-versions \
+  --message "Deprecated — republished as io.fruggr/zendesk-mcp-server. Same npm package (@fruggr/zendesk-mcp-server), nothing changes for existing installs." \
+  io.github.fruggr/zendesk-mcp-server
+```
+
+Verify:
+
+```sh
+curl "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.fruggr"
+# expect the entry with lifecycle status "deprecated" and the pointer message above
+```
+
 ## Release notes content
 
 semantic-release generates the notes from **every** commit between the previous


### PR DESCRIPTION
## Summary
Documents the one-off procedure to deprecate the `io.github.fruggr/zendesk-mcp-server`
MCP registry entry ahead of the `io.fruggr` rename (Lot 2 of 4, closes #114). Deprecation
must land **before** `mcpName` changes: the registry proves npm ownership via `mcpName`, a
package maps to exactly one name, so once `mcpName` flips the old entry can no longer be edited.

Docs-only — no code, `package.json`, or workflow changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [x] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally _(unchanged — docs-only diff)_
- [x] `pnpm test:coverage` meets the thresholds _(unchanged — docs-only diff)_
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes _(unchanged — docs-only diff)_
- [x] I have read the diff myself, line by line
- [ ] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` _(n/a — no tool added)_

## Notes for the reviewer (human or AI)

**The issue's assumed mechanism is outdated — verified against current sources.** #114
describes deprecation as *"publishing a final update of the entry carrying the deprecated
status and a description pointing at the new name."* That is no longer how it works:

- The `2025-12-11/server.schema.json` has **no publisher-settable `status` field**.
  `status` (`active`/`deprecated`/`deleted`) is registry-managed lifecycle metadata — it is
  **not** set by republishing `server.json`.
- Deprecation is a dedicated operation: `mcp-publisher status --status deprecated --message …`
  (backed by `PATCH /v0.1/servers/{name}/status`), requiring `publish`/`edit` permission on the
  namespace — which we still hold because `mcpName` is unchanged.
- The issue's pointer text therefore maps to the `--message` / `statusMessage` (≤500 chars),
  **not** to a republished `description` field.
- The pinned `mcp-publisher` **1.7.9** already ships the `status` subcommand (confirmed in the
  CLI docs and `cmd/publisher/main.go` at tag `v1.7.9`), so no raw-API fallback is needed.

Because it is a one-off, authenticated, out-of-PR action, this PR **documents a manual runbook**
rather than adding CI. A `fruggr`-org member runs it locally with `mcp-publisher login github`
(interactive, org-based — `release.yml`'s `github-oidc` login is CI-only). This deliberately
keeps `release.yml`, its OIDC auth, `mcpName`, and the README badge untouched — the auth rework
and the rename belong to #115/#116.

Acceptance guards held in this lot: no change to `mcpName`, `release.yml`,
`scripts/build-server-json.mjs`, or the README badge (diff touches only `docs/release-automation.md`).

## Functional validation plan

**This PR's diff is pure documentation** — it adds a runbook and introduces **no
runtime-observable behaviour** in the MCP server, so there is no `mcp__<server>__*` tool
path to exercise and no server-side scenario to drive. Per the `functional-validation-plan`
skill, that is stated explicitly rather than fabricating MCP scenarios.

The only real-world observable is the **live registry state after the maintainer executes
the runbook** (a manual step outside this PR). Acceptance check for that step:

```sh
curl "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.fruggr"
```

Expected once run: the `io.github.fruggr/zendesk-mcp-server` entry shows lifecycle
`status: "deprecated"` and the pointer message
`Deprecated — republished as io.fruggr/zendesk-mcp-server. Same npm package (@fruggr/zendesk-mcp-server), nothing changes for existing installs.`

Doc-review checks a reviewer can do now:
- The runbook command is copy-pasteable and the `--message` matches the acceptance text above.
- The diff touches only `docs/release-automation.md` (guards: `mcpName`, `release.yml`,
  `build-server-json.mjs`, README badge all unchanged).

Report: post a PR comment with an OK/FAIL verdict on the two doc-review checks; the live
`curl` verdict is captured by the maintainer when they run the runbook.

Closes #114

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVM48jQ7CY9KM3kfoy3wgJ)_