### PR TITLE
ci: version-control server.json, sync its version at release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,11 @@ jobs:
             echo "No release this run; skipping MCP registry publish."
           fi
 
-      - name: Generate server.json for the released version
-        if: steps.released.outputs.published == 'true'
-        # Built from package.json (already bumped by semantic-release) plus the
-        # MCP-specific metadata in the script — never hand-maintained.
-        run: node scripts/build-server-json.mjs > server.json
+      # No server.json generation step: the manifest is version-controlled at
+      # the repo root and semantic-release has already synced its `version`
+      # (via @semantic-release/exec -> scripts/sync-server-json-version.mjs) and
+      # committed it. mcp-publisher below reads that committed, freshly-bumped
+      # file straight from the working tree.
 
       - name: Install mcp-publisher
         if: steps.released.outputs.published == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,6 @@ dist/
 .tsbuildinfo
 package-lock.json
 
-# Generated MCP registry manifest (built from package.json by
-# scripts/build-server-json.mjs at release time; see docs/release-automation.md)
-server.json
-
 # Environment
 .env
 .env.*

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -46,9 +46,15 @@
     ],
     "@semantic-release/npm",
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "node scripts/sync-server-json-version.mjs ${nextRelease.version}"
+      }
+    ],
+    [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "package.json"],
+        "assets": ["CHANGELOG.md", "package.json", "server.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,9 +113,7 @@ and AI authors).
 
 ## Release workflow
 
-Fully automated via semantic-release on push to `main`; never hand-bump the
-`version` in `package.json`. `server.json` is version-controlled: seed it with
-`pnpm build:server-json` when its `package.json`-derived metadata changes, but
-never hand-bump its `version` — release syncs it from `package.json`. Triggers,
-npm + official MCP registry publishing, and the versioned manifest:
-`docs/release-automation.md`.
+Fully automated via semantic-release on push to `main`; never hand-bump
+`version` in `package.json` or the version-controlled `server.json` — release
+syncs both. Reseed `server.json` with `pnpm build:server-json` when its metadata
+changes. Details: `docs/release-automation.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,8 @@ and AI authors).
 ## Release workflow
 
 Fully automated via semantic-release on push to `main`; never hand-bump the
-`version` in `package.json` (`server.json` is generated from it — never edit it
-by hand). Triggers, npm + official MCP registry publishing, and the generated
-manifest: `docs/release-automation.md`.
+`version` in `package.json`. `server.json` is version-controlled: seed it with
+`pnpm build:server-json` when its `package.json`-derived metadata changes, but
+never hand-bump its `version` — release syncs it from `package.json`. Triggers,
+npm + official MCP registry publishing, and the versioned manifest:
+`docs/release-automation.md`.

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -48,14 +48,23 @@ each new version automatically.
   working tree only when it actually publishes. The job snapshots the version
   before and after semantic-release; the publish steps run **only** when it
   changed, so `chore:` / `docs:` pushes (no release) never touch the registry.
-- **Manifest.** `server.json` is **generated**, not committed:
-  [`scripts/build-server-json.mjs`](../scripts/build-server-json.mjs) derives
-  everything that already lives in `package.json` (name from `mcpName`, npm
-  identifier, version, repository, homepage) and declares only the
-  registry/launch specifics (schema, transport, subdomain argument, env). The
-  release job runs it (`node scripts/build-server-json.mjs > server.json`) right
-  before publishing; it is git-ignored so there is nothing to hand-maintain or
-  let drift. Regenerate locally with `pnpm build:server-json`.
+- **Manifest.** `server.json` is **version-controlled** at the repo root
+  (committed and reviewable). [`scripts/build-server-json.mjs`](../scripts/build-server-json.mjs)
+  *seeds* it from everything that already lives in `package.json` (name from
+  `mcpName`, npm identifier, version, repository, homepage) plus the
+  registry/launch specifics (schema, transport, subdomain argument, env);
+  regenerate the committed file with `pnpm build:server-json` whenever that
+  metadata changes. A unit test asserts the committed file equals what the
+  generator would seed, so it cannot drift from `package.json`.
+- **Version sync.** At release, semantic-release does **not** regenerate the
+  manifest; a `@semantic-release/exec` `prepareCmd` runs
+  [`scripts/sync-server-json-version.mjs`](../scripts/sync-server-json-version.mjs)
+  to update **only** the `version` fields to `${nextRelease.version}`, and
+  `@semantic-release/git` commits `server.json` alongside `CHANGELOG.md` and
+  `package.json`. The release commit therefore carries a clean one-line version
+  diff, and `package.json` / `server.json` versions can never diverge. The
+  MCP-registry publish step reads this committed, freshly-bumped file directly —
+  there is no generate-from-scratch step in the release job.
 - **Ownership.** The registry proves npm ownership via the `mcpName` field in
   `package.json` (which the generator uses as the `server.json` `name`).
 - **Auth.** `mcp-publisher login github-oidc` reuses the workflow's

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.2",
     "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@25.0.5(typescript@6.0.3))
+      '@semantic-release/exec':
+        specifier: ^7.1.0
+        version: 7.1.0(semantic-release@25.0.5(typescript@6.0.3))
       '@semantic-release/git':
         specifier: ^10.0.1
         version: 10.0.1(semantic-release@25.0.5(typescript@6.0.3))
@@ -685,6 +688,12 @@ packages:
   '@semantic-release/error@4.0.0':
     resolution: {integrity: sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==}
     engines: {node: '>=18'}
+
+  '@semantic-release/exec@7.1.0':
+    resolution: {integrity: sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==}
+    engines: {node: '>=20.8.1'}
+    peerDependencies:
+      semantic-release: '>=24.1.0'
 
   '@semantic-release/git@10.0.1':
     resolution: {integrity: sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==}
@@ -3696,6 +3705,18 @@ snapshots:
   '@semantic-release/error@3.0.0': {}
 
   '@semantic-release/error@4.0.0': {}
+
+  '@semantic-release/exec@7.1.0(semantic-release@25.0.5(typescript@6.0.3))':
+    dependencies:
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 3.1.0
+      debug: 4.4.3
+      execa: 9.6.1
+      lodash-es: 4.18.1
+      parse-json: 8.3.0
+      semantic-release: 25.0.5(typescript@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@semantic-release/git@10.0.1(semantic-release@25.0.5(typescript@6.0.3))':
     dependencies:

--- a/scripts/build-server-json.mjs
+++ b/scripts/build-server-json.mjs
@@ -1,11 +1,21 @@
 #!/usr/bin/env node
-// Generates the official MCP registry manifest (server.json) and prints it to
-// stdout. `package.json` is the single source of truth for everything that
-// already lives there (name, npm identifier, version, repository, homepage);
-// only the registry/launch metadata that has no other authoritative source is
-// declared below. server.json is a build artifact — never hand-edit it.
+// Seeds/validates the official MCP registry manifest (server.json) and prints it
+// to stdout. Unlike before, server.json is now version-controlled at the repo
+// root (committed, reviewable) — this generator no longer produces a throwaway
+// build artifact. Its role is twofold:
+//   - seed: `pnpm build:server-json` (re)writes the committed file when the
+//     package.json-derived metadata below changes;
+//   - validate: tests assert the committed file equals this output (no drift).
+// At release, only the `version` field of the committed file is synced (see
+// scripts/sync-server-json-version.mjs), so the release commit stays a clean
+// one-line diff and never re-derives metadata.
 //
-//   node scripts/build-server-json.mjs > server.json
+// `package.json` is the single source of truth for everything that already
+// lives there (name, npm identifier, version, repository, homepage); only the
+// registry/launch metadata that has no other authoritative source is declared
+// below.
+//
+//   node scripts/build-server-json.mjs > server.json   (or: pnpm build:server-json)
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 

--- a/scripts/sync-server-json-version.mjs
+++ b/scripts/sync-server-json-version.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Syncs ONLY the `version` fields of the committed server.json to a target
+// version, preserving every other field byte-for-byte. Run by semantic-release
+// (@semantic-release/exec `prepareCmd`) during a release so the committed
+// manifest tracks package.json with zero drift and the release commit carries a
+// clean one-line version diff — without re-deriving metadata from scratch.
+//
+// The target version comes from argv (semantic-release passes
+// ${nextRelease.version}); it falls back to package.json's version, which
+// @semantic-release/npm has already bumped in the working tree by the time this
+// runs.
+//
+//   node scripts/sync-server-json-version.mjs [version]
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const serverJsonPath = fileURLToPath(new URL('../server.json', import.meta.url));
+const pkgPath = fileURLToPath(new URL('../package.json', import.meta.url));
+
+const version = process.argv[2] ?? JSON.parse(readFileSync(pkgPath, 'utf8')).version;
+if (!version) {
+  throw new Error('No version to sync: pass it as an argument or set package.json#version');
+}
+
+const serverJson = JSON.parse(readFileSync(serverJsonPath, 'utf8'));
+serverJson.version = version;
+if (Array.isArray(serverJson.packages)) {
+  for (const pkg of serverJson.packages) {
+    pkg.version = version;
+  }
+}
+
+writeFileSync(serverJsonPath, `${JSON.stringify(serverJson, null, 2)}\n`);
+process.stdout.write(`Synced server.json version to ${version}\n`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.fruggr/zendesk-mcp-server",
+  "description": "Draft, translate and update Help Center articles and manage Zendesk tickets from your AI assistant.",
+  "version": "2.8.0",
+  "repository": {
+    "url": "https://github.com/fruggr/zendesk-mcp-server",
+    "source": "github",
+    "id": "1206027556"
+  },
+  "websiteUrl": "https://github.com/fruggr/zendesk-mcp-server#readme",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@fruggr/zendesk-mcp-server",
+      "version": "2.8.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "valueHint": "subdomain",
+          "description": "Zendesk subdomain (the <subdomain> in https://<subdomain>.zendesk.com). Alternatively set ZENDESK_SUBDOMAIN.",
+          "isRequired": true
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "ZENDESK_SUBDOMAIN",
+          "description": "Zendesk subdomain, used when no positional subdomain argument is given.",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit/server-json.test.ts
+++ b/tests/unit/server-json.test.ts
@@ -1,19 +1,28 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-// server.json is a generated artifact (not committed) — see
-// scripts/build-server-json.mjs. These tests run the generator against the real
-// package.json and assert the manifest it produces stays consistent with that
-// source of truth and the registry schema constraints.
+// server.json is a version-controlled file at the repo root (committed, not a
+// build artifact). scripts/build-server-json.mjs seeds/validates it from
+// package.json; at release only its `version` is synced. These tests read the
+// committed manifest, assert it stays consistent with package.json (the single
+// source of truth) and the registry schema constraints, and guard against any
+// drift between the committed file and what the generator would seed.
 import { buildServerJson } from '../../scripts/build-server-json.mjs';
 
 const pkg = JSON.parse(
   readFileSync(fileURLToPath(new URL('../../package.json', import.meta.url)), 'utf8'),
 );
-const serverJson = buildServerJson(pkg);
+const committedServerJson = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../../server.json', import.meta.url)), 'utf8'),
+);
+const serverJson = committedServerJson;
 const npmPackage = serverJson.packages[0];
 
-describe('server.json (generated MCP registry manifest)', () => {
+describe('server.json (version-controlled MCP registry manifest)', () => {
+  it('matches what the generator would seed from package.json (no drift)', () => {
+    expect(committedServerJson).toEqual(buildServerJson(pkg));
+  });
+
   it('pins the registry server.json schema', () => {
     expect(serverJson.$schema).toBe(
       'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
@@ -25,11 +34,14 @@ describe('server.json (generated MCP registry manifest)', () => {
     expect(serverJson.name).toBe('io.github.fruggr/zendesk-mcp-server');
   });
 
-  it('derives the npm package identifier and version from package.json', () => {
-    expect(npmPackage.registryType).toBe('npm');
-    expect(npmPackage.identifier).toBe(pkg.name);
+  it('keeps the committed version in sync with package.json (no drift)', () => {
     expect(serverJson.version).toBe(pkg.version);
     expect(npmPackage.version).toBe(pkg.version);
+  });
+
+  it('derives the npm package identifier from package.json', () => {
+    expect(npmPackage.registryType).toBe('npm');
+    expect(npmPackage.identifier).toBe(pkg.name);
   });
 
   it('derives the repository pointer and website from package.json', () => {


### PR DESCRIPTION
## Summary
Commit the MCP registry manifest `server.json` to the repo root (it was generated in CI and git-ignored) so it is reviewable and drift-proof, and reduce the release job to a **version-only** sync of the committed file. The `io.github.fruggr/zendesk-mcp-server` identity, GitHub OIDC publish auth, npm package name and CLI are all unchanged.

Addresses the "Version-control `server.json`" core of #116. The `io.fruggr` rename and the DNS-based publish auth from the issue are **out of scope (abandoned)** per the owner — this PR keeps `io.github.fruggr` and GitHub OIDC.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [x] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` (n/a — no tool surface change)

## Notes for the reviewer (human or AI)
- **Anti-drift.** `server.json` is committed; a unit test asserts it deep-equals what `scripts/build-server-json.mjs` seeds from `package.json`, so name/identifier/repo/version can't drift. Seed regen: `pnpm build:server-json`.
- **Version sync at release.** New `scripts/sync-server-json-version.mjs` rewrites *only* the `version` fields; wired via a new `@semantic-release/exec` `prepareCmd` placed **after** `@semantic-release/npm` (so `package.json` is already bumped) and **before** `@semantic-release/git` (which now lists `server.json` in `assets`). The release commit is therefore a clean one-line version diff.
- **Workflow.** Removed the "generate `server.json` from scratch" step in `release.yml`; `mcp-publisher` reads the committed, freshly-synced file. OIDC auth untouched.
- **No npm-tarball change.** `server.json` is not in `package.json#files`, so it stays out of the published npm package — as before.
- New devDependency: `@semantic-release/exec`.

## Functional validation plan

### Context
This change has **no MCP-tool-surface runtime behaviour** — it does not touch `src/`, transports, auth, or any `mcp__zendesk-local__*` tool. What it changes is *release automation* and *repo state*: a committed `server.json`, a version-only sync script, semantic-release config, and the release workflow. Validation is therefore file/script/config-based, not tool-call-based. Do **not** exercise the Zendesk tools for this — they don't cover the code.

The validator's session is already on the PR branch in a live checkout. Capture the SHA first: `git rev-parse HEAD` (expected `66dadf5…` or later).

### Setup & prerequisites
No credentials or egress required. All scenarios run against the local checkout with `node`/`pnpm`. Work on throwaway copies where a scenario mutates files (`git stash`/`git checkout --` to restore); each scenario below states its own cleanup.

### Scenarios
| id | Validates | Manipulation | Command | Expected observable |
|----|-----------|--------------|---------|---------------------|
| S1 | `server.json` is committed & not ignored | none | `git ls-files server.json` and `git check-ignore server.json` | First prints `server.json`; second prints nothing (exit 1) → file is tracked and no longer ignored |
| S2 | Committed manifest is consistent (schema, name, identity, version) | none | `cat server.json` | `$schema` = `…/2025-12-11/server.schema.json`; `name` = `io.github.fruggr/zendesk-mcp-server`; `packages[0].identifier` = `@fruggr/zendesk-mcp-server`, `transport.type` = `stdio`; `version` == `package.json` version |
| S3 | Anti-drift test passes | none | `pnpm vitest run tests/unit/server-json.test.ts` | 9 tests pass, incl. "matches what the generator would seed (no drift)" |
| S4 | Sync script changes **only** version fields | run against current tree | `cp server.json /tmp/s.json && node scripts/sync-server-json-version.mjs 9.9.9 && diff /tmp/s.json server.json; git checkout -- server.json` | `diff` shows exactly two changed lines, both `version` (top-level + `packages[0]`), nothing else |
| S5 | Post-release state stays drift-free | bump both versions to a fake release | `node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='2.99.0';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')" && node scripts/sync-server-json-version.mjs 2.99.0 && pnpm vitest run tests/unit/server-json.test.ts; git checkout -- package.json server.json` | Tests still pass (both files show 2.99.0) → after a real release the drift test won't break |
| S6 | Release config wiring is correct | none | `cat .releaserc.json` | `@semantic-release/exec` present with `prepareCmd` calling `scripts/sync-server-json-version.mjs ${nextRelease.version}`, positioned after `@semantic-release/npm` and before `@semantic-release/git`; the `git` plugin `assets` include `server.json` |
| S7 | Workflow no longer generates the manifest | none | `grep -n "build-server-json\|login github-oidc\|mcp-publisher publish" .github/workflows/release.yml` | No `build-server-json` generation step remains; `login github-oidc` and `mcp-publisher publish` are still present (OIDC auth + publish unchanged) |
| S8 | Full gate is green | none | `pnpm check && pnpm typecheck && pnpm test` | All pass |

### Long-running behaviours
None. Nothing here is time-based; there are no timers or intervals to simulate. The actual release publish only runs on push to `main` and cannot be exercised from a PR branch — its correctness is covered structurally by S4–S7.

### Priorities
Do **S3, S4, S5** first (the drift/sync guarantees — the heart of the change), then **S1/S2/S6/S7** (state & wiring), then **S8** (full gate).

### Reporting
Post a PR comment (English) with a per-id OK/FAIL verdict + the observed evidence (command output), referencing the tested SHA, and an overall green/failing summary.

Refs #116


---
_Generated by [Claude Code](https://claude.ai/code/session_01E1BtRCaaq2tGX8sJtuGhNh)_