### PR TITLE
feat(tickets): add list_macros and apply_macro tools (#120)

### DIFF
--- a/.claude/skills/run-validation-plan/SKILL.md
+++ b/.claude/skills/run-validation-plan/SKILL.md
@@ -97,7 +97,32 @@ GitHub MCP is connected, `mcp__github__add_issue_comment`. If neither is availab
 ```
 
 Per-row evidence must be concrete enough that the author can verify it without
-re-running: name the log event, the field that changed, the error string.
+re-running: name the log event, the field that changed, the error string. "Concrete"
+means the **structure** — field names, formatting markers (headings, footers,
+counts), types, the shape of the payload — *not* the live values (see next).
+
+### Redact real data — the server hits a production tenant
+
+The MCP server under test is wired to a **real, live Zendesk tenant with
+production data**, not a fixture or sandbox. Every tool output can carry live
+customer PII and confidential business data: requester/agent names, email
+addresses and phone numbers, organization names, ticket subjects / descriptions /
+comment bodies, attachment contents, custom-field values, and the tenant
+subdomain / API URLs. The report is posted to a **public GitHub PR** — so **never
+paste real data into it**.
+
+- **Expunge every real value before it leaves a tool result for the report.**
+  Replace it with a placeholder that preserves only what the scenario tests:
+  `<redacted>`, `<requester name>`, `<tenant url>`, `<int>`, etc. Keep the
+  structural evidence the author actually needs — field *names*, headings,
+  footers, counts, types, formatting markers — and drop the customer *values*.
+- Numeric IDs (ticket/macro/user ids) are lower-risk and may be kept when a
+  scenario needs them for reproduction, but never pair them with the name,
+  email, subject or body they belong to.
+- This applies to **every** outbound channel, not just the PR comment: pasted
+  output for a human, any scratch file you write, and any log excerpt you quote.
+- If the harness blocks a post for sensitive content, treat that as a correct
+  catch — redact and repost, don't try to force the original through.
 
 ## Hard rules
 
@@ -105,5 +130,8 @@ re-running: name the log event, the field that changed, the error string.
 - Independent: validate behaviour against the plan's expectations, not against the
   implementer's explanation of why it should work.
 - Real tools only (`mcp__<server>__*`), throwaway copies of any mutable state.
+- The tenant is **production**: never let a real value (PII, org, ticket
+  content, subdomain) reach the report or any other output — redact to
+  structure-only placeholders (see "Redact real data").
 - One report per run, naming the commit SHA. On a re-run after a fix, post a fresh
   report against the new SHA rather than editing the old one.

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -27,7 +27,7 @@ out every `write` tool before the proxies are built.
 | `add_private_note` | Add an internal note (not visible to requester), optionally with file attachments | write |
 | `add_public_comment` | Add a public comment (visible to requester), optionally with file attachments | write |
 | `manage_tags` | Add or remove tags on a ticket | write |
-| `apply_macro` | Preview a macro's effect on a ticket (field changes + reply) without saving; commit the result via update_ticket / add_public_comment / add_private_note | write |
+| `preview_macro_diff` | Preview a macro's changes to a ticket as a before → after diff (only changed fields + reply), without saving; commit via update_ticket / add_public_comment / add_private_note | write |
 
 </details>
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -21,11 +21,13 @@ out every `write` tool before the proxies are built.
 | `get_linked_incidents` | Get incidents linked to a problem ticket | read |
 | `list_sla_policies` | List SLA policies with filter conditions and per-priority targets (requires an admin token, or a custom role with the SLA-management permission) | read |
 | `list_ticket_fields` | List ticket field definitions (system + custom) with ids, types, and dropdown/multiselect option values, to resolve `custom_fields` ids and accepted values for create_ticket / update_ticket | read |
+| `list_macros` | List the active macros available to the authenticated user, with each macro's id, title, scope, and ordered actions | read |
 | `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |
 | `update_ticket` | Update ticket status, priority, assignee, tags, custom fields | write |
 | `add_private_note` | Add an internal note (not visible to requester), optionally with file attachments | write |
 | `add_public_comment` | Add a public comment (visible to requester), optionally with file attachments | write |
 | `manage_tags` | Add or remove tags on a ticket | write |
+| `apply_macro` | Preview a macro's effect on a ticket (field changes + reply) without saving; commit the result via update_ticket / add_public_comment / add_private_note | write |
 
 </details>
 

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -184,10 +184,13 @@ const fetchTicketSla = async (
 const formatMacroApplyResult = (
   ticketId: number,
   macroId: number,
-  result: ZendeskMacroApplyResult,
+  result: ZendeskMacroApplyResult | undefined,
 ): string => {
-  const ticket = result.ticket ?? {};
-  const comment: ZendeskMacroApplyComment | undefined = ticket.comment ?? result.comment;
+  // Zendesk always wraps the preview in `result.ticket`, but guard the whole
+  // path so a malformed body degrades to a clean "no changes" instead of a
+  // cryptic "cannot read properties of undefined" tool error.
+  const ticket = result?.ticket ?? {};
+  const comment: ZendeskMacroApplyComment | undefined = ticket.comment ?? result?.comment;
   const customFields = ticket.fields ?? ticket.custom_fields ?? [];
 
   const scalarChanges = Object.entries(ticket)

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -179,10 +179,14 @@ const fetchTicketSla = async (
   }
 };
 
-// Non-actionable ticket keys: structural (handled on their own) or identity /
-// server-recomputed fields a macro never meaningfully sets. Excluded from the
-// field diff so the preview surfaces only what the macro actually changes,
-// never `url`/`id`/`created_at` noise or a spuriously-bumped timestamp.
+// Keys the generic field diff must not emit. Two reasons, both in this set:
+//   - `comment`/`fields`/`custom_fields` are routed to their own render paths, so
+//     the scalar loop skips them regardless of whether they changed.
+//   - `updated_at`/`generated_timestamp`/`encoded_id` are server-recomputed, so a
+//     no-op preview can bump them and they'd surface as spurious changes.
+// `id`/`url`/`created_at` are byte-identical across the two fetches and already
+// drop out via the diff; they're listed as belt-and-suspenders. Erring toward
+// over-suppression is the safe direction for a preview that precedes a real write.
 const DIFF_SKIP_KEYS = new Set([
   'comment',
   'fields',

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -211,6 +211,16 @@ const shownValue = (v: unknown): string => {
   return s === '' ? '(empty)' : s;
 };
 
+// A single `label: before → after` change line, or null when the two sides
+// render identically. The null case also drops a field the apply response
+// returns as `null` where the current ticket omits the key: both render as
+// "(empty)", so it is a no-op and must not appear as a change.
+const diffLine = (label: string, before: unknown, after: unknown): string | null => {
+  const b = shownValue(before);
+  const a = shownValue(after);
+  return b === a ? null : `- **${label}**: ${b} → ${a}`;
+};
+
 // Tags diff as added/removed tokens rather than a full before/after list — that
 // is what a macro's `set_tags`/`remove_tags` actions actually express. Returns
 // null when the tag set is unchanged.
@@ -250,10 +260,14 @@ const formatMacroPreviewDiff = (
     if (key === 'tags') {
       const tagLine = formatTagDiff(beforeVal, afterVal);
       if (tagLine) changes.push(tagLine);
-    } else if (afterVal !== null && typeof afterVal === 'object' && !Array.isArray(afterVal)) {
-    } else {
-      changes.push(`- **${key}**: ${shownValue(beforeVal)} → ${shownValue(afterVal)}`);
+      continue;
     }
+    // No macro-settable standard field is a nested object; via /
+    // satisfaction_rating and the like only differ incidentally between the two
+    // reads, so skip them rather than dumping raw JSON.
+    if (afterVal !== null && typeof afterVal === 'object' && !Array.isArray(afterVal)) continue;
+    const line = diffLine(key, beforeVal, afterVal);
+    if (line) changes.push(line);
   }
 
   // Custom fields diff by id: the apply response carries every custom field, so
@@ -261,9 +275,8 @@ const formatMacroPreviewDiff = (
   const afterFields = [after.fields ?? after.custom_fields ?? []].flat();
   const beforeById = new Map((before?.custom_fields ?? []).map((f) => [f.id, f.value] as const));
   for (const f of afterFields) {
-    const prev = beforeById.get(f.id);
-    if (valuesEqual(prev, f.value)) continue;
-    changes.push(`- **custom field ${f.id}**: ${shownValue(prev)} → ${shownValue(f.value)}`);
+    const line = diffLine(`custom field ${f.id}`, beforeById.get(f.id), f.value);
+    if (line) changes.push(line);
   }
 
   const lines = [

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -197,7 +197,7 @@ const formatMacroApplyResult = (
   // object rather than a one-element array, so normalize to an array before
   // mapping — a lone object would otherwise blow up on `.map`.
   const rawFields = ticket.fields ?? ticket.custom_fields;
-  const customFields = Array.isArray(rawFields) ? rawFields : rawFields ? [rawFields] : [];
+  const customFields = [rawFields ?? []].flat();
 
   const scalarChanges = Object.entries(ticket)
     .filter(([key]) => key !== 'comment' && key !== 'fields' && key !== 'custom_fields')

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -250,6 +250,7 @@ const formatMacroPreviewDiff = (
     if (key === 'tags') {
       const tagLine = formatTagDiff(beforeVal, afterVal);
       if (tagLine) changes.push(tagLine);
+    } else if (afterVal !== null && typeof afterVal === 'object' && !Array.isArray(afterVal)) {
     } else {
       changes.push(`- **${key}**: ${shownValue(beforeVal)} → ${shownValue(afterVal)}`);
     }

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -193,7 +193,11 @@ const formatMacroApplyResult = (
   // cryptic "cannot read properties of undefined" tool error.
   const ticket = result?.ticket ?? {};
   const comment: ZendeskMacroApplyComment | undefined = ticket.comment ?? result?.comment;
-  const customFields = ticket.fields ?? ticket.custom_fields ?? [];
+  // The Zendesk docs render a single changed custom field as a bare `{id, value}`
+  // object rather than a one-element array, so normalize to an array before
+  // mapping — a lone object would otherwise blow up on `.map`.
+  const rawFields = ticket.fields ?? ticket.custom_fields;
+  const customFields = Array.isArray(rawFields) ? rawFields : rawFields ? [rawFields] : [];
 
   const scalarChanges = Object.entries(ticket)
     .filter(([key]) => key !== 'comment' && key !== 'fields' && key !== 'custom_fields')

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -29,6 +29,7 @@ import type {
 } from '../types';
 import {
   formatComment,
+  formatFieldValue,
   formatList,
   formatMacro,
   formatSlaBlock,
@@ -40,6 +41,7 @@ import {
 import {
   buildCursorParams,
   buildOffsetParams,
+  extractOffsetPaginationMeta,
   extractPaginationMeta,
   extractSearchPaginationMeta,
   PAGE_DESC,
@@ -195,22 +197,19 @@ const formatMacroApplyResult = (
 
   const scalarChanges = Object.entries(ticket)
     .filter(([key]) => key !== 'comment' && key !== 'fields' && key !== 'custom_fields')
-    .map(
-      ([key, value]) => `- **${key}**: ${Array.isArray(value) ? value.join(', ') : String(value)}`,
-    );
+    .map(([key, value]) => `- **${key}**: ${formatFieldValue(value)}`);
 
   const customFieldChanges = customFields.map(
-    (f) =>
-      `- **custom field ${f.id}**: ${Array.isArray(f.value) ? f.value.join(', ') : String(f.value)}`,
+    (f) => `- **custom field ${f.id}**: ${formatFieldValue(f.value)}`,
   );
+
+  const fieldChanges = [...scalarChanges, ...customFieldChanges];
 
   const lines = [
     `# Macro #${macroId} applied to ticket #${ticketId} (preview — nothing saved yet)`,
     '',
     '## Field changes',
-    ...(scalarChanges.length > 0 || customFieldChanges.length > 0
-      ? [...scalarChanges, ...customFieldChanges]
-      : ['- none']),
+    ...(fieldChanges.length > 0 ? fieldChanges : ['- none']),
   ];
 
   if (comment?.body) {
@@ -902,12 +901,9 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         }
         const policies = response.sla_policies ?? [];
         // The SLA policies endpoint returns the full config list and, in
-        // practice, omits the `count` wrapper, so fall back to the array length
-        // rather than reporting "Results: 0".
-        const meta =
-          response.count != null
-            ? extractSearchPaginationMeta(response, per_page, page)
-            : { count: policies.length, has_more: false, after_cursor: null };
+        // practice, omits the `count` wrapper, so the shared helper falls back to
+        // the array length rather than reporting "Results: 0".
+        const meta = extractOffsetPaginationMeta(response, policies.length, per_page, page);
         return {
           content: [{ type: 'text', text: formatList(policies, formatSlaPolicy, meta) }],
         };
@@ -996,12 +992,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           buildOffsetParams(per_page, page),
         );
         const macros = response.macros ?? [];
-        // Guard against the `count` wrapper being absent on some responses so the
-        // footer reflects the page rather than a misleading "Results: 0".
-        const meta =
-          response.count != null
-            ? extractSearchPaginationMeta(response, per_page, page)
-            : { count: macros.length, has_more: false, after_cursor: null };
+        const meta = extractOffsetPaginationMeta(response, macros.length, per_page, page);
         return {
           content: [{ type: 'text', text: formatList(macros, formatMacro, meta) }],
         };

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -17,6 +17,9 @@ import {
 import type {
   ZendeskComment,
   ZendeskListResponse,
+  ZendeskMacro,
+  ZendeskMacroApplyComment,
+  ZendeskMacroApplyResult,
   ZendeskSlaPolicy,
   ZendeskSlaSideloadEntry,
   ZendeskTicket,
@@ -27,6 +30,7 @@ import type {
 import {
   formatComment,
   formatList,
+  formatMacro,
   formatSlaBlock,
   formatSlaPolicy,
   formatTicket,
@@ -171,6 +175,55 @@ const fetchTicketSla = async (
     // SLA is supplementary — never fail get_ticket because the lookup faltered.
     return undefined;
   }
+};
+
+// Render the preview returned by the macro-apply endpoint into the concrete,
+// reviewable changes a macro would make, then spell out the commit step. The
+// apply endpoint mutates nothing, so the text ends by pointing at the write
+// tools that actually persist the change — the deliberate two-step from #120.
+const formatMacroApplyResult = (
+  ticketId: number,
+  macroId: number,
+  result: ZendeskMacroApplyResult,
+): string => {
+  const ticket = result.ticket ?? {};
+  const comment: ZendeskMacroApplyComment | undefined = ticket.comment ?? result.comment;
+  const customFields = ticket.fields ?? ticket.custom_fields ?? [];
+
+  const scalarChanges = Object.entries(ticket)
+    .filter(([key]) => key !== 'comment' && key !== 'fields' && key !== 'custom_fields')
+    .map(
+      ([key, value]) => `- **${key}**: ${Array.isArray(value) ? value.join(', ') : String(value)}`,
+    );
+
+  const customFieldChanges = customFields.map(
+    (f) =>
+      `- **custom field ${f.id}**: ${Array.isArray(f.value) ? f.value.join(', ') : String(f.value)}`,
+  );
+
+  const lines = [
+    `# Macro #${macroId} applied to ticket #${ticketId} (preview — nothing saved yet)`,
+    '',
+    '## Field changes',
+    ...(scalarChanges.length > 0 || customFieldChanges.length > 0
+      ? [...scalarChanges, ...customFieldChanges]
+      : ['- none']),
+  ];
+
+  if (comment?.body) {
+    const visibility = comment.public === false ? 'internal note' : 'public comment';
+    lines.push('', `## Reply (${visibility})`, '', comment.body);
+  } else {
+    lines.push('', '## Reply', '- none');
+  }
+
+  lines.push(
+    '',
+    '## To apply these changes',
+    'Nothing has been committed. Persist the field changes with `update_ticket` (or `manage_tags` for incremental tag edits), and post the reply with `add_public_comment` (public) or `add_private_note` (internal). Edit the reply text first if needed.',
+  );
+
+  return lines.join('\n');
 };
 
 export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
@@ -902,6 +955,97 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
                 formatTicketField,
                 extractPaginationMeta(response, fields.length),
               ),
+            },
+          ],
+        };
+      },
+    },
+    {
+      name: 'list_macros',
+      namespace: 'tickets',
+      readOnly: true,
+      title: 'List Zendesk Macros',
+      description:
+        'List the active macros available to the authenticated user. A macro bundles a canned reply and/or a set of field changes (status, priority, assignee, group, tags, custom fields) an agent applies to a ticket in one gesture; this returns each macro id, title, description, availability scope, and its ordered list of actions, offset-paginated. Results are scoped by per-user OAuth to what the current user can see, so no shared admin key is needed. Pass a macro id from here to apply_macro to preview its effect on a specific ticket.',
+      inputSchema: z.object({
+        per_page: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe(PER_PAGE_DESC),
+        page: z.number().int().min(1).default(1).describe(PAGE_DESC),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { per_page, page } = params as { per_page: number; page: number };
+        const token = await getToken();
+        const response = await zendeskGet<ZendeskListResponse<ZendeskMacro>>(
+          subdomain,
+          token,
+          '/macros/active',
+          buildOffsetParams(per_page, page),
+        );
+        const macros = response.macros ?? [];
+        // Guard against the `count` wrapper being absent on some responses so the
+        // footer reflects the page rather than a misleading "Results: 0".
+        const meta =
+          response.count != null
+            ? extractSearchPaginationMeta(response, per_page, page)
+            : { count: macros.length, has_more: false, after_cursor: null };
+        return {
+          content: [{ type: 'text', text: formatList(macros, formatMacro, meta) }],
+        };
+      },
+    },
+    {
+      name: 'apply_macro',
+      namespace: 'tickets',
+      // Marked write (readOnly: false) even though the apply endpoint mutates
+      // nothing: it is the entry point of a mutation workflow whose commit step
+      // (update_ticket / add_*_comment) is filtered out by --read-only, so
+      // exposing apply_macro there would offer an "apply" the user cannot finish.
+      readOnly: false,
+      title: 'Apply Macro to Ticket (preview)',
+      description:
+        'Resolve a macro against a ticket and return the concrete changes it would make — the canned reply (with its public/internal flag) plus every field change (status, priority, assignee, tags, custom fields) — WITHOUT saving anything. Returns the proposed reply and field set for review; nothing is committed. To actually apply it, follow up with update_ticket for the field changes and add_public_comment or add_private_note for the reply. This deliberate two-step keeps the mutation explicit and reviewable rather than hidden. Find macro ids via list_macros and the ticket id via search_tickets or list_tickets.',
+      inputSchema: z.object({
+        ticket_id: z
+          .number()
+          .int()
+          .describe(
+            'Ticket ID — the numeric id of the ticket to preview the macro against. Obtain it from search_tickets or list_tickets.',
+          ),
+        macro_id: z
+          .number()
+          .int()
+          .describe('Macro ID — the numeric id of the macro to apply. Obtain it from list_macros.'),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { ticket_id, macro_id } = params as { ticket_id: number; macro_id: number };
+        const token = await getToken();
+        const { result } = await zendeskGet<{ result: ZendeskMacroApplyResult }>(
+          subdomain,
+          token,
+          `/tickets/${ticket_id}/macros/${macro_id}/apply`,
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: truncateIfNeeded(formatMacroApplyResult(ticket_id, macro_id, result)),
             },
           ],
         };

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -179,41 +179,93 @@ const fetchTicketSla = async (
   }
 };
 
-// Render the preview returned by the macro-apply endpoint into the concrete,
-// reviewable changes a macro would make, then spell out the commit step. The
-// apply endpoint mutates nothing, so the text ends by pointing at the write
-// tools that actually persist the change — the deliberate two-step from #120.
-const formatMacroApplyResult = (
+// Non-actionable ticket keys: structural (handled on their own) or identity /
+// server-recomputed fields a macro never meaningfully sets. Excluded from the
+// field diff so the preview surfaces only what the macro actually changes,
+// never `url`/`id`/`created_at` noise or a spuriously-bumped timestamp.
+const DIFF_SKIP_KEYS = new Set([
+  'comment',
+  'fields',
+  'custom_fields',
+  'id',
+  'url',
+  'created_at',
+  'updated_at',
+  'generated_timestamp',
+  'encoded_id',
+]);
+
+// Value equality that also handles arrays/objects (tags, `via`, …) by structure
+// rather than reference, so unchanged nested fields drop out of the diff.
+const valuesEqual = (a: unknown, b: unknown): boolean =>
+  a === b || JSON.stringify(a) === JSON.stringify(b);
+
+// Render a value for the diff, marking an absent/empty side so a `→` line never
+// reads as "(blank) → x".
+const shownValue = (v: unknown): string => {
+  const s = formatFieldValue(v);
+  return s === '' ? '(empty)' : s;
+};
+
+// Tags diff as added/removed tokens rather than a full before/after list — that
+// is what a macro's `set_tags`/`remove_tags` actions actually express. Returns
+// null when the tag set is unchanged.
+const formatTagDiff = (before: unknown, after: unknown): string | null => {
+  const b = new Set(Array.isArray(before) ? before.map(String) : []);
+  const a = new Set(Array.isArray(after) ? after.map(String) : []);
+  const added = [...a].filter((t) => !b.has(t)).map((t) => `+${t}`);
+  const removed = [...b].filter((t) => !a.has(t)).map((t) => `-${t}`);
+  return added.length + removed.length === 0
+    ? null
+    : `- **tags**: ${[...added, ...removed].join(', ')}`;
+};
+
+// Preview a macro's effect on a ticket as a real before → after diff. The apply
+// endpoint returns the WHOLE resulting ticket (not just the macro's changes), so
+// diffing it against the ticket's current state is what isolates the macro's
+// actual effect; everything unchanged (identity fields, untouched custom fields)
+// drops out. The apply endpoint mutates nothing, so the text ends by pointing at
+// the write tools that persist the change — the deliberate two-step from #120.
+const formatMacroPreviewDiff = (
   ticketId: number,
   macroId: number,
+  before: ZendeskTicket | undefined,
   result: ZendeskMacroApplyResult | undefined,
 ): string => {
-  // Zendesk always wraps the preview in `result.ticket`, but guard the whole
-  // path so a malformed body degrades to a clean "no changes" instead of a
-  // cryptic "cannot read properties of undefined" tool error.
-  const ticket = result?.ticket ?? {};
-  const comment: ZendeskMacroApplyComment | undefined = ticket.comment ?? result?.comment;
-  // The Zendesk docs render a single changed custom field as a bare `{id, value}`
-  // object rather than a one-element array, so normalize to an array before
-  // mapping — a lone object would otherwise blow up on `.map`.
-  const rawFields = ticket.fields ?? ticket.custom_fields;
-  const customFields = [rawFields ?? []].flat();
+  // Guard the whole path so a malformed body degrades to a clean "no changes"
+  // instead of a cryptic "cannot read properties of undefined" tool error.
+  const after = result?.ticket ?? {};
+  const beforeObj = (before ?? {}) as unknown as Record<string, unknown>;
+  const comment: ZendeskMacroApplyComment | undefined = after.comment ?? result?.comment;
 
-  const scalarChanges = Object.entries(ticket)
-    .filter(([key]) => key !== 'comment' && key !== 'fields' && key !== 'custom_fields')
-    .map(([key, value]) => `- **${key}**: ${formatFieldValue(value)}`);
+  const changes: string[] = [];
+  for (const [key, afterVal] of Object.entries(after)) {
+    if (DIFF_SKIP_KEYS.has(key)) continue;
+    const beforeVal = beforeObj[key];
+    if (valuesEqual(beforeVal, afterVal)) continue;
+    if (key === 'tags') {
+      const tagLine = formatTagDiff(beforeVal, afterVal);
+      if (tagLine) changes.push(tagLine);
+    } else {
+      changes.push(`- **${key}**: ${shownValue(beforeVal)} → ${shownValue(afterVal)}`);
+    }
+  }
 
-  const customFieldChanges = customFields.map(
-    (f) => `- **custom field ${f.id}**: ${formatFieldValue(f.value)}`,
-  );
-
-  const fieldChanges = [...scalarChanges, ...customFieldChanges];
+  // Custom fields diff by id: the apply response carries every custom field, so
+  // compare each against the ticket's current value and keep only what changed.
+  const afterFields = [after.fields ?? after.custom_fields ?? []].flat();
+  const beforeById = new Map((before?.custom_fields ?? []).map((f) => [f.id, f.value] as const));
+  for (const f of afterFields) {
+    const prev = beforeById.get(f.id);
+    if (valuesEqual(prev, f.value)) continue;
+    changes.push(`- **custom field ${f.id}**: ${shownValue(prev)} → ${shownValue(f.value)}`);
+  }
 
   const lines = [
-    `# Macro #${macroId} applied to ticket #${ticketId} (preview — nothing saved yet)`,
+    `# Macro #${macroId} preview on ticket #${ticketId} (diff — nothing saved yet)`,
     '',
     '## Field changes',
-    ...(fieldChanges.length > 0 ? fieldChanges : ['- none']),
+    ...(changes.length > 0 ? changes : ['- none']),
   ];
 
   if (comment?.body) {
@@ -969,7 +1021,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'List Zendesk Macros',
       description:
-        'List the active macros available to the authenticated user. A macro bundles a canned reply and/or a set of field changes (status, priority, assignee, group, tags, custom fields) an agent applies to a ticket in one gesture; this returns each macro id, title, description, availability scope, and its ordered list of actions, offset-paginated. Results are scoped by per-user OAuth to what the current user can see, so no shared admin key is needed. Pass a macro id from here to apply_macro to preview its effect on a specific ticket.',
+        'List the active macros available to the authenticated user. A macro bundles a canned reply and/or a set of field changes (status, priority, assignee, group, tags, custom fields) an agent applies to a ticket in one gesture; this returns each macro id, title, description, availability scope, and its ordered list of actions, offset-paginated. Results are scoped by per-user OAuth to what the current user can see, so no shared admin key is needed. Pass a macro id from here to preview_macro_diff to preview its effect on a specific ticket.',
       inputSchema: z.object({
         per_page: z
           .number()
@@ -1003,16 +1055,16 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       },
     },
     {
-      name: 'apply_macro',
+      name: 'preview_macro_diff',
       namespace: 'tickets',
-      // Marked write (readOnly: false) even though the apply endpoint mutates
-      // nothing: it is the entry point of a mutation workflow whose commit step
-      // (update_ticket / add_*_comment) is filtered out by --read-only, so
-      // exposing apply_macro there would offer an "apply" the user cannot finish.
+      // Marked write (readOnly: false) even though both reads mutate nothing: it
+      // is the entry point of a mutation workflow whose commit step (update_ticket
+      // / add_*_comment) is filtered out by --read-only, so exposing it there would
+      // offer a preview the user cannot act on.
       readOnly: false,
-      title: 'Apply Macro to Ticket (preview)',
+      title: 'Preview a Macro Diff on a Ticket',
       description:
-        'Resolve a macro against a ticket and return the concrete changes it would make — the canned reply (with its public/internal flag) plus every field change (status, priority, assignee, tags, custom fields) — WITHOUT saving anything. Returns the proposed reply and field set for review; nothing is committed. To actually apply it, follow up with update_ticket for the field changes and add_public_comment or add_private_note for the reply. This deliberate two-step keeps the mutation explicit and reviewable rather than hidden. Find macro ids via list_macros and the ticket id via search_tickets or list_tickets.',
+        "Preview the exact changes a macro would make to a specific ticket, as a before → after diff, WITHOUT saving anything. Orchestrates two reads — the ticket's current state and Zendesk's macro-apply preview (which returns the whole resulting ticket) — and returns only the fields the macro actually changes (status, priority, assignee, group, tags, custom fields) plus the canned reply with its public/internal flag; unchanged and identity fields are omitted. Nothing is committed: to apply it, follow up with update_ticket for the field changes and add_public_comment or add_private_note for the reply. This deliberate two-step keeps the mutation explicit and reviewable rather than hidden. Find macro ids via list_macros and the ticket id via search_tickets or list_tickets.",
       inputSchema: z.object({
         ticket_id: z
           .number()
@@ -1023,7 +1075,9 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         macro_id: z
           .number()
           .int()
-          .describe('Macro ID — the numeric id of the macro to apply. Obtain it from list_macros.'),
+          .describe(
+            'Macro ID — the numeric id of the macro to preview. Obtain it from list_macros.',
+          ),
       }),
       annotations: {
         readOnlyHint: false,
@@ -1034,16 +1088,21 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       handler: async (params) => {
         const { ticket_id, macro_id } = params as { ticket_id: number; macro_id: number };
         const token = await getToken();
-        const { result } = await zendeskGet<{ result: ZendeskMacroApplyResult }>(
-          subdomain,
-          token,
-          `/tickets/${ticket_id}/macros/${macro_id}/apply`,
-        );
+        // Two reads in parallel: the ticket as it is now, and the ticket as the
+        // macro would leave it. Diffing them isolates the macro's actual effect.
+        const [{ ticket: before }, { result }] = await Promise.all([
+          zendeskGet<{ ticket: ZendeskTicket }>(subdomain, token, `/tickets/${ticket_id}`),
+          zendeskGet<{ result: ZendeskMacroApplyResult }>(
+            subdomain,
+            token,
+            `/tickets/${ticket_id}/macros/${macro_id}/apply`,
+          ),
+        ]);
         return {
           content: [
             {
               type: 'text',
-              text: truncateIfNeeded(formatMacroApplyResult(ticket_id, macro_id, result)),
+              text: truncateIfNeeded(formatMacroPreviewDiff(ticket_id, macro_id, before, result)),
             },
           ],
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,18 +120,20 @@ export interface ZendeskMacroApplyComment {
   public?: boolean;
 }
 
-// GET /tickets/{id}/macros/{macro_id}/apply returns the ticket as it WOULD be
-// after the macro runs — only the fields the macro changes, plus the comment it
-// would add. Nothing is persisted: the caller commits the changes with
-// update_ticket / add_public_comment / add_private_note. Standard fields
-// (status, priority, assignee_id, group_id, tags, subject, type) appear as
-// top-level keys; custom fields arrive under `fields` (or `custom_fields`).
 // A single custom-field change in a macro-apply result.
 export interface ZendeskMacroApplyField {
   id: number;
   value: unknown;
 }
 
+// GET /tickets/{id}/macros/{macro_id}/apply returns the WHOLE ticket as it would
+// be after the macro runs (not just the changed fields — confirmed against the
+// live tenant), plus the comment it would add. Nothing is persisted; the caller
+// commits via update_ticket / add_public_comment / add_private_note.
+// preview_macro_diff isolates the macro's actual effect by diffing this against
+// the ticket's current state. Standard fields (status, priority, assignee_id,
+// group_id, tags, subject, type, …) appear as top-level keys; custom fields
+// arrive under `fields` (or `custom_fields`).
 export interface ZendeskMacroApplyTicket {
   comment?: ZendeskMacroApplyComment;
   // The apply endpoint renders one changed custom field as a bare object and

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,7 +117,6 @@ export interface ZendeskMacro {
 // public comment (emails the requester) from an internal note.
 export interface ZendeskMacroApplyComment {
   body?: string;
-  html_body?: string;
   public?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,59 @@ export interface ZendeskTicketField {
   system_field_options?: ZendeskFieldOption[];
 }
 
+// A single action a macro performs: `field` is the target (e.g. "status",
+// "priority", "set_tags", or "comment_value" for the canned reply) and `value`
+// the value to set — a string, an array (multi-value fields), or a number,
+// depending on the field.
+export interface ZendeskMacroAction {
+  field: string;
+  value: unknown;
+}
+
+// A macro definition from GET /macros/active — the active macros available to
+// the authenticated user. `actions` is the ordered bundle of field changes and
+// the optional canned reply the macro applies; `restriction` scopes who may use
+// it (null = shared with everyone in the account).
+export interface ZendeskMacro {
+  id: number;
+  title: string;
+  description: string | null;
+  active: boolean;
+  actions: ZendeskMacroAction[];
+  position?: number;
+  restriction?: { type: string; id?: number; ids?: number[] } | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// The canned reply carried by a macro-apply result. `public` distinguishes a
+// public comment (emails the requester) from an internal note.
+export interface ZendeskMacroApplyComment {
+  body?: string;
+  html_body?: string;
+  public?: boolean;
+}
+
+// GET /tickets/{id}/macros/{macro_id}/apply returns the ticket as it WOULD be
+// after the macro runs — only the fields the macro changes, plus the comment it
+// would add. Nothing is persisted: the caller commits the changes with
+// update_ticket / add_public_comment / add_private_note. Standard fields
+// (status, priority, assignee_id, group_id, tags, subject, type) appear as
+// top-level keys; custom fields arrive under `fields` (or `custom_fields`).
+export interface ZendeskMacroApplyTicket {
+  comment?: ZendeskMacroApplyComment;
+  fields?: Array<{ id: number; value: unknown }>;
+  custom_fields?: Array<{ id: number; value: unknown }>;
+  [key: string]: unknown;
+}
+
+export interface ZendeskMacroApplyResult {
+  ticket: ZendeskMacroApplyTicket;
+  // Some API versions surface the comment as a sibling of `ticket` rather than
+  // nested inside it; the handler reads both locations.
+  comment?: ZendeskMacroApplyComment;
+}
+
 export interface ZendeskTicketAttachment {
   id: number;
   file_name: string;
@@ -253,6 +306,7 @@ export interface ZendeskListResponse<T> {
   permission_groups?: T[];
   sla_policies?: T[];
   ticket_fields?: T[];
+  macros?: T[];
   meta?: {
     has_more: boolean;
     after_cursor: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,10 +127,18 @@ export interface ZendeskMacroApplyComment {
 // update_ticket / add_public_comment / add_private_note. Standard fields
 // (status, priority, assignee_id, group_id, tags, subject, type) appear as
 // top-level keys; custom fields arrive under `fields` (or `custom_fields`).
+// A single custom-field change in a macro-apply result.
+export interface ZendeskMacroApplyField {
+  id: number;
+  value: unknown;
+}
+
 export interface ZendeskMacroApplyTicket {
   comment?: ZendeskMacroApplyComment;
-  fields?: Array<{ id: number; value: unknown }>;
-  custom_fields?: Array<{ id: number; value: unknown }>;
+  // The apply endpoint renders one changed custom field as a bare object and
+  // several as an array, so both shapes are accepted (the handler normalizes).
+  fields?: ZendeskMacroApplyField[] | ZendeskMacroApplyField;
+  custom_fields?: ZendeskMacroApplyField[] | ZendeskMacroApplyField;
   [key: string]: unknown;
 }
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -102,20 +102,17 @@ export const formatTicketField = (field: ZendeskTicketField): string => {
 };
 
 // Render an arbitrary Zendesk field value — a macro action value, a macro-apply
-// field change — as a compact string: arrays as comma-joined tokens, objects as
-// JSON, null/undefined as empty. Shared by the macro formatters (here and in the
+// field change — as a compact string: arrays as comma-joined tokens, scalars and
+// objects via the shared `formatConditionValue` ladder (null/undefined → empty,
+// object → JSON, else String). Shared by the macro formatters (here and in the
 // preview-diff renderer) so list_macros and preview_macro_diff stringify values
 // the same way instead of drifting apart.
 export const formatFieldValue = (value: unknown): string =>
-  value === null || value === undefined
-    ? ''
-    : Array.isArray(value)
-      ? // Recurse per element so an array of objects renders as JSON tokens
-        // rather than the useless "[object Object]" that a bare join produces.
-        value.map(formatFieldValue).join(', ')
-      : typeof value === 'object'
-        ? JSON.stringify(value)
-        : String(value);
+  // Recurse per element so an array of objects renders as JSON tokens rather than
+  // the useless "[object Object]" a bare join produces; scalars/objects reuse the
+  // existing condition-value stringifier (which encodes arrays as JSON, hence the
+  // array case stays here rather than delegating).
+  Array.isArray(value) ? value.map(formatFieldValue).join(', ') : formatConditionValue(value);
 
 // One macro action rendered as `field → value`. Long values (a canned reply in
 // `comment_value`) are previewed rather than dumped whole, keeping a macro list

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -104,8 +104,8 @@ export const formatTicketField = (field: ZendeskTicketField): string => {
 // Render an arbitrary Zendesk field value — a macro action value, a macro-apply
 // field change — as a compact string: arrays as comma-joined tokens, objects as
 // JSON, null/undefined as empty. Shared by the macro formatters (here and in the
-// apply-result renderer) so list_macros and apply_macro stringify values the
-// same way instead of drifting apart.
+// preview-diff renderer) so list_macros and preview_macro_diff stringify values
+// the same way instead of drifting apart.
 export const formatFieldValue = (value: unknown): string =>
   value === null || value === undefined
     ? ''
@@ -119,7 +119,7 @@ export const formatFieldValue = (value: unknown): string =>
 
 // One macro action rendered as `field → value`. Long values (a canned reply in
 // `comment_value`) are previewed rather than dumped whole, keeping a macro list
-// scannable; the full reply text is materialized by apply_macro against a
+// scannable; the full reply text is materialized by preview_macro_diff against a
 // ticket, not here.
 const MACRO_VALUE_PREVIEW = 120;
 const formatMacroActionValue = (value: unknown): string => {
@@ -132,7 +132,7 @@ const formatMacroActionValue = (value: unknown): string => {
 const formatMacroAction = (action: ZendeskMacroAction): string =>
   `  - ${action.field} → ${formatMacroActionValue(action.value)}`;
 
-// Render a macro definition for list_macros: its id (what apply_macro needs),
+// Render a macro definition for list_macros: its id (what preview_macro_diff needs),
 // title, availability scope, and the ordered bundle of actions it applies so a
 // caller can judge a macro's effect before previewing it against a ticket.
 export const formatMacro = (macro: ZendeskMacro): string => {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -101,21 +101,27 @@ export const formatTicketField = (field: ZendeskTicketField): string => {
     .join('\n');
 };
 
+// Render an arbitrary Zendesk field value — a macro action value, a macro-apply
+// field change — as a compact string: arrays as comma-joined tokens, objects as
+// JSON, null/undefined as empty. Shared by the macro formatters (here and in the
+// apply-result renderer) so list_macros and apply_macro stringify values the
+// same way instead of drifting apart.
+export const formatFieldValue = (value: unknown): string =>
+  value === null || value === undefined
+    ? ''
+    : Array.isArray(value)
+      ? value.join(', ')
+      : typeof value === 'object'
+        ? JSON.stringify(value)
+        : String(value);
+
 // One macro action rendered as `field → value`. Long values (a canned reply in
 // `comment_value`) are previewed rather than dumped whole, keeping a macro list
 // scannable; the full reply text is materialized by apply_macro against a
 // ticket, not here.
 const MACRO_VALUE_PREVIEW = 120;
 const formatMacroActionValue = (value: unknown): string => {
-  const rendered =
-    value === null || value === undefined
-      ? ''
-      : Array.isArray(value)
-        ? value.join(', ')
-        : typeof value === 'object'
-          ? JSON.stringify(value)
-          : String(value);
-  const oneLine = rendered.replace(/\s+/g, ' ').trim();
+  const oneLine = formatFieldValue(value).replace(/\s+/g, ' ').trim();
   return oneLine.length > MACRO_VALUE_PREVIEW
     ? `${oneLine.slice(0, MACRO_VALUE_PREVIEW)}…`
     : oneLine;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -110,7 +110,9 @@ export const formatFieldValue = (value: unknown): string =>
   value === null || value === undefined
     ? ''
     : Array.isArray(value)
-      ? value.join(', ')
+      ? // Recurse per element so an array of objects renders as JSON tokens
+        // rather than the useless "[object Object]" that a bare join produces.
+        value.map(formatFieldValue).join(', ')
       : typeof value === 'object'
         ? JSON.stringify(value)
         : String(value);
@@ -134,13 +136,17 @@ const formatMacroAction = (action: ZendeskMacroAction): string =>
 // title, availability scope, and the ordered bundle of actions it applies so a
 // caller can judge a macro's effect before previewing it against a ticket.
 export const formatMacro = (macro: ZendeskMacro): string => {
-  const scope = macro.restriction ? 'restricted' : 'shared';
+  // A shared macro comes back with `restriction: null` — but the API also
+  // renders an unrestricted macro as an empty object `{}`, so key off a real
+  // `type` rather than mere truthiness to avoid mislabeling it "restricted".
+  const scope = macro.restriction?.type ? 'restricted' : 'shared';
+  const actions = macro.actions ?? [];
   return [
     `## ${macro.title} (id ${macro.id})`,
     `- **${macro.active ? 'active' : 'inactive'}** | **Scope**: ${scope}`,
     macro.description ? `- **Description**: ${macro.description}` : '',
-    macro.actions.length > 0 ? '- **Actions**:' : '- **Actions**: none',
-    ...macro.actions.map(formatMacroAction),
+    actions.length > 0 ? '- **Actions**:' : '- **Actions**: none',
+    ...actions.map(formatMacroAction),
   ]
     .filter(Boolean)
     .join('\n');

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -7,6 +7,8 @@ import type {
   ZendeskComment,
   ZendeskContentTag,
   ZendeskLabel,
+  ZendeskMacro,
+  ZendeskMacroAction,
   ZendeskOrganization,
   ZendeskPermissionGroup,
   ZendeskSection,
@@ -94,6 +96,45 @@ export const formatTicketField = (field: ZendeskTicketField): string => {
     field.tag ? `- **Tag**: ${field.tag}` : '',
     options.length > 0 ? '- **Options** (name → value):' : '',
     ...options.map((o) => `  - ${o.name} → ${o.value}`),
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+// One macro action rendered as `field → value`. Long values (a canned reply in
+// `comment_value`) are previewed rather than dumped whole, keeping a macro list
+// scannable; the full reply text is materialized by apply_macro against a
+// ticket, not here.
+const MACRO_VALUE_PREVIEW = 120;
+const formatMacroActionValue = (value: unknown): string => {
+  const rendered =
+    value === null || value === undefined
+      ? ''
+      : Array.isArray(value)
+        ? value.join(', ')
+        : typeof value === 'object'
+          ? JSON.stringify(value)
+          : String(value);
+  const oneLine = rendered.replace(/\s+/g, ' ').trim();
+  return oneLine.length > MACRO_VALUE_PREVIEW
+    ? `${oneLine.slice(0, MACRO_VALUE_PREVIEW)}…`
+    : oneLine;
+};
+
+const formatMacroAction = (action: ZendeskMacroAction): string =>
+  `  - ${action.field} → ${formatMacroActionValue(action.value)}`;
+
+// Render a macro definition for list_macros: its id (what apply_macro needs),
+// title, availability scope, and the ordered bundle of actions it applies so a
+// caller can judge a macro's effect before previewing it against a ticket.
+export const formatMacro = (macro: ZendeskMacro): string => {
+  const scope = macro.restriction ? 'restricted' : 'shared';
+  return [
+    `## ${macro.title} (id ${macro.id})`,
+    `- **${macro.active ? 'active' : 'inactive'}** | **Scope**: ${scope}`,
+    macro.description ? `- **Description**: ${macro.description}` : '',
+    macro.actions.length > 0 ? '- **Actions**:' : '- **Actions**: none',
+    ...macro.actions.map(formatMacroAction),
   ]
     .filter(Boolean)
     .join('\n');

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -45,6 +45,20 @@ export const extractPaginationMeta = <T>(
   count: response.count ?? itemCount,
 });
 
+// Offset-based list endpoints (e.g. /slas/policies, /macros/active) that
+// *usually* carry a `count` wrapper but occasionally omit it. When present, use
+// the normal offset math; when absent, fall back to the returned page length so
+// the footer reflects what came back rather than a misleading "Results: 0".
+export const extractOffsetPaginationMeta = <T>(
+  response: ZendeskListResponse<T>,
+  itemCount: number,
+  perPage: number,
+  page: number,
+): PaginationMeta =>
+  response.count != null
+    ? extractSearchPaginationMeta(response, perPage, page)
+    : { count: itemCount, has_more: false, after_cursor: null };
+
 // For search responses — offset-based, count is always present
 export const extractSearchPaginationMeta = <T>(
   response: ZendeskListResponse<T>,

--- a/tests/functional/scenarios/04-all-baseline/expected.md
+++ b/tests/functional/scenarios/04-all-baseline/expected.md
@@ -4,7 +4,7 @@
 
 ## Expected values
 
-- **A1.** `tools.length === 40`. Breakdown: 12 ticket tools + 22 Help Center
+- **A1.** `tools.length === 42`. Breakdown: 14 ticket tools + 22 Help Center
   tools + 5 user/organization tools + 1 unified search tool. If the count
   drifts, update the documentation listed in `AGENTS.md` "Documentation
   maintenance" before running.

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -115,14 +115,30 @@ export const MOCK_MACRO = {
   updated_at: '2026-01-02T00:00:00Z',
 };
 
-// GET /tickets/{id}/macros/{macro_id}/apply — the ticket as it WOULD be after
-// the macro runs (only changed fields) plus the comment it would add, nested
-// under `result.ticket`. Nothing is persisted by this endpoint.
+// GET /tickets/{id}/macros/{macro_id}/apply — the WHOLE ticket as it would be
+// after the macro runs (not just the changed fields — confirmed against the live
+// tenant), plus the comment it would add, nested under `result.ticket`. Nothing
+// is persisted. Modelled on MOCK_TICKET (the "before") with the macro's changes
+// applied: status open→solved, two tags added, one custom field set. The
+// identity fields (id/url/created_at/updated_at) match the before so the diff
+// correctly drops them; preview_macro_diff surfaces only the real changes.
 export const MOCK_MACRO_APPLY = {
   result: {
     ticket: {
+      id: 1,
+      url: 'https://testsubdomain.zendesk.com/api/v2/tickets/1.json',
+      subject: 'Test ticket',
+      description: 'A test ticket',
+      type: 'incident',
+      priority: 'normal',
       status: 'solved',
-      tags: ['resolved', 'macro_applied'],
+      assignee_id: 100,
+      requester_id: 200,
+      group_id: 300,
+      organization_id: 400,
+      tags: ['test', 'mock', 'resolved', 'macro_applied'],
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-02T00:00:00Z',
       fields: [{ id: 360000000001, value: 'severity_2' }],
       comment: {
         body: 'Thanks for your business! We hope to see you again soon.',

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -97,6 +97,41 @@ export const MOCK_TICKET_FIELD_CUSTOM = {
   ],
 };
 
+// A macro from GET /macros/active: a canned reply (`comment_value`) plus field
+// changes, mirroring the real Macros API shape (actions are {field, value}).
+export const MOCK_MACRO = {
+  id: 700,
+  title: 'Close and thank the customer',
+  description: 'Solve the ticket and send a thank-you note',
+  active: true,
+  position: 9999,
+  restriction: null,
+  actions: [
+    { field: 'status', value: 'solved' },
+    { field: 'set_tags', value: ['resolved', 'macro_applied'] },
+    { field: 'comment_value', value: 'Thanks for your business! We hope to see you again soon.' },
+  ],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+};
+
+// GET /tickets/{id}/macros/{macro_id}/apply — the ticket as it WOULD be after
+// the macro runs (only changed fields) plus the comment it would add, nested
+// under `result.ticket`. Nothing is persisted by this endpoint.
+export const MOCK_MACRO_APPLY = {
+  result: {
+    ticket: {
+      status: 'solved',
+      tags: ['resolved', 'macro_applied'],
+      fields: [{ id: 360000000001, value: 'severity_2' }],
+      comment: {
+        body: 'Thanks for your business! We hope to see you again soon.',
+        public: true,
+      },
+    },
+  },
+};
+
 export const MOCK_USER = {
   id: 9999,
   name: 'Test User',
@@ -389,6 +424,12 @@ export const handlers = [
     HttpResponse.json({ ticket: { ...MOCK_TICKET, id: Number(params['id']), status: 'solved' } }),
   ),
   http.post(`${BASE}/uploads`, () => HttpResponse.json({ upload: MOCK_UPLOAD })),
+
+  // Macros — active macros for the current user, and the per-ticket apply
+  // (preview) endpoint. The apply route sits under /tickets/:id/ but has extra
+  // path segments, so it does not collide with the Show Ticket handler above.
+  http.get(`${BASE}/macros/active`, () => HttpResponse.json({ macros: [MOCK_MACRO], count: 1 })),
+  http.get(`${BASE}/tickets/:id/macros/:mid/apply`, () => HttpResponse.json(MOCK_MACRO_APPLY)),
 
   // SLA policies — the real endpoint returns the full config list with no
   // `count` wrapper, so omit it here to exercise the array-length fallback.

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -64,7 +64,7 @@ describe('groupByNamespace', () => {
     const ticketCount = grouped.get('tickets')?.length ?? 0;
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
-    expect(ticketCount).toBe(13); // 12 ticket tools + 1 search
+    expect(ticketCount).toBe(15); // 14 ticket tools + 1 search
     expect(hcCount).toBe(22);
     expect(userCount).toBe(5);
   });

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -886,6 +886,24 @@ describe('ticket tools', () => {
       expect(text).toContain('Internal only');
     });
 
+    it('renders a single custom field returned as a bare object (not an array)', async () => {
+      // The Zendesk docs show one changed custom field as `fields: {id, value}`
+      // rather than a one-element array; the handler must not choke on it.
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/macros/:mid/apply', () =>
+          HttpResponse.json({
+            result: { ticket: { fields: { id: 27642, value: '745' } } },
+          }),
+        ),
+      );
+      const tool = findTool('apply_macro');
+      const result = await tool.handler({ ticket_id: 1, macro_id: 700 });
+      expect(result.isError).toBeFalsy();
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('custom field 27642');
+      expect(text).toContain('745');
+    });
+
     it('degrades to "no changes" when the apply response has no result body', async () => {
       mswServer.use(
         http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/macros/:mid/apply', () =>

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -909,6 +909,9 @@ describe('ticket tools', () => {
                 via: { channel: 'api' },
                 generated_timestamp: 222,
                 tags: ['keep'],
+                // Present as `null` here but absent from the before-read: a no-op
+                // that used to leak as "(empty) → (empty)" — must be dropped.
+                deleted_ticket_form_id: null,
                 fields: [{ id: 9, value: 'unchanged' }],
               },
             },
@@ -924,6 +927,9 @@ describe('ticket tools', () => {
       expect(text).not.toContain('generated_timestamp');
       expect(text).not.toContain('custom field 9');
       expect(text).not.toContain('**tags**');
+      // The no-op null-vs-absent field must not render at all.
+      expect(text).not.toContain('deleted_ticket_form_id');
+      expect(text).not.toContain('(empty) → (empty)');
     });
 
     it('marks a macro comment with public=false as an internal note', async () => {

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -21,9 +21,9 @@ const getAllText = (result: { content: Array<{ type: string; text?: string }> })
     .join('\n');
 
 describe('ticket tools', () => {
-  it('creates 12 tools (search_tickets lives here; the unified search is elsewhere)', () => {
+  it('creates 14 tools (search_tickets lives here; the unified search is elsewhere)', () => {
     const tools = createTicketTools(ctx);
-    expect(tools).toHaveLength(12);
+    expect(tools).toHaveLength(14);
   });
 
   describe('get_ticket', () => {
@@ -821,6 +821,76 @@ describe('ticket tools', () => {
       const tool = findTool('manage_tags');
       expect(tool.description).toContain('update_ticket');
       expect(tool.description).toContain('idempotent');
+    });
+  });
+
+  describe('list_macros', () => {
+    it('lists active macros with their actions', async () => {
+      const tool = findTool('list_macros');
+      const result = await tool.handler({ per_page: 100, page: 1 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('Close and thank the customer');
+      expect(text).toContain('(id 700)');
+      expect(text).toContain('status → solved');
+      expect(text).toContain('set_tags → resolved, macro_applied');
+    });
+
+    it('hits the active-macros endpoint (scoped to the current user)', async () => {
+      let requestedPath: string | null = null;
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/macros/active', ({ request }) => {
+          requestedPath = new URL(request.url).pathname;
+          return HttpResponse.json({ macros: [], count: 0 });
+        }),
+      );
+      const tool = findTool('list_macros');
+      await tool.handler({ per_page: 100, page: 1 });
+      expect(requestedPath).toBe('/api/v2/macros/active');
+    });
+
+    it('is read-only (survives --read-only)', () => {
+      const tool = findTool('list_macros');
+      expect(tool.readOnly).toBe(true);
+      expect(tool.annotations.readOnlyHint).toBe(true);
+    });
+  });
+
+  describe('apply_macro', () => {
+    it('previews the field changes and reply without committing', async () => {
+      const tool = findTool('apply_macro');
+      const result = await tool.handler({ ticket_id: 1, macro_id: 700 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('preview — nothing saved yet');
+      expect(text).toContain('**status**: solved');
+      expect(text).toContain('resolved, macro_applied');
+      expect(text).toContain('custom field 360000000001');
+      expect(text).toContain('severity_2');
+      expect(text).toContain('Thanks for your business!');
+      // Steers the caller to the commit tools (the deliberate two-step).
+      expect(text).toContain('update_ticket');
+      expect(text).toContain('add_public_comment');
+    });
+
+    it('marks a macro comment with public=false as an internal note', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/macros/:mid/apply', () =>
+          HttpResponse.json({
+            result: { ticket: { comment: { body: 'Internal only', public: false } } },
+          }),
+        ),
+      );
+      const tool = findTool('apply_macro');
+      const result = await tool.handler({ ticket_id: 1, macro_id: 700 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('internal note');
+      expect(text).toContain('Internal only');
+    });
+
+    it('is a write tool so it is filtered out under --read-only', () => {
+      const tool = findTool('apply_macro');
+      expect(tool.readOnly).toBe(false);
+      expect(tool.annotations.readOnlyHint).toBe(false);
+      expect(tool.annotations.destructiveHint).toBe(false);
     });
   });
 });

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -904,7 +904,9 @@ describe('ticket tools', () => {
                 id: 42,
                 url: 'https://testsubdomain.zendesk.com/api/v2/tickets/42.json',
                 status: 'pending',
-                via: { channel: 'web' },
+                // `via` DIFFERS from the before-read: a nested object is never a
+                // macro change, so the object-guard must drop it regardless.
+                via: { channel: 'api' },
                 generated_timestamp: 222,
                 tags: ['keep'],
                 fields: [{ id: 9, value: 'unchanged' }],

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -855,20 +855,73 @@ describe('ticket tools', () => {
     });
   });
 
-  describe('apply_macro', () => {
-    it('previews the field changes and reply without committing', async () => {
-      const tool = findTool('apply_macro');
+  describe('preview_macro_diff', () => {
+    it('diffs the ticket before/after the macro, showing only what changes', async () => {
+      const tool = findTool('preview_macro_diff');
       const result = await tool.handler({ ticket_id: 1, macro_id: 700 });
       const text = result.content[0]?.text ?? '';
-      expect(text).toContain('preview — nothing saved yet');
-      expect(text).toContain('**status**: solved');
-      expect(text).toContain('resolved, macro_applied');
+      expect(text).toContain('diff — nothing saved yet');
+      // Changed fields render as before → after; tags as added/removed tokens.
+      expect(text).toContain('**status**: open → solved');
+      expect(text).toContain('**tags**: +resolved, +macro_applied');
       expect(text).toContain('custom field 360000000001');
-      expect(text).toContain('severity_2');
+      expect(text).toContain('(empty) → severity_2');
       expect(text).toContain('Thanks for your business!');
       // Steers the caller to the commit tools (the deliberate two-step).
       expect(text).toContain('update_ticket');
       expect(text).toContain('add_public_comment');
+      // Unchanged and identity fields are omitted (the bug this fixes): the
+      // ticket's untouched fields and its url/id/created_at must not appear.
+      expect(text).not.toContain('**priority**');
+      expect(text).not.toContain('**assignee_id**');
+      expect(text).not.toContain('**url**');
+      expect(text).not.toContain('**id**');
+      expect(text).not.toContain('**created_at**');
+    });
+
+    it('omits identity/volatile fields and unchanged custom fields from the diff', async () => {
+      // The apply endpoint returns the WHOLE ticket; only the macro's real
+      // change (status) must surface — not url/via (identity), not a bumped
+      // generated_timestamp (volatile), not an unchanged custom field.
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id', () =>
+          HttpResponse.json({
+            ticket: {
+              id: 42,
+              url: 'https://testsubdomain.zendesk.com/api/v2/tickets/42.json',
+              status: 'open',
+              via: { channel: 'web' },
+              generated_timestamp: 111,
+              tags: ['keep'],
+              custom_fields: [{ id: 9, value: 'unchanged' }],
+            },
+          }),
+        ),
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/macros/:mid/apply', () =>
+          HttpResponse.json({
+            result: {
+              ticket: {
+                id: 42,
+                url: 'https://testsubdomain.zendesk.com/api/v2/tickets/42.json',
+                status: 'pending',
+                via: { channel: 'web' },
+                generated_timestamp: 222,
+                tags: ['keep'],
+                fields: [{ id: 9, value: 'unchanged' }],
+              },
+            },
+          }),
+        ),
+      );
+      const tool = findTool('preview_macro_diff');
+      const result = await tool.handler({ ticket_id: 42, macro_id: 700 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('**status**: open → pending');
+      expect(text).not.toContain('**url**');
+      expect(text).not.toContain('**via**');
+      expect(text).not.toContain('generated_timestamp');
+      expect(text).not.toContain('custom field 9');
+      expect(text).not.toContain('**tags**');
     });
 
     it('marks a macro comment with public=false as an internal note', async () => {
@@ -879,7 +932,7 @@ describe('ticket tools', () => {
           }),
         ),
       );
-      const tool = findTool('apply_macro');
+      const tool = findTool('preview_macro_diff');
       const result = await tool.handler({ ticket_id: 1, macro_id: 700 });
       const text = result.content[0]?.text ?? '';
       expect(text).toContain('internal note');
@@ -888,7 +941,7 @@ describe('ticket tools', () => {
 
     it('renders a single custom field returned as a bare object (not an array)', async () => {
       // The Zendesk docs show one changed custom field as `fields: {id, value}`
-      // rather than a one-element array; the handler must not choke on it.
+      // rather than a one-element array; the diff must not choke on it.
       mswServer.use(
         http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/macros/:mid/apply', () =>
           HttpResponse.json({
@@ -896,7 +949,7 @@ describe('ticket tools', () => {
           }),
         ),
       );
-      const tool = findTool('apply_macro');
+      const tool = findTool('preview_macro_diff');
       const result = await tool.handler({ ticket_id: 1, macro_id: 700 });
       expect(result.isError).toBeFalsy();
       const text = result.content[0]?.text ?? '';
@@ -910,7 +963,7 @@ describe('ticket tools', () => {
           HttpResponse.json({}),
         ),
       );
-      const tool = findTool('apply_macro');
+      const tool = findTool('preview_macro_diff');
       const result = await tool.handler({ ticket_id: 1, macro_id: 700 });
       expect(result.isError).toBeFalsy();
       const text = result.content[0]?.text ?? '';
@@ -918,8 +971,29 @@ describe('ticket tools', () => {
       expect(text).toContain('- none');
     });
 
+    it('reads the ticket state as well as the apply preview (two GETs)', async () => {
+      const paths: string[] = [];
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id', ({ request }) => {
+          paths.push(new URL(request.url).pathname);
+          return HttpResponse.json({ ticket: { id: 1, status: 'open' } });
+        }),
+        http.get(
+          'https://testsubdomain.zendesk.com/api/v2/tickets/:id/macros/:mid/apply',
+          ({ request }) => {
+            paths.push(new URL(request.url).pathname);
+            return HttpResponse.json({ result: { ticket: { status: 'solved' } } });
+          },
+        ),
+      );
+      const tool = findTool('preview_macro_diff');
+      await tool.handler({ ticket_id: 1, macro_id: 700 });
+      expect(paths).toContain('/api/v2/tickets/1');
+      expect(paths).toContain('/api/v2/tickets/1/macros/700/apply');
+    });
+
     it('is a write tool so it is filtered out under --read-only', () => {
-      const tool = findTool('apply_macro');
+      const tool = findTool('preview_macro_diff');
       expect(tool.readOnly).toBe(false);
       expect(tool.annotations.readOnlyHint).toBe(false);
       expect(tool.annotations.destructiveHint).toBe(false);

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -886,6 +886,20 @@ describe('ticket tools', () => {
       expect(text).toContain('Internal only');
     });
 
+    it('degrades to "no changes" when the apply response has no result body', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/macros/:mid/apply', () =>
+          HttpResponse.json({}),
+        ),
+      );
+      const tool = findTool('apply_macro');
+      const result = await tool.handler({ ticket_id: 1, macro_id: 700 });
+      expect(result.isError).toBeFalsy();
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('## Field changes');
+      expect(text).toContain('- none');
+    });
+
     it('is a write tool so it is filtered out under --read-only', () => {
       const tool = findTool('apply_macro');
       expect(tool.readOnly).toBe(false);

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -5,6 +5,7 @@ import {
   formatCategory,
   formatComment,
   formatList,
+  formatMacro,
   formatOrganization,
   formatSection,
   formatSlaBlock,
@@ -19,6 +20,7 @@ import {
   MOCK_ARTICLE,
   MOCK_CATEGORY,
   MOCK_COMMENT,
+  MOCK_MACRO,
   MOCK_ORGANIZATION,
   MOCK_SECTION,
   MOCK_SLA_POLICY,
@@ -284,6 +286,28 @@ describe('formatSection', () => {
     expect(result).toContain('FAQ');
     expect(result).toContain('600');
     expect(result).toContain('800');
+  });
+});
+
+describe('formatMacro', () => {
+  it('includes id, title, scope and the ordered actions', () => {
+    const result = formatMacro(MOCK_MACRO);
+    expect(result).toContain('Close and thank the customer (id 700)');
+    expect(result).toContain('Scope**: shared');
+    expect(result).toContain('status → solved');
+    expect(result).toContain('set_tags → resolved, macro_applied');
+    expect(result).toContain('comment_value → Thanks for your business!');
+  });
+
+  it('marks a restricted macro and previews an over-long action value', () => {
+    const result = formatMacro({
+      ...MOCK_MACRO,
+      restriction: { type: 'Group', id: 1 },
+      actions: [{ field: 'comment_value', value: 'x'.repeat(500) }],
+    });
+    expect(result).toContain('Scope**: restricted');
+    expect(result).toContain('…');
+    expect(result).not.toContain('x'.repeat(500));
   });
 });
 

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -4,6 +4,7 @@ import {
   formatArticleSummary,
   formatCategory,
   formatComment,
+  formatFieldValue,
   formatList,
   formatMacro,
   formatOrganization,
@@ -286,6 +287,17 @@ describe('formatSection', () => {
     expect(result).toContain('FAQ');
     expect(result).toContain('600');
     expect(result).toContain('800');
+  });
+});
+
+describe('formatFieldValue', () => {
+  it('joins arrays, JSON-encodes objects, empties null/undefined, stringifies scalars', () => {
+    expect(formatFieldValue(['a', 'b'])).toBe('a, b');
+    expect(formatFieldValue({ x: 1 })).toBe('{"x":1}');
+    expect(formatFieldValue(null)).toBe('');
+    expect(formatFieldValue(undefined)).toBe('');
+    expect(formatFieldValue(0)).toBe('0');
+    expect(formatFieldValue('solved')).toBe('solved');
   });
 });
 

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -299,6 +299,10 @@ describe('formatFieldValue', () => {
     expect(formatFieldValue(0)).toBe('0');
     expect(formatFieldValue('solved')).toBe('solved');
   });
+
+  it('renders an array of objects as JSON tokens, not "[object Object]"', () => {
+    expect(formatFieldValue([{ id: 1 }, { id: 2 }])).toBe('{"id":1}, {"id":2}');
+  });
 });
 
 describe('formatMacro', () => {
@@ -320,6 +324,18 @@ describe('formatMacro', () => {
     expect(result).toContain('Scope**: restricted');
     expect(result).toContain('…');
     expect(result).not.toContain('x'.repeat(500));
+  });
+
+  it('treats an empty-object restriction as shared, not restricted', () => {
+    // The Zendesk list-macros response renders an unrestricted macro's
+    // `restriction` as `{}`; a truthiness check would mislabel it "restricted".
+    const result = formatMacro({ ...MOCK_MACRO, restriction: {} as never });
+    expect(result).toContain('Scope**: shared');
+  });
+
+  it('does not crash when a macro has no actions array', () => {
+    const result = formatMacro({ ...MOCK_MACRO, actions: undefined as never });
+    expect(result).toContain('**Actions**: none');
   });
 });
 

--- a/tests/unit/utils/pagination.test.ts
+++ b/tests/unit/utils/pagination.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildCursorParams, extractPaginationMeta } from '../../../src/utils/pagination';
+import {
+  buildCursorParams,
+  extractOffsetPaginationMeta,
+  extractPaginationMeta,
+} from '../../../src/utils/pagination';
 
 describe('buildCursorParams', () => {
   it('builds params with page size only', () => {
@@ -16,6 +20,18 @@ describe('buildCursorParams', () => {
   it('omits cursor when undefined', () => {
     const params = buildCursorParams(50, undefined);
     expect(params).not.toHaveProperty('page[after]');
+  });
+});
+
+describe('extractOffsetPaginationMeta', () => {
+  it('uses offset math when the count wrapper is present', () => {
+    const meta = extractOffsetPaginationMeta({ macros: [], count: 150 }, 0, 100, 1);
+    expect(meta).toEqual({ count: 150, has_more: true, after_cursor: '2' });
+  });
+
+  it('falls back to the returned page length when count is absent', () => {
+    const meta = extractOffsetPaginationMeta({ sla_policies: [] }, 7, 100, 1);
+    expect(meta).toEqual({ count: 7, has_more: false, after_cursor: null });
   });
 });
 


### PR DESCRIPTION
## Summary

Adds macro support to the `tickets` namespace, closing #120 — the single most
common agent gesture (applying a saved macro: canned reply + field changes) was
missing. Two tools:

- **`list_macros`** (read): lists the active macros available to the
  authenticated user via `GET /macros/active`, with each macro's id, title,
  availability scope and ordered actions. Per-user OAuth scopes the result, so
  no shared admin key is needed; survives `--read-only`.
- **`preview_macro_diff`** (write): resolves a macro against a ticket via Zendesk's
  apply endpoint (`GET /tickets/{id}/macros/{macro_id}/apply`) and returns the
  concrete field changes + reply **without saving them**, then points at
  `update_ticket` / `add_public_comment` / `add_private_note` to commit. This
  deliberate two-step keeps the mutation explicit and reviewable rather than
  hidden (per the issue's design). It is gated as `write` so it disappears under
  `--read-only` alongside the commit tools it depends on.

Tool-reference table and the `04-all-baseline` functional expectation
(40 → 42 tools) are synced in the same PR.

## Status

**Ready for review — live-validated and reconciled (head `0dd6335`).** An independent
functional validation run settled the one open design question: the apply endpoint
returns the **whole** resulting ticket, not just the macro's changes. `preview_macro_diff`
(renamed from `apply_macro`) now handles that by rendering a real **before → after diff**.

- ✅ `list_macros` — offset pagination (`count` / `next_page`) and the macro object
  fields confirmed against the official reference; no change needed.
- ✅ `preview_macro_diff` — orchestrates two reads (the ticket's current state + the
  macro-apply preview) and surfaces only the fields the macro changes
  (status/priority/tags/custom fields as before → after, tags as +added/-removed),
  plus the interpolated reply. Identity/volatile fields and unchanged custom fields
  are dropped, so the ~50-field dump that failed V3 is gone.
- ✅ Fixes since the first draft: single-object `fields` shape; `{}` restriction →
  *shared*; missing `actions` guard; arrays of objects as JSON tokens; dropped the
  unused `html_body` field; the diff rework itself.
- ✅ `pnpm test` (443 green), `pnpm check`, `pnpm typecheck`, coverage — all pass.

**Re-validation pending on `0dd6335`.** The prior run (on `6c3100c`) failed V3 because
of the full-ticket dump; that is now fixed. Re-running V1/V3 against the new tool name
`preview_macro_diff` should confirm `## Field changes` shows only the macro's diff, with
no full-ticket dump.

## Reference: Zendesk API docs verification (✅ done)

✅ **Done (head `0dd6335`).** The response shapes below were verified against the
official reference and the code reconciled — see the Status section. This block is
kept as the reconciliation checklist and reference; the one residual is the
apply-result field-set question, which the live V1/V3 payloads settle.

**Docs to open:** https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/

**1. `GET /api/v2/macros/active` (list_macros)** — confirm:
- Response wrapper is `{ macros: [...] }`.
- Pagination style: offset (`page` / `per_page` + `count` / `next_page`) **or**
  cursor-based (`meta.has_more` / `links.next`)? The code currently assumes
  **offset** (`buildOffsetParams` + `extractOffsetPaginationMeta`). If Zendesk
  has moved this endpoint to cursor-based pagination (CBP), switch `list_macros`
  to `buildCursorParams` + `extractPaginationMeta` (mirror `list_tickets`).
- Macro object fields consumed by `formatMacro`: `id`, `title`, `description`,
  `active`, `actions: [{field, value}]`, `restriction` (null = shared). Confirm
  the names/types.

**2. `GET /api/v2/tickets/{ticket_id}/macros/{macro_id}/apply` (preview_macro_diff)** —
the critical one. Confirm the **exact nesting** of the `result` object:
- Reply location: `result.ticket.comment` **or** `result.comment`? (code reads
  `result.ticket.comment ?? result.comment`.)
- Custom fields: `result.ticket.fields` **or** `result.ticket.custom_fields`?
  (code reads `result.ticket.fields ?? result.ticket.custom_fields`.)
- Comment fields present: `body`, `html_body`, `public`, `scoped_body`.
- Which standard ticket fields come back as top-level keys under `result.ticket`
  (status, priority, assignee_id, group_id, tags, subject, type,
  custom_status_id …). The diff renders every changed key except
  `comment` / `fields` / `custom_fields` as a scalar change, so verify no
  unexpected nested-object field lands there (it would render as JSON).

**Files to reconcile if the shape differs:**
- `src/types.ts` — `ZendeskMacro`, `ZendeskMacroAction`, `ZendeskMacroApplyComment`,
  `ZendeskMacroApplyTicket`, `ZendeskMacroApplyResult`.
- `src/tools/tickets.ts` — `list_macros`, `preview_macro_diff`, `formatMacroPreviewDiff`.
- `src/utils/formatting.ts` — `formatMacro`, `formatFieldValue`.
- `tests/msw-handlers.ts` — `MOCK_MACRO`, `MOCK_MACRO_APPLY` (make them mirror the
  verified real shape; the validation plan's V1/V3 raw payloads are the ground
  truth to copy in).
- `tests/unit/tools/tickets.test.ts`, `tests/unit/utils/formatting.test.ts`.
- Counts if the tool set changes: `tests/unit/routing/registry.test.ts`
  (tickets = 15 incl. unified search), `tests/unit/tools/tickets.test.ts` (14),
  `tests/functional/scenarios/04-all-baseline/expected.md` (42).

**Invariants to preserve (deliberate design, don't change without reason):**
- `preview_macro_diff` stays **preview-only** — never commit; the two-step commit via
  `update_ticket` / `add_public_comment` / `add_private_note` is intentional (#120).
- `preview_macro_diff` is classified **write** (`readOnly: false` + `readOnlyHint: false`)
  so it's filtered under `--read-only` alongside its commit tools; the annotations
  invariant test requires `readOnlyHint === readOnly`.
- `list_macros` stays **read** (survives `--read-only`).
- Keep the Glama tool-quality bar (per-param `.describe()`, ≥2-sentence
  descriptions, an outcome marker on the write tool) — enforced by
  `tests/unit/tools/tool-quality.test.ts`.

## Type of change
- [x] New feature

## Author checklist
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
- [x] If the change has runtime-observable behaviour: this PR carries a `## Functional validation plan` (authored with `/functional-validation-plan`), and it has been executed by an independent validator (`/run-validation-plan`) whose report is posted as a PR comment

## Notes for the reviewer (human or AI)

- **Why `preview_macro_diff` is `readOnly: false` though its endpoints mutate
  nothing.** It is the entry point of a mutation workflow whose commit step
  (`update_ticket` / `add_*_comment`) is filtered out by `--read-only`. Exposing
  a preview in read-only mode would offer an action the user cannot
  finish. The annotation invariant (`readOnlyHint === readOnly`) then forces
  `readOnlyHint: false`; a code comment documents the intent.
- **The preview is a real before → after diff.** The handler reads the ticket's
  current state and the macro-apply preview (which returns the whole resulting
  ticket) and diffs them, so only the fields the macro actually changes surface;
  identity/volatile fields and unchanged custom fields drop out. This is the fix
  for the V3 finding where the raw apply response dumped the entire ticket.

## Functional validation plan

**Commit under test:** validate the latest pushed commit (`git rev-parse HEAD`;
`0dd6335` at the time of writing).

### Context

The change adds two MCP tools, both exercised directly through the running
server in `--mode all`:

- `mcp__zendesk-local__list_macros` → `GET /macros/active`
- `mcp__zendesk-local__preview_macro_diff` → `GET /tickets/{id}` + `GET /tickets/{ticket_id}/macros/{macro_id}/apply`

`preview_macro_diff` is **preview-only**: it must NOT change the ticket. The actual
commit is a separate, existing step (`update_ticket` / `add_public_comment` /
`add_private_note`) and is out of scope here — do not treat "the ticket didn't
change" as a failure; that is the expected behaviour.

### Setup & prerequisites

Everything is already provided: on-branch checkout, server running and
authenticated, tools loaded as `mcp__zendesk-local__*`. You need:

- One real **macro id** — obtain it from V1 (`list_macros`), don't hard-code.
- One real, low-stakes **ticket id** you may read (e.g. from
  `mcp__zendesk-local__list_tickets` or `search_tickets`). `preview_macro_diff` does not
  write, so any readable ticket is safe, but pick a test ticket anyway.

A credential/egress error is a `BLOCKED` finding — report it, don't try to fix
the environment.

### Scenarios

| id | Validates | Manipulation / call | Expected observable |
|----|-----------|---------------------|---------------------|
| **V1** | `list_macros` returns the user's active macros | Call `list_macros` with no args (defaults `per_page=100, page=1`) | Non-error result. Each macro shows `## <title> (id <n>)`, an **active**/**Scope** line, and an **Actions** list of `field → value` rows. Capture one macro id (ideally one with a `comment_value` action + a `status`/`set_tags` action) for V3–V4. Paste the raw block for one macro into the report. |
| **V2** | Pagination footer | Call `list_macros` with `per_page=1, page=1` | Result begins with a `Results: <count>` footer; if more than one macro exists, it shows `More available (cursor: 2)`. No error. |
| **V3** | `preview_macro_diff` shows the macro's before → after diff without saving | Call `preview_macro_diff` with the ticket id and the macro id from V1 | Non-error. Header contains **"diff — nothing saved yet"**. `## Field changes` lists ONLY the fields the macro changes as before → after (e.g. `**status**: open → solved`), tags as `+added/-removed`, custom fields as `**custom field <id>**: <before> → <after>` — and NOT the full ticket (no `url`/`id`/`created_at`, no `via`/`satisfaction_rating` JSON, no empty custom fields). `## Reply` shows the canned body; `## To apply these changes` names `update_ticket`, `add_public_comment`, `add_private_note`. Paste the raw output. |
| **V4** | Preview does not mutate the ticket | Immediately after V3, call `get_ticket` on the same ticket id | Ticket status/tags/comments are unchanged from before V3 (the macro's effect is NOT persisted). This confirms the two-step design. |
| **V5** | Reply visibility flag | In V3's output, check the macro's reply | If the macro's comment is public, the Reply heading reads `## Reply (public comment)`; if internal, `## Reply (internal note)`. If the chosen macro has no comment action, the section reads `## Reply` then `- none` — note which case applied. |
| **V6** | `list_macros` is read-only | Confirm `list_macros` appears in a `--read-only` surface and `preview_macro_diff` does not — this is covered by unit tests; only spot-check if a read-only surface is available. Otherwise mark N/A. | `list_macros` present under read-only, `preview_macro_diff` absent. |

### Long-running behaviours

None — no timers, intervals, or timeouts. All behaviour is a single synchronous
round-trip per call.

### Ground-truth note (V1/V3)

If `## Field changes` comes back as `- none` for a macro that V1 clearly shows
sets fields, the diff is comparing the wrong keys (or the before/after fetch
failed) — report it with both the V1 macro block and the V3 output so the
implementer can align. Conversely, if V3 shows more than the macro's declared
actions (identity/immutable fields, nested JSON), the noise-filtering regressed.

### Priorities

Do **V1 → V3 → V4** first (the real user path: discover a macro, preview it,
confirm it didn't commit). V2, V5, V6 are secondary.

### Reporting

Post a PR comment (English) with a per-id verdict (`OK` / `FAIL` / `BLOCKED` /
`N/A`) and concrete evidence (the tool output text) for V1, V3, V4 at minimum.
Reference the commit SHA you tested. End with an overall green/failing summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tools to list active ticket macros and generate a human-readable diff preview for applying a macro (including proposed field/tag changes and the resulting note/comment).
  - Enhanced macro display with consistent markdown formatting, truncation for long values, and clearer scope/action details.
- **Bug Fixes**
  - Improved SLA policy pagination when the API omits total-count metadata.
- **Documentation**
  - Updated the tool reference to reflect the new macro tools and ordering.
- **Tests**
  - Updated tool-count expectations and expanded coverage for macro workflows, formatting, and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->