### PR TITLE
feat(tickets): Views access — list_views + get_view_tickets (#121)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,19 @@ Local setup and auth flows live in `README.md`; CLI flags and env vars in
 troubleshooting in `docs/troubleshooting.md`; manual tool testing in
 `docs/live-testing.md`.
 
+## Design principle — usage-first, not API-shaped
+
+Design every tool for what an LLM needs to accomplish a real task, not for what
+the Zendesk API happens to expose. The API's endpoints, names, pagination and
+data shapes are an implementation detail, not a template — they may be awkward or
+built for a use case that isn't ours. Don't mirror them 1:1, and don't copy other
+MCP servers just because they exist; neither is evidence of what serves the LLM.
+A single tool may fan out to several Zendesk calls and join, reshape or drop the
+result to hand back exactly what the use case needs — that cross-calling is
+expected, not a smell. When API shape and usage pull apart, follow the usage. (This
+never overrides the multi-agent rule below: internal naming coherence and the
+quality bar still hold — the freedom is from Zendesk's shape, not from craft.)
+
 ## Testing
 
 - New features: TDD — failing test first. Bug fixes: reproduce with a test first.

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -21,6 +21,8 @@ out every `write` tool before the proxies are built.
 | `get_linked_incidents` | Get incidents linked to a problem ticket | read |
 | `list_sla_policies` | List SLA policies with filter conditions and per-priority targets (requires an admin token, or a custom role with the SLA-management permission) | read |
 | `list_ticket_fields` | List ticket field definitions (system + custom) with ids, types, and dropdown/multiselect option values, to resolve `custom_fields` ids and accepted values for create_ticket / update_ticket | read |
+| `list_views` | List the agent's active views (saved ticket queues) with their current ticket counts, to see where the workload sits before opening a queue | read |
+| `get_view_tickets` | Read the tickets inside a view — by title or id — in the view's own configured sort order, cursor-paginated (no live SLA block; use search_tickets for that) | read |
 | `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |
 | `update_ticket` | Update ticket status, priority, assignee, tags, custom fields | write |
 | `add_private_note` | Add an internal note (not visible to requester), optionally with file attachments | write |

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -21,7 +21,7 @@ out every `write` tool before the proxies are built.
 | `get_linked_incidents` | Get incidents linked to a problem ticket | read |
 | `list_sla_policies` | List SLA policies with filter conditions and per-priority targets (requires an admin token, or a custom role with the SLA-management permission) | read |
 | `list_ticket_fields` | List ticket field definitions (system + custom) with ids, types, and dropdown/multiselect option values, to resolve `custom_fields` ids and accepted values for create_ticket / update_ticket | read |
-| `list_views` | List the agent's active views (saved ticket queues) with their current ticket counts, to see where the workload sits before opening a queue | read |
+| `list_views` | List the agent's active views (saved ticket queues) with best-effort (cached, may show "(count updating)") ticket counts, to see where the workload sits before opening a queue | read |
 | `get_view_tickets` | Read the tickets inside a view — by title or id — in the view's own configured sort order, cursor-paginated (no live SLA block; use search_tickets for that) | read |
 | `list_macros` | List the active macros available to the authenticated user, with each macro's id, title, scope, and ordered actions | read |
 | `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |

--- a/scripts/probe-views-shape.ts
+++ b/scripts/probe-views-shape.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env tsx
+/**
+ * Ground-truth capture for the Views API (issue #121).
+ *
+ * The MCP tools only ever return *formatted text*, never the raw Zendesk JSON,
+ * so the exact shape of the Views responses (which is thinly documented) cannot
+ * be observed through them. get_view_tickets makes one high-risk assumption we
+ * could only *guess* from the docs: that each row of `GET /views/{id}/execute`
+ * carries the ticket id at `row.ticket.id` (the docs show a partial `"ticket": {}`
+ * and inline column values). If that guess is wrong, get_view_tickets silently
+ * returns zero tickets for a non-empty view. This one-shot, READ-ONLY probe hits
+ * the live tenant directly and prints the RAW JSON for each endpoint the feature
+ * relies on:
+ *   - GET /api/v2/users/me.json                    (token identity)
+ *   - GET /api/v2/views.json?active=true           (view object shape)
+ *   - GET /api/v2/views/count_many.json?ids=...     (view_counts shape + fresh)
+ *   - GET /api/v2/views/{id}/execute.json           (columns/rows — WHERE is the id?)
+ *   - GET /api/v2/tickets/show_many.json?ids=...     (hydration returns full tickets?)
+ *
+ * It auto-discovers a non-empty view to execute so an empty rows[] can't be
+ * blamed on "that view happened to have no tickets". For each of the first rows
+ * it prints exactly how the tool would extract the id (row.ticket.id, else an
+ * inlined id/ticket_id column), so a mismatch is obvious. It prints column
+ * definitions and row *keys* rather than dumping every ticket subject; only if no
+ * id is extractable does it dump a full row for diagnosis (may contain a subject —
+ * redact before pasting).
+ *
+ * Usage (zero setup in an env where the zendesk-local MCP server is configured):
+ *   pnpm tsx scripts/probe-views-shape.ts [view_id]
+ *
+ * Pass a view_id known to be non-empty, or omit it to let the probe discover one.
+ * The subdomain is read from ZENDESK_SUBDOMAIN, else from the zendesk-local entry
+ * in .mcp.json. The token is read from ZENDESK_OAUTH_TOKEN, else from the access
+ * token cached on disk when the server was authenticated once. Override either:
+ *   ZENDESK_SUBDOMAIN=fruggr ZENDESK_OAUTH_TOKEN=<token> \
+ *     pnpm tsx scripts/probe-views-shape.ts [view_id]
+ *
+ * Paste the output into a PR comment so the maintainer can align the execute-row
+ * types, the id-extraction logic, and the test mocks to reality.
+ */
+import { readFileSync } from 'node:fs';
+import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';
+import { zendeskGet } from '../src/client/zendesk-api';
+
+const cliViewId = process.argv[2];
+if (cliViewId && !/^\d+$/.test(cliViewId)) {
+  console.error(
+    'Usage: pnpm tsx scripts/probe-views-shape.ts [view_id]\n' +
+      '  view_id (optional) must be numeric; omit it to auto-discover a non-empty view.',
+  );
+  process.exit(1);
+}
+
+const resolveSubdomain = (): string => {
+  const fromEnv = process.env['ZENDESK_SUBDOMAIN'];
+  if (fromEnv) return fromEnv;
+  try {
+    const mcp = JSON.parse(readFileSync(new URL('../.mcp.json', import.meta.url), 'utf8'));
+    const sub = mcp?.mcpServers?.['zendesk-local']?.env?.ZENDESK_SUBDOMAIN;
+    if (typeof sub === 'string' && sub) return sub;
+  } catch {
+    // fall through to the error below
+  }
+  console.error(
+    'No Zendesk subdomain. Set ZENDESK_SUBDOMAIN, or run from a checkout whose ' +
+      '.mcp.json configures the zendesk-local server.',
+  );
+  process.exit(1);
+};
+
+const subdomain = resolveSubdomain();
+
+const resolveToken = (): string => {
+  const fromEnv = process.env['ZENDESK_OAUTH_TOKEN'];
+  if (fromEnv) return fromEnv;
+  const cached = loadToken(resolveTokenPath(subdomain));
+  if (cached?.accessToken) return cached.accessToken;
+  console.error(
+    `No token available. Export ZENDESK_OAUTH_TOKEN, or authenticate the server once for "${subdomain}" ` +
+      `so a token is cached at ${resolveTokenPath(subdomain)}.`,
+  );
+  process.exit(1);
+};
+
+const dump = (label: string, value: unknown): void => {
+  console.log(`\n===== ${label} =====`);
+  console.log(JSON.stringify(value, null, 2));
+};
+
+// Mirror the tool's extraction (see extractRowTicketId in src/tools/tickets.ts).
+const extractRowTicketId = (row: Record<string, unknown>): number | undefined => {
+  const ticket = row['ticket'] as { id?: unknown } | undefined;
+  if (typeof ticket?.id === 'number') return ticket.id;
+  for (const key of ['id', 'ticket_id']) {
+    if (typeof row[key] === 'number') return row[key] as number;
+  }
+  return undefined;
+};
+
+const main = async (): Promise<void> => {
+  const token = resolveToken();
+
+  // (0) Token identity — views are per-agent scoped, so this shows whose queue
+  // the probe sees (not admin-gated, unlike the SLA probe).
+  try {
+    const me = await zendeskGet<Record<string, unknown>>(subdomain, token, '/users/me');
+    const user = (me['user'] as Record<string, unknown> | undefined) ?? {};
+    dump('GET /users/me — token identity', {
+      id: user['id'],
+      role: user['role'],
+      role_type: user['role_type'],
+    });
+  } catch (e) {
+    console.log(`\n(could not read /users/me: ${e instanceof Error ? e.message : e})`);
+  }
+
+  // (1) List Views — the object shape list_views renders (id/title/active/description).
+  const viewsResp = await zendeskGet<{ views?: Array<Record<string, unknown>> }>(
+    subdomain,
+    token,
+    '/views',
+    { active: 'true', 'page[size]': '100' },
+  );
+  const views = viewsResp.views ?? [];
+  dump(
+    'GET /views?active=true — first view (representative shape)',
+    views[0] ?? '(no active views)',
+  );
+  dump(
+    'GET /views?active=true — all view ids/titles',
+    views.map((v) => ({ id: v['id'], title: v['title'], active: v['active'] })),
+  );
+  console.log(`\n(${views.length} active views)`);
+  if (views.length === 0) {
+    console.error('\nNo active views to probe. Create a view or run with a different token.');
+    process.exit(1);
+  }
+
+  // (2) count_many — the raw view_counts shape (view_id/value/pretty/fresh). Used
+  // to pick a non-empty view to execute.
+  const ids = views.map((v) => Number(v['id'])).filter((n) => Number.isFinite(n));
+  const countsResp = await zendeskGet<{ view_counts?: Array<Record<string, unknown>> }>(
+    subdomain,
+    token,
+    '/views/count_many',
+    { ids: ids.slice(0, 20).join(',') },
+  );
+  const counts = countsResp.view_counts ?? [];
+  dump('GET /views/count_many — raw view_counts (first 20 ids)', counts);
+
+  let targetId = cliViewId;
+  if (!targetId) {
+    const nonEmpty = counts.find(
+      (c) => typeof c['value'] === 'number' && (c['value'] as number) > 0,
+    );
+    targetId = String(nonEmpty?.['view_id'] ?? views[0]?.['id']);
+    console.log(`\n-> No view_id passed; executing view ${targetId} (auto-discovered non-empty).`);
+  }
+
+  // (3) Execute View — THE critical shape. Where does the ticket id live on a row?
+  const exec = await zendeskGet<Record<string, unknown>>(
+    subdomain,
+    token,
+    `/views/${targetId}/execute`,
+    { 'page[size]': '20' },
+  );
+  dump(`GET /views/${targetId}/execute — top-level keys`, Object.keys(exec));
+  dump('execute columns', exec['columns'] ?? '(no columns)');
+  const rows = (exec['rows'] as Array<Record<string, unknown>> | undefined) ?? [];
+  console.log(`\n(${rows.length} rows returned)`);
+  const extraction = rows.slice(0, 5).map((row, i) => ({
+    row_index: i,
+    row_keys: Object.keys(row),
+    'row.ticket': row['ticket'] ?? '(no ticket key)',
+    extracted_id: extractRowTicketId(row),
+  }));
+  dump('execute rows — id extraction per row (extracted_id MUST be a number)', extraction);
+  const extractedIds = rows
+    .map((r) => extractRowTicketId(r))
+    .filter((id): id is number => typeof id === 'number');
+  if (extractedIds.length === 0 && rows.length > 0) {
+    console.log(
+      '\n!!! NO ticket id extractable from any row — get_view_tickets would return EMPTY for ' +
+        'this non-empty view. The row shape differs from the assumption; full first row below ' +
+        '(may contain a ticket subject — REDACT before pasting):',
+    );
+    dump('execute rows[0] — FULL (diagnosis only)', rows[0]);
+    dump('execute meta / pagination keys', {
+      meta: exec['meta'],
+      count: exec['count'],
+      next_page: exec['next_page'],
+    });
+    return;
+  }
+  dump('execute meta / pagination keys', {
+    meta: exec['meta'],
+    count: exec['count'],
+    next_page: exec['next_page'],
+  });
+
+  // (4) show_many hydration — confirm it returns FULL tickets for those ids, and
+  // whether the returned order matches the requested order (the tool re-sorts, so
+  // a mismatch here is expected and handled — this just documents it).
+  const many = await zendeskGet<{ tickets?: Array<Record<string, unknown>> }>(
+    subdomain,
+    token,
+    '/tickets/show_many',
+    { ids: extractedIds.slice(0, 20).join(',') },
+  );
+  const tickets = many.tickets ?? [];
+  dump(
+    'GET /tickets/show_many — first ticket keys (full ticket expected)',
+    Object.keys(tickets[0] ?? {}),
+  );
+  dump('show_many — requested vs returned id order', {
+    requested: extractedIds.slice(0, 20),
+    returned: tickets.map((t) => t['id']),
+  });
+};
+
+main().catch((error) => {
+  console.error('probe-views-shape failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/probe-views-shape.ts
+++ b/scripts/probe-views-shape.ts
@@ -178,25 +178,30 @@ const main = async (): Promise<void> => {
   const extractedIds = rows
     .map((r) => extractRowTicketId(r))
     .filter((id): id is number => typeof id === 'number');
-  if (extractedIds.length === 0 && rows.length > 0) {
-    console.log(
-      '\n!!! NO ticket id extractable from any row — get_view_tickets would return EMPTY for ' +
-        'this non-empty view. The row shape differs from the assumption; full first row below ' +
-        '(may contain a ticket subject — REDACT before pasting):',
-    );
-    dump('execute rows[0] — FULL (diagnosis only)', rows[0]);
-    dump('execute meta / pagination keys', {
-      meta: exec['meta'],
-      count: exec['count'],
-      next_page: exec['next_page'],
-    });
-    return;
-  }
   dump('execute meta / pagination keys', {
     meta: exec['meta'],
     count: exec['count'],
     next_page: exec['next_page'],
   });
+  // No ids to hydrate — exit cleanly instead of calling show_many with an empty
+  // `ids` list. Two distinct causes, distinguished so the reader knows which:
+  if (extractedIds.length === 0) {
+    if (rows.length === 0) {
+      console.log(
+        `\nView ${targetId} returned 0 rows (empty view). The hydration step needs a ` +
+          'non-empty view — re-run with an explicit non-empty view id: ' +
+          'pnpm tsx scripts/probe-views-shape.ts <view_id>',
+      );
+    } else {
+      console.log(
+        '\n!!! NO ticket id extractable from any row — get_view_tickets would return EMPTY for ' +
+          'this non-empty view. The row shape differs from the assumption; full first row below ' +
+          '(may contain a ticket subject — REDACT before pasting):',
+      );
+      dump('execute rows[0] — FULL (diagnosis only)', rows[0]);
+    }
+    return;
+  }
 
   // (4) show_many hydration — confirm it returns FULL tickets for those ids, and
   // whether the returned order matches the requested order (the tool re-sorts, so

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -15,6 +15,7 @@ import {
   MAX_PAGE_SIZE,
 } from '../constants';
 import type {
+  PaginationMeta,
   ZendeskComment,
   ZendeskListResponse,
   ZendeskSlaPolicy,
@@ -23,6 +24,11 @@ import type {
   ZendeskTicketAttachment,
   ZendeskTicketField,
   ZendeskUpload,
+  ZendeskView,
+  ZendeskViewCount,
+  ZendeskViewCountManyResponse,
+  ZendeskViewExecuteResponse,
+  ZendeskViewExecuteRow,
 } from '../types';
 import {
   formatComment,
@@ -31,6 +37,7 @@ import {
   formatSlaPolicy,
   formatTicket,
   formatTicketField,
+  formatView,
   truncateIfNeeded,
 } from '../utils/formatting';
 import {
@@ -171,6 +178,116 @@ const fetchTicketSla = async (
     // SLA is supplementary — never fail get_ticket because the lookup faltered.
     return undefined;
   }
+};
+
+// count_many accepts at most 20 view ids per request; larger listings are
+// chunked. Kept low deliberately — Zendesk rate-limits this endpoint tightly.
+const VIEW_COUNT_BATCH = 20;
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const groups: T[][] = [];
+  for (let i = 0; i < items.length; i += size) groups.push(items.slice(i, i + size));
+  return groups;
+};
+
+// Fetch cached ticket counts for a page of views, best-effort. count_many is
+// batched (<=20 ids) and heavily rate-limited, so a failed batch degrades to
+// "no count" for those views rather than failing the whole listing.
+const fetchViewCounts = async (
+  subdomain: string,
+  token: string,
+  viewIds: number[],
+): Promise<Map<number, ZendeskViewCount>> => {
+  const counts = new Map<number, ZendeskViewCount>();
+  for (const group of chunk(viewIds, VIEW_COUNT_BATCH)) {
+    try {
+      const { view_counts } = await zendeskGet<ZendeskViewCountManyResponse>(
+        subdomain,
+        token,
+        '/views/count_many',
+        { ids: group.join(',') },
+      );
+      for (const c of view_counts ?? []) counts.set(c.view_id, c);
+    } catch {
+      // Best-effort: leave these views without a count rather than failing.
+    }
+  }
+  return counts;
+};
+
+// Resolve a view reference (title or numeric id) to an id. A numeric reference is
+// used as-is; a title is matched case-insensitively against the agent's active
+// views. Returns the available titles on no match so the caller can self-correct.
+const resolveViewId = async (
+  subdomain: string,
+  token: string,
+  view: string | number,
+): Promise<{ id: number } | { available: string[] }> => {
+  if (typeof view === 'number') return { id: view };
+  if (/^\d+$/.test(view.trim())) return { id: Number(view.trim()) };
+  const response = await zendeskGet<ZendeskListResponse<ZendeskView>>(subdomain, token, '/views', {
+    active: 'true',
+    ...buildCursorParams(MAX_PAGE_SIZE),
+  });
+  const views = response.views ?? [];
+  const target = view.trim().toLowerCase();
+  const match = views.find((v) => v.title.trim().toLowerCase() === target);
+  return match ? { id: match.id } : { available: views.map((v) => v.title) };
+};
+
+// Read the ticket id off an execute row. The row's `ticket` object is partial but
+// carries the id; fall back to an inlined id/ticket_id column just in case.
+const extractRowTicketId = (row: ZendeskViewExecuteRow): number | undefined => {
+  if (typeof row.ticket?.id === 'number') return row.ticket.id;
+  for (const key of ['id', 'ticket_id']) {
+    if (typeof row[key] === 'number') return row[key] as number;
+  }
+  return undefined;
+};
+
+// Execute a view (its own column set + configured sort) and return the ordered
+// rows plus pagination meta. sort_by/sort_order override the view's sort.
+const executeView = async (
+  subdomain: string,
+  token: string,
+  viewId: number,
+  opts: {
+    sort_by?: string | undefined;
+    sort_order?: string | undefined;
+    page_size: number;
+    cursor?: string | undefined;
+  },
+): Promise<{ rows: ZendeskViewExecuteRow[]; meta: PaginationMeta }> => {
+  const params = buildCursorParams(opts.page_size, opts.cursor);
+  if (opts.sort_by) params['sort_by'] = opts.sort_by;
+  if (opts.sort_order) params['sort_order'] = opts.sort_order;
+  const response = await zendeskGet<ZendeskViewExecuteResponse>(
+    subdomain,
+    token,
+    `/views/${viewId}/execute`,
+    params,
+  );
+  const rows = response.rows ?? [];
+  return { rows, meta: extractPaginationMeta(response, rows.length) };
+};
+
+// Hydrate full tickets for the view-ordered ids and restore that order (show_many
+// returns tickets in id order, not the requested order). /execute yields only
+// partial tickets, so full, consistent detail comes from here — one batched call.
+const hydrateViewTickets = async (
+  subdomain: string,
+  token: string,
+  ids: number[],
+): Promise<ZendeskTicket[]> => {
+  if (ids.length === 0) return [];
+  const { tickets } = await zendeskGet<{ tickets: ZendeskTicket[] }>(
+    subdomain,
+    token,
+    '/tickets/show_many',
+    { ids: ids.join(',') },
+  );
+  const byId = new Map((tickets ?? []).map((t) => [t.id, t]));
+  return ids.map((id) => byId.get(id)).filter((t): t is ZendeskTicket => t !== undefined);
 };
 
 export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
@@ -904,6 +1021,152 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
               ),
             },
           ],
+        };
+      },
+    },
+    {
+      name: 'list_views',
+      namespace: 'tickets',
+      readOnly: true,
+      title: 'List Zendesk Views',
+      description:
+        'List the agent\'s active Zendesk views — the saved ticket queues ("Unassigned tickets", "My open tickets", "Breaching today") the agent sees in the Zendesk UI — each with its current ticket count so you can tell at a glance where the workload sits. Views are per-agent scoped, so per-user auth returns exactly the queues this agent can see, with no shared key. Counts come from Zendesk\'s cache and can lag by up to about an hour (shown as "(count updating)" while a fresh value is still being computed); pass a view\'s title or id to get_view_tickets to read the tickets inside it.',
+      inputSchema: z.object({
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Views per page (1-100, default 100).'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response; omit for the first page.'),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { page_size, cursor } = params as { page_size: number; cursor?: string };
+        const token = await getToken();
+        const response = await zendeskGet<ZendeskListResponse<ZendeskView>>(
+          subdomain,
+          token,
+          '/views',
+          { active: 'true', ...buildCursorParams(page_size, cursor) },
+        );
+        const views = response.views ?? [];
+        const counts = await fetchViewCounts(
+          subdomain,
+          token,
+          views.map((v) => v.id),
+        );
+        const rows = views.map((view) => ({ view, count: counts.get(view.id) }));
+        return {
+          content: [
+            {
+              type: 'text',
+              text: formatList(
+                rows,
+                ({ view, count }) => formatView(view, count),
+                extractPaginationMeta(response, views.length),
+              ),
+            },
+          ],
+        };
+      },
+    },
+    {
+      name: 'get_view_tickets',
+      namespace: 'tickets',
+      readOnly: true,
+      title: 'Get Tickets In A View',
+      description:
+        'Read the tickets inside a Zendesk view, in the view\'s own configured sort order — the same order the agent sees in the Zendesk UI — which is the natural way to work a named queue like "Unassigned tickets" or "Breaching today". Accepts the view by title or by numeric id (discover both with list_views); a title is matched case-insensitively against the agent\'s active views, and on no match the available titles are returned so you can retry in one step. Tickets come back with the same fields as list_tickets and are cursor-paginated; there is no live SLA block here (use search_tickets when you need per-ticket SLA state), and sort_by/sort_order override the view\'s order when you want a different cut.',
+      inputSchema: z.object({
+        view: z
+          .union([z.string().min(1), z.number().int().positive()])
+          .describe(
+            'The view to read: its exact title as shown in Zendesk (e.g. "Unassigned tickets") or its numeric id from list_views. A title is matched case-insensitively against your active views; on no match the tool returns the available titles instead of erroring, so you can retry with a correct one.',
+          ),
+        sort_by: z
+          .string()
+          .optional()
+          .describe(
+            'Optional column to sort by, overriding the view\'s own sort. Must be one of the view\'s columns (e.g. "status", "priority", "updated_at", or a custom field id); "subject" and "submitter" are not sortable. Omit to keep the view\'s configured order.',
+          ),
+        sort_order: z
+          .enum(['asc', 'desc'])
+          .optional()
+          .describe(
+            'Sort direction applied to sort_by: "asc" (oldest/lowest first) or "desc" (newest/highest first). Only meaningful together with sort_by; omit to keep the view\'s configured direction.',
+          ),
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe('Tickets per page (1-100, default 100).'),
+        cursor: z
+          .string()
+          .optional()
+          .describe('Pagination cursor from a previous response; omit for the first page.'),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { view, sort_by, sort_order, page_size, cursor } = params as {
+          view: string | number;
+          sort_by?: string;
+          sort_order?: 'asc' | 'desc';
+          page_size: number;
+          cursor?: string;
+        };
+        const token = await getToken();
+        const resolved = await resolveViewId(subdomain, token, view);
+        if ('available' in resolved) {
+          const text =
+            resolved.available.length > 0
+              ? `No active view matches "${view}". Available views: ${resolved.available.join(', ')}.`
+              : `No active view matches "${view}", and no active views were found for this agent.`;
+          return { content: [{ type: 'text', text }] };
+        }
+        let rows: ZendeskViewExecuteRow[];
+        let meta: PaginationMeta;
+        try {
+          ({ rows, meta } = await executeView(subdomain, token, resolved.id, {
+            sort_by,
+            sort_order,
+            page_size,
+            cursor,
+          }));
+        } catch (error) {
+          // Views can be restricted to specific groups; a 403 means this agent
+          // cannot see that view. Rewrite the generic "Permission denied" into
+          // guidance the LLM can act on.
+          if (error instanceof ZendeskApiError && error.status === 403) {
+            throw new Error(
+              `Access denied to view ${resolved.id} (HTTP 403). Zendesk views can be restricted to specific groups, and this agent is not allowed to read this one. Call list_views to see the queues available to this agent.`,
+              { cause: error },
+            );
+          }
+          throw error;
+        }
+        const ids = rows
+          .map(extractRowTicketId)
+          .filter((id): id is number => typeof id === 'number');
+        const tickets = await hydrateViewTickets(subdomain, token, ids);
+        return {
+          content: [{ type: 'text', text: formatList(tickets, formatTicket, meta) }],
         };
       },
     },

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -221,24 +221,38 @@ const fetchViewCounts = async (
   return counts;
 };
 
-// Resolve a view reference (title or numeric id) to an id. A numeric reference is
-// used as-is; a title is matched case-insensitively against the agent's active
-// views. Returns the available titles on no match so the caller can self-correct.
+// Resolve a view reference to an id. A numeric reference is used as-is; a string
+// is always treated as a title (even an all-digits one — the numeric-id path is
+// `typeof view === 'number'` only) and matched case-insensitively against the
+// agent's active views. The active-views list is cursor-paginated to completion
+// so a title on a later page still resolves; on no match the full set of
+// available titles is returned so the caller can self-correct.
 const resolveViewId = async (
   subdomain: string,
   token: string,
   view: string | number,
 ): Promise<{ id: number } | { available: string[] }> => {
-  const ref = String(view).trim();
-  if (/^\d+$/.test(ref)) return { id: Number(ref) };
-  const response = await zendeskGet<ZendeskListResponse<ZendeskView>>(subdomain, token, '/views', {
-    active: 'true',
-    ...buildCursorParams(MAX_PAGE_SIZE),
-  });
-  const views = response.views ?? [];
-  const target = ref.toLowerCase();
-  const match = views.find((v) => v.title.trim().toLowerCase() === target);
-  return match ? { id: match.id } : { available: views.map((v) => v.title) };
+  if (typeof view === 'number') return { id: view };
+  const target = view.trim().toLowerCase();
+  const available: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const response = await zendeskGet<ZendeskListResponse<ZendeskView>>(
+      subdomain,
+      token,
+      '/views',
+      {
+        active: 'true',
+        ...buildCursorParams(MAX_PAGE_SIZE, cursor),
+      },
+    );
+    const views = response.views ?? [];
+    const match = views.find((v) => v.title.trim().toLowerCase() === target);
+    if (match) return { id: match.id };
+    available.push(...views.map((v) => v.title));
+    cursor = response.meta?.has_more ? (response.meta.after_cursor ?? undefined) : undefined;
+  } while (cursor);
+  return { available };
 };
 
 // Read the ticket id off an execute row. The row's `ticket` object is partial but
@@ -1290,8 +1304,17 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           .map(extractRowTicketId)
           .filter((id): id is number => typeof id === 'number');
         const tickets = await hydrateViewTickets(subdomain, token, ids);
+        // Count reflects the tickets actually rendered, not the raw execute rows:
+        // a row whose id can't be extracted or that show_many can't resolve is
+        // dropped, so rows.length would overstate the list. Pagination (has_more /
+        // after_cursor) is preserved from the execute response.
         return {
-          content: [{ type: 'text', text: formatList(tickets, formatTicket, meta) }],
+          content: [
+            {
+              type: 'text',
+              text: formatList(tickets, formatTicket, { ...meta, count: tickets.length }),
+            },
+          ],
         };
       },
     },

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -223,14 +223,14 @@ const resolveViewId = async (
   token: string,
   view: string | number,
 ): Promise<{ id: number } | { available: string[] }> => {
-  if (typeof view === 'number') return { id: view };
-  if (/^\d+$/.test(view.trim())) return { id: Number(view.trim()) };
+  const ref = String(view).trim();
+  if (/^\d+$/.test(ref)) return { id: Number(ref) };
   const response = await zendeskGet<ZendeskListResponse<ZendeskView>>(subdomain, token, '/views', {
     active: 'true',
     ...buildCursorParams(MAX_PAGE_SIZE),
   });
   const views = response.views ?? [];
-  const target = view.trim().toLowerCase();
+  const target = ref.toLowerCase();
   const match = views.find((v) => v.title.trim().toLowerCase() === target);
   return match ? { id: match.id } : { available: views.map((v) => v.title) };
 };
@@ -1065,14 +1065,13 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           token,
           views.map((v) => v.id),
         );
-        const rows = views.map((view) => ({ view, count: counts.get(view.id) }));
         return {
           content: [
             {
               type: 'text',
               text: formatList(
-                rows,
-                ({ view, count }) => formatView(view, count),
+                views,
+                (view) => formatView(view, counts.get(view.id)),
                 extractPaginationMeta(response, views.length),
               ),
             },

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,56 @@ export interface ZendeskTicketField {
   system_field_options?: ZendeskFieldOption[];
 }
 
+// GET /api/v2/views — a Zendesk view: a saved, per-agent ticket queue
+// ("Unassigned tickets", "Breaching today"). We surface title/id/description for
+// list_views; `execution`/`conditions`/`restriction` are read by the API but not
+// rendered (the usage is the queue, not its filter definition).
+export interface ZendeskView {
+  id: number;
+  title: string;
+  active: boolean;
+  description: string | null;
+  position?: number;
+}
+
+// GET /api/v2/views/count_many — a view's cached ticket count. Zendesk caches
+// these heavily (up to ~an hour for large views): while it recomputes, `fresh`
+// is false and `value` may be null. `pretty` is the display form ("298", "~700",
+// or "..." when not yet computed), so prefer it for rendering.
+export interface ZendeskViewCount {
+  view_id: number;
+  value: number | null;
+  pretty: string;
+  fresh: boolean;
+  url?: string;
+}
+
+export interface ZendeskViewCountManyResponse {
+  view_counts?: ZendeskViewCount[];
+}
+
+// GET /api/v2/views/{id}/execute — a view executed with its own column set and
+// configured sort order. Each row carries the view's column values inlined plus a
+// *partial* ticket object; we use the rows only for the view-ordered ticket ids,
+// then hydrate full tickets via /tickets/show_many (the partial ticket and the
+// view-dependent columns are not a reliable full ticket, see #121).
+export interface ZendeskViewExecuteRow {
+  ticket?: { id?: number };
+  [key: string]: unknown;
+}
+
+export interface ZendeskViewExecuteResponse {
+  columns?: Array<{ id: string | number; title: string }>;
+  rows?: ZendeskViewExecuteRow[];
+  view?: { id: number };
+  meta?: {
+    has_more: boolean;
+    after_cursor: string;
+  };
+  count?: number;
+  next_page?: string | null;
+}
+
 export interface ZendeskTicketAttachment {
   id: number;
   file_name: string;
@@ -243,6 +293,7 @@ export interface ZendeskListResponse<T> {
   results?: T[];
   records?: T[];
   tickets?: T[];
+  views?: T[];
   users?: T[];
   organizations?: T[];
   articles?: T[];

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -18,6 +18,8 @@ import type {
   ZendeskTranslation,
   ZendeskUser,
   ZendeskUserSegment,
+  ZendeskView,
+  ZendeskViewCount,
 } from '../types.js';
 
 export const truncateIfNeeded = (text: string): string => {
@@ -206,6 +208,19 @@ export const formatCategory = (category: ZendeskCategory): string =>
 
 export const formatSection = (section: ZendeskSection): string =>
   `- **${section.name}** (${section.id}) — Category: ${section.category_id} — ${section.description || 'No description'}`;
+
+// Compact one-line view entry for list_views: title, id, and — when a count was
+// resolved — the queue size. Counts are cached by Zendesk; a non-fresh one is
+// marked "(count updating)" so the caller does not treat a stale/estimated value
+// (or "...") as exact. Rendered via `count.pretty`, which already carries the
+// exact/approximate/"not yet computed" form.
+export const formatView = (view: ZendeskView, count?: ZendeskViewCount): string => {
+  const countText = count
+    ? ` — ${count.pretty} ticket(s)${count.fresh ? '' : ' (count updating)'}`
+    : '';
+  const description = view.description ? ` — ${view.description}` : '';
+  return `- **${view.title}** (id ${view.id})${countText}${description}`;
+};
 
 export const formatPermissionGroup = (group: ZendeskPermissionGroup): string =>
   `- **${group.name}** (${group.id})${group.built_in ? ' — Built-in' : ''}`;

--- a/tests/functional/scenarios/04-all-baseline/expected.md
+++ b/tests/functional/scenarios/04-all-baseline/expected.md
@@ -4,7 +4,7 @@
 
 ## Expected values
 
-- **A1.** `tools.length === 40`. Breakdown: 12 ticket tools + 22 Help Center
+- **A1.** `tools.length === 42`. Breakdown: 14 ticket tools + 22 Help Center
   tools + 5 user/organization tools + 1 unified search tool. If the count
   drifts, update the documentation listed in `AGENTS.md` "Documentation
   maintenance" before running.

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -89,6 +89,8 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(names).toContain('get_ticket');
         expect(names).toContain('create_ticket');
         expect(names).toContain('list_sla_policies');
+        expect(names).toContain('list_views');
+        expect(names).toContain('get_view_tickets');
       });
 
       it('reaches list_sla_policies over the wire and returns the policy matrix', async () => {
@@ -148,6 +150,17 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
 
         expect(result.isError).toBeFalsy();
         expect(textOf(result)).toContain('Test User');
+      });
+
+      it('reads a view by title and returns its tickets over the wire', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'get_view_tickets',
+          arguments: { view: 'Unassigned tickets' },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('Ticket #1');
       });
 
       it('uploads and attaches a file when posting a public comment', async () => {

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -20,6 +20,14 @@ export const MOCK_TICKET = {
   custom_fields: [],
 };
 
+export const MOCK_VIEW = {
+  id: 25,
+  title: 'Unassigned tickets',
+  active: true,
+  description: 'Tickets with no assignee',
+  position: 1,
+};
+
 // Shape mirrors the official SLA Policies API reference: condition values can be
 // arrays (e.g. `includes`), policy_metrics carry target_in_seconds, and the
 // record has a `url`. The resolution metric is `total_resolution_time`.
@@ -337,6 +345,42 @@ export const manyContentTagsHandler = http.get(`${BASE}/guide/content_tags`, () 
 );
 
 export const handlers = [
+  // Views (issue #121). Registered before `/tickets/:id` so `/tickets/show_many`
+  // hits its own handler instead of being captured as an `:id`.
+  http.get(`${BASE}/tickets/show_many`, ({ request }) => {
+    const ids = (new URL(request.url).searchParams.get('ids') ?? '')
+      .split(',')
+      .filter(Boolean)
+      .map(Number);
+    return HttpResponse.json({ tickets: ids.map((id) => ({ ...MOCK_TICKET, id })) });
+  }),
+  http.get(`${BASE}/views/count_many`, ({ request }) => {
+    const ids = (new URL(request.url).searchParams.get('ids') ?? '')
+      .split(',')
+      .filter(Boolean)
+      .map(Number);
+    return HttpResponse.json({
+      view_counts: ids.map((id) => ({
+        view_id: id,
+        value: 298,
+        pretty: '298',
+        fresh: true,
+        url: `${BASE}/views/${id}/count.json`,
+      })),
+    });
+  }),
+  http.get(`${BASE}/views/:id/execute`, ({ params }) =>
+    HttpResponse.json({
+      columns: [{ id: 'subject', title: 'Subject' }],
+      rows: [{ ticket: { id: MOCK_TICKET.id } }],
+      view: { id: Number(params['id']) },
+      meta: { has_more: false, after_cursor: '' },
+    }),
+  ),
+  http.get(`${BASE}/views`, () =>
+    HttpResponse.json({ views: [MOCK_VIEW], meta: { has_more: false, after_cursor: '' } }),
+  ),
+
   // Tickets
   http.get(`${BASE}/tickets/:id`, ({ params }) => {
     if (params['id'] === '404') return HttpResponse.json({}, { status: 404 });

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -64,7 +64,7 @@ describe('groupByNamespace', () => {
     const ticketCount = grouped.get('tickets')?.length ?? 0;
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
-    expect(ticketCount).toBe(13); // 12 ticket tools + 1 search
+    expect(ticketCount).toBe(15); // 14 ticket tools + 1 search
     expect(hcCount).toBe(22);
     expect(userCount).toBe(5);
   });

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -891,6 +891,48 @@ describe('ticket tools', () => {
       expect(result.content[0]?.text).toContain('Ticket #1');
     });
 
+    it('paginates the active-views lookup to resolve a title on a later page', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/views', ({ request }) => {
+          const cursor = new URL(request.url).searchParams.get('page[after]');
+          if (!cursor) {
+            return HttpResponse.json({
+              views: [{ ...MOCK_VIEW, id: 11, title: 'Some other queue' }],
+              meta: { has_more: true, after_cursor: 'PAGE2' },
+            });
+          }
+          return HttpResponse.json({
+            views: [{ ...MOCK_VIEW, id: 77, title: 'Breaching today' }],
+            meta: { has_more: false, after_cursor: '' },
+          });
+        }),
+      );
+      const tool = findTool('get_view_tickets');
+      const result = await tool.handler({ view: 'Breaching today', page_size: 100 });
+      // Resolved to id 77 on page 2, then executed + hydrated to a ticket.
+      expect(result.content[0]?.text).toContain('Ticket #1');
+    });
+
+    it('treats a digit-only string as a title, not an id', async () => {
+      let executedViewId: string | null = null;
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/views', () =>
+          HttpResponse.json({
+            views: [{ ...MOCK_VIEW, id: 55, title: '2024' }],
+            meta: { has_more: false, after_cursor: '' },
+          }),
+        ),
+        http.get('https://testsubdomain.zendesk.com/api/v2/views/:id/execute', ({ params }) => {
+          executedViewId = params['id'] as string;
+          return HttpResponse.json({ rows: [], meta: { has_more: false, after_cursor: '' } });
+        }),
+      );
+      const tool = findTool('get_view_tickets');
+      await tool.handler({ view: '2024', page_size: 100 });
+      // "2024" is matched as a title (view id 55), not used directly as id 2024.
+      expect(executedViewId).toBe('55');
+    });
+
     it("preserves the view's order after hydrating full tickets", async () => {
       mswServer.use(
         http.get('https://testsubdomain.zendesk.com/api/v2/views/:id/execute', () =>

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -2,7 +2,7 @@ import { HttpResponse, http } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createTicketTools } from '../../../src/tools/tickets';
-import { MOCK_SLA_SIDELOAD, MOCK_TICKET, MOCK_UPLOAD } from '../../msw-handlers';
+import { MOCK_SLA_SIDELOAD, MOCK_TICKET, MOCK_UPLOAD, MOCK_VIEW } from '../../msw-handlers';
 import { mswServer } from '../../setup';
 
 const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
@@ -21,9 +21,9 @@ const getAllText = (result: { content: Array<{ type: string; text?: string }> })
     .join('\n');
 
 describe('ticket tools', () => {
-  it('creates 12 tools (search_tickets lives here; the unified search is elsewhere)', () => {
+  it('creates 14 tools (search_tickets lives here; the unified search is elsewhere)', () => {
     const tools = createTicketTools(ctx);
-    expect(tools).toHaveLength(12);
+    expect(tools).toHaveLength(14);
   });
 
   describe('get_ticket', () => {
@@ -821,6 +821,158 @@ describe('ticket tools', () => {
       const tool = findTool('manage_tags');
       expect(tool.description).toContain('update_ticket');
       expect(tool.description).toContain('idempotent');
+    });
+  });
+
+  describe('list_views', () => {
+    it('lists active views with their ticket counts', async () => {
+      const tool = findTool('list_views');
+      const result = await tool.handler({ page_size: 100 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain(MOCK_VIEW.title);
+      expect(text).toContain(`(id ${MOCK_VIEW.id})`);
+      expect(text).toContain('298 ticket(s)');
+    });
+
+    it('marks a non-fresh count as updating instead of implying it is exact', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/views/count_many', () =>
+          HttpResponse.json({
+            view_counts: [{ view_id: MOCK_VIEW.id, value: null, pretty: '...', fresh: false }],
+          }),
+        ),
+      );
+      const tool = findTool('list_views');
+      const result = await tool.handler({ page_size: 100 });
+      expect(result.content[0]?.text).toContain('(count updating)');
+    });
+
+    it('still lists views when the counts endpoint errors (best-effort counts)', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/views/count_many', () =>
+          HttpResponse.json({}, { status: 500 }),
+        ),
+      );
+      const tool = findTool('list_views');
+      const result = await tool.handler({ page_size: 100 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain(MOCK_VIEW.title);
+      expect(text).not.toContain('ticket(s)');
+    });
+
+    it('is read-only and passes the cursor through to Zendesk', async () => {
+      let sawCursor: string | null = null;
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/views', ({ request }) => {
+          sawCursor = new URL(request.url).searchParams.get('page[after]');
+          return HttpResponse.json({ views: [], meta: { has_more: false, after_cursor: '' } });
+        }),
+      );
+      const tool = findTool('list_views');
+      expect(tool.readOnly).toBe(true);
+      expect(tool.annotations.readOnlyHint).toBe(true);
+      await tool.handler({ page_size: 50, cursor: 'CURSOR123' });
+      expect(sawCursor).toBe('CURSOR123');
+    });
+  });
+
+  describe('get_view_tickets', () => {
+    it('resolves a view by title and returns its tickets', async () => {
+      const tool = findTool('get_view_tickets');
+      const result = await tool.handler({ view: MOCK_VIEW.title, page_size: 100 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('Ticket #1');
+      expect(text).toContain('Test ticket');
+    });
+
+    it('accepts a numeric view id directly', async () => {
+      const tool = findTool('get_view_tickets');
+      const result = await tool.handler({ view: MOCK_VIEW.id, page_size: 100 });
+      expect(result.content[0]?.text).toContain('Ticket #1');
+    });
+
+    it("preserves the view's order after hydrating full tickets", async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/views/:id/execute', () =>
+          HttpResponse.json({
+            rows: [{ ticket: { id: 3 } }, { ticket: { id: 1 } }, { ticket: { id: 2 } }],
+            meta: { has_more: false, after_cursor: '' },
+          }),
+        ),
+        // show_many returns tickets in ascending id order, NOT the requested order.
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/show_many', ({ request }) => {
+          const ids = (new URL(request.url).searchParams.get('ids') ?? '').split(',').map(Number);
+          const tickets = [...ids].sort((a, b) => a - b).map((id) => ({ ...MOCK_TICKET, id }));
+          return HttpResponse.json({ tickets });
+        }),
+      );
+      const tool = findTool('get_view_tickets');
+      const result = await tool.handler({ view: MOCK_VIEW.id, page_size: 100 });
+      const text = result.content[0]?.text ?? '';
+      const i3 = text.indexOf('Ticket #3');
+      const i1 = text.indexOf('Ticket #1');
+      const i2 = text.indexOf('Ticket #2');
+      expect(i3).toBeGreaterThanOrEqual(0);
+      expect(i3).toBeLessThan(i1);
+      expect(i1).toBeLessThan(i2);
+    });
+
+    it('passes sort_by/sort_order and the cursor through to the execute endpoint', async () => {
+      let sawSortBy: string | null = null;
+      let sawSortOrder: string | null = null;
+      let sawCursor: string | null = null;
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/views/:id/execute', ({ request }) => {
+          const url = new URL(request.url);
+          sawSortBy = url.searchParams.get('sort_by');
+          sawSortOrder = url.searchParams.get('sort_order');
+          sawCursor = url.searchParams.get('page[after]');
+          return HttpResponse.json({ rows: [], meta: { has_more: false, after_cursor: '' } });
+        }),
+      );
+      const tool = findTool('get_view_tickets');
+      await tool.handler({
+        view: MOCK_VIEW.id,
+        sort_by: 'priority',
+        sort_order: 'desc',
+        page_size: 50,
+        cursor: 'CUR',
+      });
+      expect(sawSortBy).toBe('priority');
+      expect(sawSortOrder).toBe('desc');
+      expect(sawCursor).toBe('CUR');
+    });
+
+    it('returns the available view titles when the title does not match', async () => {
+      const tool = findTool('get_view_tickets');
+      const result = await tool.handler({ view: 'Nonexistent queue', page_size: 100 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('Available views');
+      expect(text).toContain(MOCK_VIEW.title);
+      expect(text).not.toContain('Ticket #');
+    });
+
+    it('rewrites a 403 on a restricted view into actionable guidance', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/views/:id/execute', () =>
+          HttpResponse.json({ error: 'Forbidden' }, { status: 403 }),
+        ),
+      );
+      const tool = findTool('get_view_tickets');
+      const error = await tool.handler({ view: MOCK_VIEW.id, page_size: 100 }).then(
+        () => {
+          throw new Error('expected get_view_tickets to reject on 403');
+        },
+        (err: unknown) => err as Error,
+      );
+      expect(error.message).toMatch(/list_views/);
+      expect(error.message).toMatch(/403|restricted|denied/i);
+    });
+
+    it('has readOnly annotation', () => {
+      const tool = findTool('get_view_tickets');
+      expect(tool.readOnly).toBe(true);
+      expect(tool.annotations.readOnlyHint).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements #121 — access to Zendesk **Views**, the way an agent thinks about its queue (by name), instead of hand-writing a `search_tickets` query.

- **`list_views`** — the agent's *active* views (saved ticket queues like "Unassigned tickets", "Breaching today") with their current ticket **counts**. Counts come from `GET /views/count_many` (batched ≤20 ids, best-effort: a rate-limited/errored batch degrades to "no count" rather than failing the listing) and are marked `(count updating)` when Zendesk reports them non-fresh, so a stale/estimated value is never read as exact.
- **`get_view_tickets`** — the tickets inside a view, addressable by **title or numeric id**, in the view's **own configured sort order** via `GET /views/{id}/execute`. Execute rows carry only a *partial* ticket, so the view-ordered ids are hydrated to full tickets via `GET /tickets/show_many` and re-sorted back into the view's order — output matches `list_tickets`. `sort_by`/`sort_order` override the view's sort; an unmatched title returns the available titles for one-step retry; a 403 on a group-restricted view is rewritten with guidance to call `list_views`.

Both are read-only, `tickets` namespace, per-user OAuth (the API returns exactly the queues the authenticated agent can see). There is **no live SLA block** on view tickets — the `slas` sideload rides only on `/search`, so `search_tickets` stays the path for per-ticket SLA state.

This is the first feature to apply the `usage-first, not API-shaped` principle added to `AGENTS.md` on this branch: `get_view_tickets` fans out across three Zendesk calls (resolve name → execute for order → hydrate for detail) to hand the LLM exactly what the "work my queue" use case needs.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [x] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] `pnpm test` passes locally (457 tests)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
- [x] If the change has runtime-observable behaviour: this PR carries a `## Functional validation plan` (authored with `/functional-validation-plan`), and it has been executed by an independent validator (`/run-validation-plan`) whose report is posted as a PR comment

  _Validation plan below; executed by an independent validator against the live `fruggr` tenant — report posted as a PR comment. Result: green (V0 + S1–S8 OK; S9 BLOCKED as expected — no forbidden-but-referenceable view for a per-user token, 403 path unit-covered)._

## Notes for the reviewer (human or AI)
`get_view_tickets` makes one assumption that could only be *guessed* from thin Zendesk docs: that each `/views/{id}/execute` row exposes the ticket id at `row.ticket.id` (extraction falls back to an inlined `id`/`ticket_id`). If that is wrong, the tool would silently return an empty list for a non-empty view — so the validation plan's **V0** capture (`scripts/probe-views-shape.ts`) is a blocking, ground-truth check before the rest is trusted. **V0 passed live:** on a 54-ticket view every execute row exposes a numeric `row.ticket.id`. This branch also still carries the `docs(agents): add usage-first design principle` commit (originally the standalone PR #146); it merges together with the feature.

## Functional validation plan

**Context.** Two read-only tools exercise this change; drive them by calling the running server's `list_views` and `get_view_tickets` tools (mode `all`). Transport (stdio/HTTP) is irrelevant — the logic is in the tool handlers. `search`, `list_tickets`, `search_tickets` are untouched.

**Setup & prerequisites.** The environment is already on the branch with the server running and authenticated — no build/checkout/creds needed. Record the commit under test with `git rev-parse HEAD`. The tenant must have ≥1 active view (fruggr does). Counts and the execute-row shape are cached/undocumented upstream data, so V0 captures the raw JSON first.

**V0 — Ground-truth capture (BLOCKING).** Run `pnpm tsx scripts/probe-views-shape.ts` and paste the full output into a PR comment (redact any ticket subject if a FULL-row dump is triggered). Confirm: (a) `/views` objects carry `id`/`title`/`active`/`description`; (b) `count_many` returns `view_counts` with `value`/`pretty`/`fresh`; (c) **every execute row yields a numeric `extracted_id`** (the probe prints this per row) — any `extracted_id: undefined` on a non-empty view is a FAIL: the id-extraction/type must be aligned to the captured shape before the rest is trusted; (d) `show_many` returns full ticket objects. `get_view_tickets` returning empty for a non-empty view traces back to (c).

| id | validates | do | expected observable |
|----|-----------|----|---------------------|
| S1 | list_views basic | call `list_views {}` | bullet list of active views, each `- **<title>** (id <n>)`, and `— <pretty> ticket(s)` where a count resolved; cross-check one title/count against V0 |
| S2 | count freshness marker | inspect S1 | a view whose V0 count is `fresh:false` shows `(count updating)`; fresh ones don't (can't force staleness live — unit-covered) |
| S3 | get_view_tickets by title | `get_view_tickets {view:"<non-empty title from S1>"}` | `## Ticket #…` list, same fields as list_tickets (Status/Priority/Requester/Assignee), **no `### SLA`**; count ≤ page_size |
| S4 | by numeric id | `get_view_tickets {view:<same id>}` | same tickets as S3 |
| S5 | order fidelity | compare S3/S4 order to the view's order in the Zendesk UI (or V0's execute row order) | matches the view's configured sort, **not** plain ascending id |
| S6 | sort override | `get_view_tickets {view:<id>, sort_by:"priority", sort_order:"desc"}` | order changes vs S4 accordingly |
| S7 | unknown title | `get_view_tickets {view:"definitely-not-a-view-zzz"}` | text "No active view matches …" + "Available views: …" with real titles; **no** `## Ticket #` |
| S8 | pagination | on a view with > page_size tickets: `get_view_tickets {view:<id>, page_size:1}`, then feed the returned cursor back | first call: one ticket + "More available (cursor: …)"; second: next ticket |
| S9 | restricted-view 403 | if a view restricted to a group the token lacks exists: `get_view_tickets {view:<that id>}` | error mentioning HTTP 403 and "call list_views"; BLOCKED if no such view exists |

**Long-running behaviours.** None (no timers). The `fresh:false` marker, the count_many best-effort degradation, and the 403 rewrite are covered by unit tests in `tests/unit/tools/tickets.test.ts`; don't re-prove them live beyond the opportunistic S2/S9 checks.

**Priorities.** V0 (blocking) → S1 → S3 → S5 (the real user paths: see the queue, read it, in the right order) → S7 → S6/S8/S9.

**Reporting.** Post one PR comment: the commit SHA tested, the V0 raw output, then per-id OK/FAIL/BLOCKED with the observed tool output as evidence, and an overall green/failing summary.

https://claude.ai/code/session_01PfFHrF3JzPXR7zh81izQCC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfFHrF3JzPXR7zh81izQCC)_