### PR TITLE
feat(tickets): add list_ticket_fields to expose field definitions and option values

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ zendesk-mcp-server acme --namespace tickets
 | `list_tickets` | List tickets with cursor-based pagination | read |
 | `get_linked_incidents` | Get incidents linked to a problem ticket | read |
 | `list_sla_policies` | List SLA policies with filter conditions and per-priority targets (requires an admin token, or a custom role with the SLA-management permission) | read |
+| `list_ticket_fields` | List ticket field definitions (system and custom) with valid option values, for use in create_ticket / update_ticket | read |
 | `create_ticket` | Create a new ticket with subject, description, priority, tags... | write |
 | `update_ticket` | Update ticket status, priority, assignee, tags, custom fields | write |
 | `add_private_note` | Add an internal note (not visible to requester), optionally with file attachments | write |

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -21,6 +21,7 @@ import type {
   ZendeskSlaSideloadEntry,
   ZendeskTicket,
   ZendeskTicketAttachment,
+  ZendeskTicketField,
   ZendeskUpload,
 } from '../types';
 import {
@@ -29,6 +30,7 @@ import {
   formatSlaBlock,
   formatSlaPolicy,
   formatTicket,
+  formatTicketField,
   truncateIfNeeded,
 } from '../utils/formatting';
 import {
@@ -379,7 +381,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: false,
       title: 'Create Zendesk Ticket',
       description:
-        'Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags. The description becomes the first public comment of the ticket, and the new ticket id is returned. After creation, use update_ticket to change status or assignee, add_public_comment or add_private_note to reply, and manage_tags to adjust tags. Look up valid assignee_id / group_id and custom field ids via search_users or your Zendesk admin settings.',
+        'Create a new Zendesk support ticket with subject, description, and optional priority/type/assignee/tags. The description becomes the first public comment of the ticket, and the new ticket id is returned. After creation, use update_ticket to change status or assignee, add_public_comment or add_private_note to reply, and manage_tags to adjust tags. Look up valid assignee_id / group_id via search_users, and custom field ids and their accepted values via list_ticket_fields.',
       inputSchema: z.object({
         subject: z.string().min(1).describe('Ticket subject'),
         description: z.string().min(1).describe('Ticket description'),
@@ -402,7 +404,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           .array(z.object({ id: z.number().int(), value: z.unknown() }))
           .optional()
           .describe(
-            'Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings).',
+            'Custom field values as { id, value } pairs. Discover valid field ids and their accepted values with list_ticket_fields.',
           ),
       }),
       annotations: {
@@ -467,7 +469,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           .array(z.object({ id: z.number().int(), value: z.unknown() }))
           .optional()
           .describe(
-            'Custom field values as { id, value } pairs (field ids come from your Zendesk admin settings).',
+            'Custom field values as { id, value } pairs. Discover valid field ids and their accepted values with list_ticket_fields.',
           ),
       }),
       annotations: {
@@ -764,6 +766,45 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
             : { count: policies.length, has_more: false, after_cursor: null };
         return {
           content: [{ type: 'text', text: formatList(policies, formatSlaPolicy, meta) }],
+        };
+      },
+    },
+    {
+      name: 'list_ticket_fields',
+      namespace: 'tickets',
+      readOnly: true,
+      title: 'List Ticket Fields',
+      description:
+        'List ticket field definitions (system and custom) with their valid dropdown/tagger option values. Use this to discover the field id and the exact value to pass in the custom_fields of create_ticket / update_ticket, instead of guessing. Read-only; returns active fields by default (pass active_only: false to include archived/deactivated fields).',
+      inputSchema: z.object({
+        active_only: z
+          .boolean()
+          .default(true)
+          .describe(
+            'Return only active fields (default true). Set false to include inactive ones.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { active_only } = params as { active_only: boolean };
+        const token = await getToken();
+        const response = await zendeskGet<ZendeskListResponse<ZendeskTicketField>>(
+          subdomain,
+          token,
+          '/ticket_fields',
+          buildOffsetParams(MAX_PAGE_SIZE, 1),
+        );
+        const fields = (response.ticket_fields ?? []).filter((f) => !active_only || f.active);
+        // The ticket_fields endpoint returns the full list with no `count`
+        // wrapper, so report the array length rather than "Results: 0".
+        const meta = { count: fields.length, has_more: false, after_cursor: null };
+        return {
+          content: [{ type: 'text', text: formatList(fields, formatTicketField, meta) }],
         };
       },
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,7 +208,7 @@ export interface ZendeskLocalesResponse {
   default_locale: string;
 }
 
-// GET /api/v2/ticket_fields.json — a ticket field definition (system or custom)
+// GET /api/v2/ticket_fields.json: a ticket field definition (system or custom)
 // with the valid option values for dropdown/tagger and system fields.
 export interface ZendeskTicketFieldOption {
   name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,6 +208,25 @@ export interface ZendeskLocalesResponse {
   default_locale: string;
 }
 
+// GET /api/v2/ticket_fields.json — a ticket field definition (system or custom)
+// with the valid option values for dropdown/tagger and system fields.
+export interface ZendeskTicketFieldOption {
+  name: string;
+  value: string;
+}
+
+export interface ZendeskTicketField {
+  id: number;
+  type: string;
+  title: string | null;
+  active: boolean;
+  required: boolean;
+  // Valid values for custom dropdown/tagger fields.
+  custom_field_options?: ZendeskTicketFieldOption[];
+  // Valid values for system fields (e.g. priority, type).
+  system_field_options?: ZendeskTicketFieldOption[];
+}
+
 export interface PaginationMeta {
   has_more: boolean;
   after_cursor: string | null;
@@ -226,6 +245,7 @@ export interface ZendeskListResponse<T> {
   translations?: T[];
   permission_groups?: T[];
   sla_policies?: T[];
+  ticket_fields?: T[];
   meta?: {
     has_more: boolean;
     after_cursor: string;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -14,6 +14,7 @@ import type {
   ZendeskSlaPolicy,
   ZendeskSlaSideloadEntry,
   ZendeskTicket,
+  ZendeskTicketField,
   ZendeskTranslation,
   ZendeskUser,
   ZendeskUserSegment,
@@ -71,6 +72,21 @@ export const formatSlaPolicy = (policy: ZendeskSlaPolicy): string => {
     conditions.length > 0 ? `- **Conditions**: ${conditions.join('; ')}` : '',
     targets.length > 0 ? '- **Targets**:' : '',
     ...targets,
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+export const formatTicketField = (field: ZendeskTicketField): string => {
+  // A field carries either custom_field_options (custom dropdowns/taggers) or
+  // system_field_options (system fields like priority); merge whichever applies.
+  const options = [...(field.custom_field_options ?? []), ...(field.system_field_options ?? [])];
+  return [
+    `## Ticket field: ${field.title ?? '(untitled)'} (${field.id}) [${field.type}]`,
+    `- **Active**: ${field.active ? 'yes' : 'no'} | **Required**: ${field.required ? 'yes' : 'no'}`,
+    options.length > 0
+      ? `- **Options**: ${options.map((o) => `${o.name} → ${o.value}`).join('; ')}`
+      : '',
   ]
     .filter(Boolean)
     .join('\n');

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -101,6 +101,16 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(textOf(result)).toContain('SLA contractuels fruggr - Bugs/Incidents');
       });
 
+      it('reaches list_ticket_fields over the wire and returns option values', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'list_ticket_fields',
+          arguments: {},
+        });
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('fruggr_classic');
+      });
+
       it('exposes one proxy per namespace in "namespace" mode', async () => {
         connected = await harness.connect(makeConfig({ mode: 'namespace' }));
         const { tools } = await connected.client.listTools();
@@ -132,6 +142,7 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         const names = toolNames((await connected.client.listTools()).tools);
 
         expect(names).toContain('get_current_user');
+        expect(names).toContain('list_ticket_fields');
         expect(names).not.toContain('create_ticket');
         expect(names).not.toContain('update_ticket');
       });

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -67,6 +67,42 @@ export const MOCK_SLA_SIDELOAD = {
   ],
 };
 
+// Ticket field definitions (GET /api/v2/ticket_fields). One active custom
+// dropdown (carries custom_field_options), one active system field (carries
+// system_field_options), and one inactive field to exercise the active_only
+// filter.
+export const MOCK_TICKET_FIELD_CUSTOM = {
+  id: 360000123,
+  type: 'tagger',
+  title: 'Product',
+  active: true,
+  required: false,
+  custom_field_options: [
+    { name: 'Fruggr Classic', value: 'fruggr_classic' },
+    { name: 'Fruggr IT', value: 'fruggr_it' },
+  ],
+};
+
+export const MOCK_TICKET_FIELD_SYSTEM = {
+  id: 25,
+  type: 'priority',
+  title: 'Priority',
+  active: true,
+  required: false,
+  system_field_options: [
+    { name: 'Low', value: 'low' },
+    { name: 'Urgent', value: 'urgent' },
+  ],
+};
+
+export const MOCK_TICKET_FIELD_INACTIVE = {
+  id: 360000999,
+  type: 'text',
+  title: 'Legacy reference',
+  active: false,
+  required: false,
+};
+
 export const MOCK_USER = {
   id: 9999,
   name: 'Test User',
@@ -329,6 +365,18 @@ export const handlers = [
   // SLA policies — the real endpoint returns the full config list with no
   // `count` wrapper, so omit it here to exercise the array-length fallback.
   http.get(`${BASE}/slas/policies`, () => HttpResponse.json({ sla_policies: [MOCK_SLA_POLICY] })),
+
+  // Ticket field definitions — the real endpoint returns system and custom
+  // fields (active and inactive) with no `count` wrapper.
+  http.get(`${BASE}/ticket_fields`, () =>
+    HttpResponse.json({
+      ticket_fields: [
+        MOCK_TICKET_FIELD_CUSTOM,
+        MOCK_TICKET_FIELD_SYSTEM,
+        MOCK_TICKET_FIELD_INACTIVE,
+      ],
+    }),
+  ),
 
   // Search
   http.get(`${BASE}/search`, ({ request }) => {

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -366,7 +366,7 @@ export const handlers = [
   // `count` wrapper, so omit it here to exercise the array-length fallback.
   http.get(`${BASE}/slas/policies`, () => HttpResponse.json({ sla_policies: [MOCK_SLA_POLICY] })),
 
-  // Ticket field definitions — the real endpoint returns system and custom
+  // Ticket field definitions: the real endpoint returns system and custom
   // fields (active and inactive) with no `count` wrapper.
   http.get(`${BASE}/ticket_fields`, () =>
     HttpResponse.json({

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -64,7 +64,7 @@ describe('groupByNamespace', () => {
     const ticketCount = grouped.get('tickets')?.length ?? 0;
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
-    expect(ticketCount).toBe(12); // 11 ticket tools + 1 search
+    expect(ticketCount).toBe(13); // 12 ticket tools + 1 search
     expect(hcCount).toBe(21);
     expect(userCount).toBe(5);
   });

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -21,9 +21,9 @@ const getAllText = (result: { content: Array<{ type: string; text?: string }> })
     .join('\n');
 
 describe('ticket tools', () => {
-  it('creates 11 tools (search_tickets lives here; the unified search is elsewhere)', () => {
+  it('creates 12 tools (search_tickets lives here; the unified search is elsewhere)', () => {
     const tools = createTicketTools(ctx);
-    expect(tools).toHaveLength(11);
+    expect(tools).toHaveLength(12);
   });
 
   describe('get_ticket', () => {
@@ -476,6 +476,40 @@ describe('ticket tools', () => {
       );
       expect(error.message).toMatch(/admin/i);
       expect(error.message).toMatch(/get_ticket|search_tickets/);
+    });
+  });
+
+  describe('list_ticket_fields', () => {
+    it('returns system and custom fields with their option values', async () => {
+      const tool = findTool('list_ticket_fields');
+      const result = await tool.handler({ active_only: true });
+      const text = result.content[0]?.text ?? '';
+      // Custom dropdown options (custom_field_options)
+      expect(text).toContain('Product');
+      expect(text).toContain('fruggr_classic');
+      // System field options (system_field_options)
+      expect(text).toContain('Priority');
+      expect(text).toContain('urgent');
+    });
+
+    it('hides inactive fields by default', async () => {
+      const tool = findTool('list_ticket_fields');
+      const result = await tool.handler({ active_only: true });
+      const text = result.content[0]?.text ?? '';
+      expect(text).not.toContain('Legacy reference');
+    });
+
+    it('includes inactive fields when active_only is false', async () => {
+      const tool = findTool('list_ticket_fields');
+      const result = await tool.handler({ active_only: false });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('Legacy reference');
+    });
+
+    it('has readOnly annotation', () => {
+      const tool = findTool('list_ticket_fields');
+      expect(tool.readOnly).toBe(true);
+      expect(tool.annotations.readOnlyHint).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a read-only `list_ticket_fields` tool (tickets namespace) backed by `GET /api/v2/ticket_fields`. It returns system and custom field definitions with their `id`, `type`, `active`/`required` flags and valid option values (`custom_field_options` + `system_field_options`), so the model can discover the field id and accepted values for the `custom_fields` of `create_ticket` / `update_ticket` instead of guessing. An `active_only` param (default `true`) hides archived/deactivated fields. The `custom_fields` descriptions of `create_ticket` / `update_ticket` now point to it.

Closes #119.

## Type of change
- [x] New feature

## Author checklist
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `README.md`

## Notes for the reviewer (human or AI)

Design choices, matching the guardrails in #119:
- **Scope**: returns both system and custom fields, mapping `custom_field_options` **and** `system_field_options` (the latter goes beyond the `yutamago/tokenless-zendesk-mcp` reference, which only maps custom options).
- **No client-facing pagination**: the endpoint returns the full reference list with no `count` wrapper, so this mirrors `list_sla_policies` (array-length fallback for the meta). `active_only` is applied server-side. If a tenant ever exceeds `MAX_PAGE_SIZE` (100) fields this would silently drop the overflow; called out here rather than papered over.
- **Naming**: `list_ticket_fields` follows the repo's `list_*` convention (cf. `list_sla_policies`).
- **Schema superset preserved**: `create_ticket` / `update_ticket` descriptions were only enriched (pointing at the new tool), never shortened; no field dropped or loosened.

## Functional validation plan

**Context.** The feature is the new `mcp__zendesk-local__list_ticket_fields` tool. The single call that exercises it is `list_ticket_fields` with (or without) `active_only`. The doc-loop change is metadata only: verify it via `tools/list` describing `create_ticket` / `update_ticket`, not by writing. Reviewed commit SHA to record: `git rev-parse HEAD`.

**Setup & prerequisites.** None beyond the ready environment (on-branch, server running and authenticated, tools loaded as `mcp__zendesk-local__*`, `--mode all`). No state to seed. A credential/egress error on any Zendesk round-trip is a `BLOCKED` finding, not a setup task. Observe results directly in the returned tool text and in the `tools/list` metadata.

| id | Validates | Manipulation | Tool call | Expected observable |
|----|-----------|--------------|-----------|---------------------|
| S1 | Tool exists, read-only, discoverable | none | `tools/list` | `list_ticket_fields` is present; its inputSchema exposes a boolean `active_only`; it is present under `--read-only` (unlike create/update). |
| S2 | Active fields + option values (custom **and** system) | none | `list_ticket_fields` (no args → `active_only` defaults true) | Non-error result listing the tenant's active fields. At least one custom dropdown/tagger field shows an `Options: name → value` line; at least one system field (e.g. Priority/Type) shows its option values too. No field marked inactive appears. |
| S3 | `active_only: false` includes inactive fields | none | `list_ticket_fields` with `{ "active_only": false }` | Result is a **superset** of S2: same active fields plus any archived/deactivated field(s) the tenant has (an `Active: no` line appears for at least one field, if the tenant has any inactive field; if none exist, note that and treat S3 as N/A). |
| S4 | Discovery → write loop (the #119 rationale) | Create a throwaway ticket first (do **not** reuse an existing ticket). | (a) `create_ticket` with a minimal subject/description → note the returned id; (b) pick a real `{ id, value }` from S2's output for a custom dropdown field; (c) `update_ticket` on the new ticket id with `custom_fields: [{ id, value }]`. | The `update_ticket` call succeeds (no 422 validation error). The value applied is one surfaced by `list_ticket_fields`, proving the loop. Record the created ticket id in the report. |
| S5 | Doc-loop metadata | none | `tools/list` | The `create_ticket` and `update_ticket` `custom_fields` parameter descriptions reference `list_ticket_fields` (no longer "your Zendesk admin settings"). |

**Long-running behaviours.** None; nothing time-based. The `active_only` filter, the system+custom option merge and the read-only exposure are already covered by unit tests (`tests/unit/tools/tickets.test.ts`) and integration tests (`tests/integration/core-scenarios.ts`) against MSW — the validator need not re-prove those in isolation; S2–S4 exercise them against the live tenant.

**Priorities.** S2 and S4 are the real user-facing paths (discover fields, then write a valid custom field) — do first. S1/S5 are quick metadata checks. S3 depends on the tenant having an inactive field.

**Reporting.** Post a PR comment (English) with a per-id verdict (OK / FAIL / BLOCKED / N/A) and the observed evidence (the relevant tool-output excerpt, the created ticket id for S4), plus an overall green/failing summary. Confirm the tested SHA matches the latest pushed commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only `list_ticket_fields` tool for viewing active ticket fields and valid option values.
  * Added an option to include inactive fields in the results.
  * Updated ticket creation and editing guidance to reference field definitions.

* **Documentation**
  * Documented the new tool in the available tools list.

* **Tests**
  * Added coverage for field listing, filtering, options, and read-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->