### PR TITLE
feat(tickets): add read-only list_ticket_fields tool

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@
 - [ ] I ran a Claude Code review on the diff and addressed its findings
 - [ ] Documentation is updated where needed
 - [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
+- [ ] If the change has runtime-observable behaviour: this PR carries a `## Functional validation plan` (authored with `/functional-validation-plan`), and it has been executed by an independent validator (`/run-validation-plan`) whose report is posted as a PR comment
 
 ## Notes for the reviewer (human or AI)
 <!-- Points worth attention, design choices to validate, alternatives ruled out -->

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -20,6 +20,7 @@ out every `write` tool before the proxies are built.
 | `list_tickets` | List tickets with cursor-based pagination | read |
 | `get_linked_incidents` | Get incidents linked to a problem ticket | read |
 | `list_sla_policies` | List SLA policies with filter conditions and per-priority targets (requires an admin token, or a custom role with the SLA-management permission) | read |
+| `list_ticket_fields` | List ticket field definitions (system + custom) with ids, types, and dropdown/multiselect option values, to resolve `custom_fields` ids and accepted values for create_ticket / update_ticket | read |
 | `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |
 | `update_ticket` | Update ticket status, priority, assignee, tags, custom fields | write |
 | `add_private_note` | Add an internal note (not visible to requester), optionally with file attachments | write |

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -404,7 +404,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Create Zendesk Ticket',
       description:
-        'Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags. The description becomes the first public comment of the ticket, and the new ticket id is returned. After creation, use update_ticket to change status or assignee, add_public_comment or add_private_note to reply, and manage_tags to adjust tags. Look up valid assignee_id / group_id via search_users, and custom field ids and their accepted option values via list_ticket_fields.',
+        'Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags. The description becomes the first public comment of the ticket, and the new ticket id is returned. After creation, use update_ticket to change status or assignee, add_public_comment or add_private_note to reply, and manage_tags to adjust tags. Look up valid assignee_id / group_id and custom field ids via search_users or your Zendesk admin settings. Discover custom field ids and their accepted option values with list_ticket_fields.',
       inputSchema: z.object({
         subject: z
           .string()

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -21,6 +21,7 @@ import type {
   ZendeskSlaSideloadEntry,
   ZendeskTicket,
   ZendeskTicketAttachment,
+  ZendeskTicketField,
   ZendeskUpload,
 } from '../types';
 import {
@@ -29,6 +30,7 @@ import {
   formatSlaBlock,
   formatSlaPolicy,
   formatTicket,
+  formatTicketField,
   truncateIfNeeded,
 } from '../utils/formatting';
 import {
@@ -402,7 +404,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Create Zendesk Ticket',
       description:
-        'Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags. The description becomes the first public comment of the ticket, and the new ticket id is returned. After creation, use update_ticket to change status or assignee, add_public_comment or add_private_note to reply, and manage_tags to adjust tags. Look up valid assignee_id / group_id and custom field ids via search_users or your Zendesk admin settings.',
+        'Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags. The description becomes the first public comment of the ticket, and the new ticket id is returned. After creation, use update_ticket to change status or assignee, add_public_comment or add_private_note to reply, and manage_tags to adjust tags. Look up valid assignee_id / group_id via search_users, and custom field ids and their accepted option values via list_ticket_fields.',
       inputSchema: z.object({
         subject: z
           .string()
@@ -440,7 +442,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           .array(z.object({ id: z.number().int(), value: z.unknown() }))
           .optional()
           .describe(
-            'Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings).',
+            'Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings). Call list_ticket_fields first to discover the numeric field ids and, for dropdown/multiselect fields, the exact option values Zendesk accepts.',
           ),
       }),
       annotations: {
@@ -513,7 +515,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           .array(z.object({ id: z.number().int(), value: z.unknown() }))
           .optional()
           .describe(
-            'Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings).',
+            'Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings). Call list_ticket_fields first to discover the numeric field ids and, for dropdown/multiselect fields, the exact option values Zendesk accepts.',
           ),
       }),
       annotations: {
@@ -852,6 +854,56 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
             : { count: policies.length, has_more: false, after_cursor: null };
         return {
           content: [{ type: 'text', text: formatList(policies, formatSlaPolicy, meta) }],
+        };
+      },
+    },
+    {
+      name: 'list_ticket_fields',
+      namespace: 'tickets',
+      readOnly: true,
+      title: 'List Ticket Fields',
+      description:
+        'List the ticket field definitions configured on this Zendesk (both system fields and custom fields), returning each field\'s id, type, whether it is active/required, and — for dropdown and multiselect fields — the valid option values. Use this to discover the numeric field ids and accepted option tags that create_ticket and update_ticket expect in their custom_fields argument, so a natural-language intent ("set severity to High") maps to the right id and a value Zendesk will accept instead of a blind guess. Read-only reference lookup; cursor-paginated in Zendesk\'s default field order.',
+      inputSchema: z.object({
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Ticket field definitions per page (1-100, default 100).'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response; omit for the first page.'),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { page_size, cursor } = params as { page_size: number; cursor?: string };
+        const token = await getToken();
+        const response = await zendeskGet<ZendeskListResponse<ZendeskTicketField>>(
+          subdomain,
+          token,
+          '/ticket_fields',
+          buildCursorParams(page_size, cursor),
+        );
+        const fields = response.ticket_fields ?? [];
+        return {
+          content: [
+            {
+              type: 'text',
+              text: formatList(
+                fields,
+                formatTicketField,
+                extractPaginationMeta(response, fields.length),
+              ),
+            },
+          ],
         };
       },
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,36 @@ export interface ZendeskSlaSideloadEntry {
   policy_metrics: ZendeskSlaLiveMetric[];
 }
 
+// A selectable option on a dropdown/multiselect custom field. `value` is the
+// tag written back via create_ticket / update_ticket custom_fields; `name` is
+// the human label shown in the Zendesk UI.
+export interface ZendeskCustomFieldOption {
+  id: number;
+  name: string;
+  raw_name?: string;
+  value: string;
+  default?: boolean;
+}
+
+// A ticket field definition (system or custom) from the Ticket Fields API. The
+// `id` is what create_ticket / update_ticket custom_fields expect; `type`
+// determines whether `custom_field_options` (dropdown/multiselect) or
+// `system_field_options` (system fields like priority) carry the valid values.
+export interface ZendeskTicketField {
+  id: number;
+  type: string;
+  title: string;
+  description: string | null;
+  active: boolean;
+  required: boolean;
+  position?: number;
+  tag?: string | null;
+  custom_field_options?: ZendeskCustomFieldOption[];
+  system_field_options?: Array<{ name: string; value: string }>;
+  created_at?: string;
+  updated_at?: string;
+}
+
 export interface ZendeskTicketAttachment {
   id: number;
   file_name: string;
@@ -227,6 +257,7 @@ export interface ZendeskListResponse<T> {
   translations?: T[];
   permission_groups?: T[];
   sla_policies?: T[];
+  ticket_fields?: T[];
   meta?: {
     has_more: boolean;
     after_cursor: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,15 +63,13 @@ export interface ZendeskSlaSideloadEntry {
   policy_metrics: ZendeskSlaLiveMetric[];
 }
 
-// A selectable option on a dropdown/multiselect custom field. `value` is the
-// tag written back via create_ticket / update_ticket custom_fields; `name` is
-// the human label shown in the Zendesk UI.
-export interface ZendeskCustomFieldOption {
-  id: number;
+// A selectable value on a ticket field. `value` is the tag written back via
+// create_ticket / update_ticket custom_fields; `name` is the human label shown
+// in the Zendesk UI. Shared by dropdown/multiselect custom fields
+// (`custom_field_options`) and system fields (`system_field_options`).
+export interface ZendeskFieldOption {
   name: string;
-  raw_name?: string;
   value: string;
-  default?: boolean;
 }
 
 // A ticket field definition (system or custom) from the Ticket Fields API. The
@@ -85,12 +83,9 @@ export interface ZendeskTicketField {
   description: string | null;
   active: boolean;
   required: boolean;
-  position?: number;
   tag?: string | null;
-  custom_field_options?: ZendeskCustomFieldOption[];
-  system_field_options?: Array<{ name: string; value: string }>;
-  created_at?: string;
-  updated_at?: string;
+  custom_field_options?: ZendeskFieldOption[];
+  system_field_options?: ZendeskFieldOption[];
 }
 
 export interface ZendeskTicketAttachment {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -14,6 +14,7 @@ import type {
   ZendeskSlaPolicy,
   ZendeskSlaSideloadEntry,
   ZendeskTicket,
+  ZendeskTicketField,
   ZendeskTranslation,
   ZendeskUser,
   ZendeskUserSegment,
@@ -74,6 +75,26 @@ export const formatSlaPolicy = (policy: ZendeskSlaPolicy): string => {
   ]
     .filter(Boolean)
     .join('\n');
+};
+
+// Render a ticket field definition. Surfaces the id (what custom_fields writes
+// need), the type, and — for dropdown/multiselect (custom_field_options) or
+// system fields (system_field_options) — the exact value tags accepted, so the
+// caller can map a natural-language intent to a valid write without guessing.
+export const formatTicketField = (field: ZendeskTicketField): string => {
+  const flags = [
+    field.active ? 'active' : 'inactive',
+    field.required ? 'required' : 'optional',
+  ].join(', ');
+  const lines = [`## ${field.title} (id ${field.id})`, `- **Type**: ${field.type} | **${flags}**`];
+  if (field.description) lines.push(`- **Description**: ${field.description}`);
+  if (field.tag) lines.push(`- **Tag**: ${field.tag}`);
+  const options = field.custom_field_options ?? field.system_field_options;
+  if (options && options.length > 0) {
+    lines.push('- **Options** (name → value):');
+    for (const o of options) lines.push(`  - ${o.name} → ${o.value}`);
+  }
+  return lines.join('\n');
 };
 
 const minutesUntil = (iso: string): number | null => {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -86,15 +86,17 @@ export const formatTicketField = (field: ZendeskTicketField): string => {
     field.active ? 'active' : 'inactive',
     field.required ? 'required' : 'optional',
   ].join(', ');
-  const lines = [`## ${field.title} (id ${field.id})`, `- **Type**: ${field.type} | **${flags}**`];
-  if (field.description) lines.push(`- **Description**: ${field.description}`);
-  if (field.tag) lines.push(`- **Tag**: ${field.tag}`);
-  const options = field.custom_field_options ?? field.system_field_options;
-  if (options && options.length > 0) {
-    lines.push('- **Options** (name → value):');
-    for (const o of options) lines.push(`  - ${o.name} → ${o.value}`);
-  }
-  return lines.join('\n');
+  const options = field.custom_field_options ?? field.system_field_options ?? [];
+  return [
+    `## ${field.title} (id ${field.id})`,
+    `- **Type**: ${field.type} | **${flags}**`,
+    field.description ? `- **Description**: ${field.description}` : '',
+    field.tag ? `- **Tag**: ${field.tag}` : '',
+    options.length > 0 ? '- **Options** (name → value):' : '',
+    ...options.map((o) => `  - ${o.name} → ${o.value}`),
+  ]
+    .filter(Boolean)
+    .join('\n');
 };
 
 const minutesUntil = (iso: string): number | null => {

--- a/tests/functional/scenarios/04-all-baseline/expected.md
+++ b/tests/functional/scenarios/04-all-baseline/expected.md
@@ -4,7 +4,7 @@
 
 ## Expected values
 
-- **A1.** `tools.length === 39`. Breakdown: 11 ticket tools + 22 Help Center
+- **A1.** `tools.length === 40`. Breakdown: 12 ticket tools + 22 Help Center
   tools + 5 user/organization tools + 1 unified search tool. If the count
   drifts, update the documentation listed in `AGENTS.md` "Documentation
   maintenance" before running.

--- a/tests/functional/scenarios/04-all-baseline/expected.md
+++ b/tests/functional/scenarios/04-all-baseline/expected.md
@@ -4,7 +4,7 @@
 
 ## Expected values
 
-- **A1.** `tools.length === 38`. Breakdown: 10 ticket tools + 22 Help Center
+- **A1.** `tools.length === 39`. Breakdown: 11 ticket tools + 22 Help Center
   tools + 5 user/organization tools + 1 unified search tool. If the count
   drifts, update the documentation listed in `AGENTS.md` "Documentation
   maintenance" before running.

--- a/tests/functional/scenarios/04-all-baseline/spec.md
+++ b/tests/functional/scenarios/04-all-baseline/spec.md
@@ -35,7 +35,7 @@ own `annotations` object intact (PR #53 must not regress flat mode).
   "readOnly": false,
   "branch": "claude/laughing-lovelace-HmZOn",
   "assertions": [
-    { "id": "A1", "desc": "tools/list returns exactly 39 entries",                                   "pass": null, "actual": null },
+    { "id": "A1", "desc": "tools/list returns exactly 40 entries",                                   "pass": null, "actual": null },
     { "id": "A2", "desc": "every entry has a non-empty annotations object",                          "pass": null, "actual": null },
     { "id": "A3", "desc": "every entry has openWorldHint=true",                                      "pass": null, "actual": null },
     { "id": "A4", "desc": "get_current_user has readOnlyHint=true and destructiveHint=false",        "pass": null, "actual": null },

--- a/tests/functional/scenarios/04-all-baseline/spec.md
+++ b/tests/functional/scenarios/04-all-baseline/spec.md
@@ -35,7 +35,7 @@ own `annotations` object intact (PR #53 must not regress flat mode).
   "readOnly": false,
   "branch": "claude/laughing-lovelace-HmZOn",
   "assertions": [
-    { "id": "A1", "desc": "tools/list returns exactly 38 entries",                                   "pass": null, "actual": null },
+    { "id": "A1", "desc": "tools/list returns exactly 39 entries",                                   "pass": null, "actual": null },
     { "id": "A2", "desc": "every entry has a non-empty annotations object",                          "pass": null, "actual": null },
     { "id": "A3", "desc": "every entry has openWorldHint=true",                                      "pass": null, "actual": null },
     { "id": "A4", "desc": "get_current_user has readOnlyHint=true and destructiveHint=false",        "pass": null, "actual": null },

--- a/tests/functional/scenarios/05-strict-params/expected.md
+++ b/tests/functional/scenarios/05-strict-params/expected.md
@@ -6,7 +6,7 @@ executor — it is the verdict criterion.
 
 | ID | Expected |
 | -- | -------- |
-| S1 | `tools/list` returns **38** entries, and **all 38** have `inputSchema.additionalProperties === false` — including zero-parameter tools such as `get_current_user` (`inputSchema: {type:"object", properties:{}, additionalProperties:false}`). A count below 38, or any entry missing the key / not `false`, is a FAIL. (Total is allowed to drift if the tool surface changed; the load-bearing part is **every** entry having `additionalProperties:false`.) |
+| S1 | `tools/list` returns **39** entries, and **all 39** have `inputSchema.additionalProperties === false` — including zero-parameter tools such as `get_current_user` (`inputSchema: {type:"object", properties:{}, additionalProperties:false}`). A count below 39, or any entry missing the key / not `false`, is a FAIL. (Total is allowed to drift if the tool surface changed; the load-bearing part is **every** entry having `additionalProperties:false`.) |
 | S2 | `list_tickets` → `inputSchema.properties.page_size.description` === `"Tickets per page (1-100, default 100)."` (non-empty is the bar; exact string here for reference). |
 | S3 | `list_tickets` → `inputSchema.properties.cursor.description` === `"Pagination cursor from a previous response; omit for the first page."` Must convey "omit for the first page"; the bare old value `"Pagination cursor"` is a FAIL. |
 | S4 | `list_tickets` → top-level `description` contains both the substring `page_size` and the substring `per_page`. Exact text: `"List tickets with cursor-based pagination, sorted by most recently updated. Page size is controlled by page_size (not per_page, which is the offset-based parameter used by search_tickets); paginate by passing the returned cursor."` |

--- a/tests/functional/scenarios/05-strict-params/expected.md
+++ b/tests/functional/scenarios/05-strict-params/expected.md
@@ -6,7 +6,7 @@ executor — it is the verdict criterion.
 
 | ID | Expected |
 | -- | -------- |
-| S1 | `tools/list` returns **39** entries, and **all 39** have `inputSchema.additionalProperties === false` — including zero-parameter tools such as `get_current_user` (`inputSchema: {type:"object", properties:{}, additionalProperties:false}`). A count below 39, or any entry missing the key / not `false`, is a FAIL. (Total is allowed to drift if the tool surface changed; the load-bearing part is **every** entry having `additionalProperties:false`.) |
+| S1 | `tools/list` returns **40** entries, and **all 40** have `inputSchema.additionalProperties === false` — including zero-parameter tools such as `get_current_user` (`inputSchema: {type:"object", properties:{}, additionalProperties:false}`). A count below 40, or any entry missing the key / not `false`, is a FAIL. (Total is allowed to drift if the tool surface changed; the load-bearing part is **every** entry having `additionalProperties:false`.) |
 | S2 | `list_tickets` → `inputSchema.properties.page_size.description` === `"Tickets per page (1-100, default 100)."` (non-empty is the bar; exact string here for reference). |
 | S3 | `list_tickets` → `inputSchema.properties.cursor.description` === `"Pagination cursor from a previous response; omit for the first page."` Must convey "omit for the first page"; the bare old value `"Pagination cursor"` is a FAIL. |
 | S4 | `list_tickets` → top-level `description` contains both the substring `page_size` and the substring `per_page`. Exact text: `"List tickets with cursor-based pagination, sorted by most recently updated. Page size is controlled by page_size (not per_page, which is the offset-based parameter used by search_tickets); paginate by passing the returned cursor."` |

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -67,6 +67,42 @@ export const MOCK_SLA_SIDELOAD = {
   ],
 };
 
+// Two ticket field definitions: a system priority field (system_field_options)
+// and a custom dropdown (custom_field_options), mirroring the Ticket Fields API
+// so the tool's option rendering for both shapes is exercised.
+export const MOCK_TICKET_FIELD_SYSTEM = {
+  id: 10,
+  type: 'priority',
+  title: 'Priority',
+  description: 'Ticket priority',
+  active: true,
+  required: false,
+  position: 1,
+  system_field_options: [
+    { name: 'Low', value: 'low' },
+    { name: 'High', value: 'high' },
+  ],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+};
+
+export const MOCK_TICKET_FIELD_CUSTOM = {
+  id: 360000000001,
+  type: 'tagger',
+  title: 'Severity',
+  description: 'Customer-facing severity',
+  active: true,
+  required: true,
+  position: 9,
+  tag: null,
+  custom_field_options: [
+    { id: 1, name: 'Sev-1', raw_name: 'Sev-1', value: 'severity_1', default: false },
+    { id: 2, name: 'Sev-2', raw_name: 'Sev-2', value: 'severity_2', default: true },
+  ],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+};
+
 export const MOCK_USER = {
   id: 9999,
   name: 'Test User',
@@ -363,6 +399,14 @@ export const handlers = [
   // SLA policies — the real endpoint returns the full config list with no
   // `count` wrapper, so omit it here to exercise the array-length fallback.
   http.get(`${BASE}/slas/policies`, () => HttpResponse.json({ sla_policies: [MOCK_SLA_POLICY] })),
+
+  // Ticket field definitions (system + custom), cursor-paginated like /tickets.
+  http.get(`${BASE}/ticket_fields`, () =>
+    HttpResponse.json({
+      ticket_fields: [MOCK_TICKET_FIELD_SYSTEM, MOCK_TICKET_FIELD_CUSTOM],
+      meta: { has_more: false, after_cursor: '' },
+    }),
+  ),
 
   // Search
   http.get(`${BASE}/search`, ({ request }) => {

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -77,13 +77,10 @@ export const MOCK_TICKET_FIELD_SYSTEM = {
   description: 'Ticket priority',
   active: true,
   required: false,
-  position: 1,
   system_field_options: [
     { name: 'Low', value: 'low' },
     { name: 'High', value: 'high' },
   ],
-  created_at: '2026-01-01T00:00:00Z',
-  updated_at: '2026-01-02T00:00:00Z',
 };
 
 export const MOCK_TICKET_FIELD_CUSTOM = {
@@ -93,14 +90,11 @@ export const MOCK_TICKET_FIELD_CUSTOM = {
   description: 'Customer-facing severity',
   active: true,
   required: true,
-  position: 9,
   tag: null,
   custom_field_options: [
-    { id: 1, name: 'Sev-1', raw_name: 'Sev-1', value: 'severity_1', default: false },
-    { id: 2, name: 'Sev-2', raw_name: 'Sev-2', value: 'severity_2', default: true },
+    { name: 'Sev-1', value: 'severity_1' },
+    { name: 'Sev-2', value: 'severity_2' },
   ],
-  created_at: '2026-01-01T00:00:00Z',
-  updated_at: '2026-01-02T00:00:00Z',
 };
 
 export const MOCK_USER = {

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -64,7 +64,7 @@ describe('groupByNamespace', () => {
     const ticketCount = grouped.get('tickets')?.length ?? 0;
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
-    expect(ticketCount).toBe(12); // 11 ticket tools + 1 search
+    expect(ticketCount).toBe(13); // 12 ticket tools + 1 search
     expect(hcCount).toBe(22);
     expect(userCount).toBe(5);
   });

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -21,9 +21,9 @@ const getAllText = (result: { content: Array<{ type: string; text?: string }> })
     .join('\n');
 
 describe('ticket tools', () => {
-  it('creates 11 tools (search_tickets lives here; the unified search is elsewhere)', () => {
+  it('creates 12 tools (search_tickets lives here; the unified search is elsewhere)', () => {
     const tools = createTicketTools(ctx);
-    expect(tools).toHaveLength(11);
+    expect(tools).toHaveLength(12);
   });
 
   describe('get_ticket', () => {
@@ -566,6 +566,39 @@ describe('ticket tools', () => {
       );
       expect(error.message).toMatch(/admin/i);
       expect(error.message).toMatch(/get_ticket|search_tickets/);
+    });
+  });
+
+  describe('list_ticket_fields', () => {
+    it('lists field definitions with ids, types, and option values', async () => {
+      const tool = findTool('list_ticket_fields');
+      const result = await tool.handler({ page_size: 100 });
+      const text = result.content[0]?.text ?? '';
+      // System field: title, id, and its system_field_options.
+      expect(text).toContain('Priority (id 10)');
+      expect(text).toContain('High → high');
+      // Custom dropdown: id and its custom_field_options tags.
+      expect(text).toContain('Severity (id 360000000001)');
+      expect(text).toContain('Sev-2 → severity_2');
+      expect(text).toContain('required');
+    });
+
+    it('is read-only and passes the cursor through to Zendesk', async () => {
+      let sawCursor: string | null = null;
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/ticket_fields', ({ request }) => {
+          sawCursor = new URL(request.url).searchParams.get('page[after]');
+          return HttpResponse.json({
+            ticket_fields: [],
+            meta: { has_more: false, after_cursor: '' },
+          });
+        }),
+      );
+      const tool = findTool('list_ticket_fields');
+      expect(tool.readOnly).toBe(true);
+      expect(tool.annotations.readOnlyHint).toBe(true);
+      await tool.handler({ page_size: 50, cursor: 'CURSOR123' });
+      expect(sawCursor).toBe('CURSOR123');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a read-only `list_ticket_fields` tool to the `tickets` namespace so the model can **discover** ticket field definitions — the ids, types, active/required flags, and (for dropdown/multiselect and system fields) the accepted option values. This is the read half of a write capability we already ship: `create_ticket` / `update_ticket` accept `custom_fields` as `{ id, value }` pairs, but until now nothing let the assistant learn those ids or the values a field accepts, so custom-field writes were blind. Closes #119.

This PR also adds a `## Functional validation plan` checklist item to `.github/pull_request_template.md` (mirroring the AGENTS.md "Planning" rule).

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes (`tsc --noEmit`)
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
- [x] If the change has runtime-observable behaviour: this PR carries a `## Functional validation plan` (authored with `/functional-validation-plan`), and it has been executed by an independent validator (`/run-validation-plan`) whose report is posted as a PR comment — _validated against `5add1b7`: all scenarios V1–V6 OK, including real-API cursor pagination (V5)_

## Notes for the reviewer (human or AI)

- **Endpoint:** `GET /api/v2/ticket_fields`, cursor-paginated like `list_tickets` (`page[size]` / `page[after]`). Confirmed against Zendesk docs that this endpoint is cursor-based when `page[size]` is sent (which `buildCursorParams` always does), and empirically confirmed by the validation report (V5: real cursor round-trip on the live tenant).
- **Rendering:** `formatTicketField` surfaces `custom_field_options` (custom dropdown/multiselect) and falls back to `system_field_options` (system fields like priority) under one "Options (name → value)" block — `value` is the tag written back via `custom_fields`.
- **Superset rule:** the `custom_fields` descriptions and the `create_ticket` description were only *enriched* — existing text kept verbatim, new sentence appended — no field dropped, no type loosened.
- **Counts synced:** `tests/unit/routing/registry.test.ts` (tickets 12→13), `tests/unit/tools/tickets.test.ts` (11→12), and the functional-scenario 04/05 baselines corrected to **40** tools (12 ticket tools + 22 help_center + 5 users + 1 unified search) — this also fixed a pre-existing off-by-one in those baselines.
- **Reviewed:** ran `/simplify` (types trimmed, formatter idiom aligned) and `/code-review` (fixed the additive-description regression and the baseline count); pagination and proxy-truncation concerns were investigated and refuted. CodeRabbit review returned no actionable comments.

## Functional validation plan

**Context.** The feature is the new read-only tool `list_ticket_fields` (tickets namespace). The tool call that exercises it is `mcp__zendesk-local__list_ticket_fields`. It hits `GET /api/v2/ticket_fields` and renders each field via `formatTicketField`. No write path is touched; `create_ticket`/`update_ticket` only got description enrichment (validated by reading their schema text, not by mutating tickets).

**Setup & prerequisites.** None beyond the ready environment — the server is running, authenticated, and its tools are loaded as `mcp__zendesk-local__*`. Capture the SHA under test with `git rev-parse HEAD` and report it. A credential/egress error is a `BLOCKED` finding, not a setup task. No throwaway state to seed (read-only). No ground-truth probe is needed: the Ticket Fields API shape is documented and stable, and the assertions below are about the rendered output, which the tool itself reveals.

**Scenarios.**

| id | validates | manipulation / call | expected observable |
|----|-----------|---------------------|---------------------|
| V1 | tool is registered & read-only | inspect `tools/list` (already loaded) for `list_ticket_fields` | present in the `tickets` surface; no `[RO]`/write behaviour; description mentions discovering ids for `custom_fields` |
| V2 | happy-path listing | call `mcp__zendesk-local__list_ticket_fields` with no args | text lists field definitions, each with a title + `(id <n>)`, a `Type:` line, and `active/inactive`, `required/optional` flags. `Results: <n>` footer present |
| V3 | dropdown/custom option values surface | in the V2 output, find a custom dropdown/multiselect field (type `tagger`/`multiselect`) | it renders an `Options (name → value)` block listing each option's human name and its write-back `value` tag |
| V4 | system field options surface | in the V2 output, find a system field with a fixed value set (e.g. Priority) | its accepted values render under the same Options block (name → value) |
| V5 | pagination round-trips | call with `page_size: 1` (or a small size); if the footer reports "More available (cursor: X)", call again with `cursor: X` | second page returns a different/next field; no error; cursor is honoured |
| V6 | end-to-end intent → write mapping (read-only check) | pick a field + option from V3, confirm `update_ticket`'s `custom_fields` schema description now points to `list_ticket_fields`; **do not actually mutate a ticket** unless a throwaway ticket is available | the id + value pair from V3 is exactly the `{ id, value }` shape `custom_fields` expects; description guidance is present |

**Long-running behaviours.** None — no timers or intervals. Nothing to simulate.

**Priorities.** V2 → V3 → V4 are the core user-facing paths (discovering ids and option values). V1 and V5 are surface/pagination sanity. V6 is a documentation/shape cross-check.

**Reporting.** Post a PR comment (English) with the tested commit SHA and a per-id verdict (OK/FAIL/BLOCKED) plus the observed evidence (the relevant lines of tool output). Close with an overall green/failing summary.

**Result:** ✅ executed by an independent validator against `5add1b7` — all 6 scenarios (V1–V6) OK. See the [validation report comment](https://github.com/fruggr/zendesk-mcp-server/pull/143#issuecomment).

https://claude.ai/code/session_01MMvynHB39YeNVfyuMYNi5Y