### PR TITLE
chore: add guardrails against duplicate issue work

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 - [ ] Tooling / CI
 
 ## Author checklist
+- [ ] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
 - [ ] `pnpm test` passes locally
 - [ ] `pnpm test:coverage` meets the thresholds
 - [ ] `pnpm check` is clean (lint + format)

--- a/.github/workflows/duplicate-issue-guard.yml
+++ b/.github/workflows/duplicate-issue-guard.yml
@@ -1,0 +1,124 @@
+name: Duplicate issue guard
+
+# Flags a PR whose linked issue is already closed as completed — the signature of
+# work done twice in parallel (see the "Claim before you build" rule in AGENTS.md).
+# It only warns; it never blocks a merge. `pull_request_target` runs with the base
+# repo's token so it can comment on PRs from forks; no PR head code is checked out
+# or executed here, so this stays safe.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const text = `${pr.title || ''}\n${pr.body || ''}`;
+
+            // GitHub closing keywords, same-repo `#<n>` references only.
+            const keyword = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]+#(\d+)/gi;
+            const referenced = [...new Set(
+              [...text.matchAll(keyword)].map((m) => Number(m[1])),
+            )];
+            if (referenced.length === 0) {
+              core.info('No "Closes #<n>" reference found; nothing to check.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const alreadyShipped = [];
+            for (const number of referenced) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: number,
+                });
+                // Skip PRs (the issues API returns them too) and only flag issues
+                // closed as *completed* — "not planned" is not a duplicate signal.
+                if (
+                  !issue.pull_request &&
+                  issue.state === 'closed' &&
+                  issue.state_reason === 'completed'
+                ) {
+                  alreadyShipped.push(number);
+                }
+              } catch (err) {
+                core.info(`Could not read #${number}: ${err.message}`);
+              }
+            }
+
+            if (alreadyShipped.length === 0) {
+              core.info('No linked issue is already closed as completed.');
+              return;
+            }
+
+            const label = 'possible-duplicate';
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: [label],
+              });
+            } catch (err) {
+              // Label may not exist yet — create it once, then retry.
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label,
+                  color: 'd93f0b',
+                  description: 'Linked issue is already closed as completed',
+                });
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  labels: [label],
+                });
+              } catch (inner) {
+                core.info(`Could not apply label: ${inner.message}`);
+              }
+            }
+
+            const marker = '<!-- duplicate-issue-guard -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            if (comments.some((c) => (c.body || '').includes(marker))) {
+              core.info('Already warned on this PR; not commenting again.');
+              return;
+            }
+
+            const list = alreadyShipped.map((n) => `#${n}`).join(', ');
+            const body = [
+              marker,
+              `⚠️ **Possible duplicate work.** This PR references ${list}, which ` +
+                'is already **closed as completed** — a merged PR likely shipped ' +
+                'it already.',
+              '',
+              'Before continuing, please confirm this is not redoing work that has ' +
+                'already landed (see the *Claim before you build* rule in ' +
+                '`AGENTS.md`). If a follow-up is genuinely needed, open a new issue ' +
+                'describing the delta and link that instead.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr.number,
+              body,
+            });

--- a/.github/workflows/duplicate-issue-guard.yml
+++ b/.github/workflows/duplicate-issue-guard.yml
@@ -87,12 +87,19 @@ jobs:
             }
 
             const marker = '<!-- duplicate-issue-guard -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner,
-              repo,
-              issue_number: pr.number,
-              per_page: 100,
-            });
+            let comments;
+            try {
+              const result = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              comments = result.data;
+            } catch (err) {
+              core.info(`Could not list comments: ${err.message}`);
+              return;
+            }
             if (comments.some((c) => (c.body || '').includes(marker))) {
               core.info('Already warned on this PR; not commenting again.');
               return;
@@ -110,9 +117,13 @@ jobs:
                 '`AGENTS.md`). If a follow-up is genuinely needed, open a new issue ' +
                 'describing the delta and link that instead.',
             ].join('\n');
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: pr.number,
-              body,
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body,
+              });
+            } catch (err) {
+              core.info(`Could not post warning comment: ${err.message}`);
+            }

--- a/.github/workflows/duplicate-issue-guard.yml
+++ b/.github/workflows/duplicate-issue-guard.yml
@@ -23,47 +23,58 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const text = `${pr.title || ''}\n${pr.body || ''}`;
-
-            // GitHub closing keywords, same-repo `#<n>` references only.
-            const keyword = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]+#(\d+)/gi;
-            const referenced = [...new Set(
-              [...text.matchAll(keyword)].map((m) => Number(m[1])),
-            )];
-            if (referenced.length === 0) {
-              core.info('No "Closes #<n>" reference found; nothing to check.');
-              return;
-            }
-
             const { owner, repo } = context.repo;
-            const alreadyShipped = [];
-            for (const number of referenced) {
-              try {
-                const { data: issue } = await github.rest.issues.get({
-                  owner,
-                  repo,
-                  issue_number: number,
-                });
-                // Skip PRs (the issues API returns them too) and only flag issues
-                // closed as *completed* — "not planned" is not a duplicate signal.
-                if (
-                  !issue.pull_request &&
-                  issue.state === 'closed' &&
-                  issue.state_reason === 'completed'
-                ) {
-                  alreadyShipped.push(number);
-                }
-              } catch (err) {
-                core.info(`Could not read #${number}: ${err.message}`);
-              }
-            }
 
-            if (alreadyShipped.length === 0) {
-              core.info('No linked issue is already closed as completed.');
+            // Ask GitHub which issues this PR closes rather than re-parsing
+            // closing keywords by hand: closingIssuesReferences already handles
+            // keyword casing, URL and cross-repo references, and matches exactly
+            // what a merge would close. Nodes are issues (never PRs). This runs
+            // on every PR open/edit, so a transient API error skips the advisory
+            // check rather than failing the run (red X) on an unrelated PR.
+            let linked;
+            try {
+              const { repository } = await github.graphql(
+                `query ($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      closingIssuesReferences(first: 20) {
+                        nodes { number state stateReason }
+                      }
+                    }
+                  }
+                }`,
+                { owner, repo, number: pr.number },
+              );
+              linked = repository.pullRequest.closingIssuesReferences.nodes;
+            } catch (err) {
+              core.info(`Could not read linked issues: ${err.message}`);
               return;
             }
 
+            // Only flag issues closed as *completed* — "not planned" is not a
+            // duplicate signal.
+            const alreadyShipped = linked
+              .filter((i) => i.state === 'CLOSED' && i.stateReason === 'COMPLETED')
+              .map((i) => i.number);
+            if (alreadyShipped.length === 0) {
+              core.info('No linked issue is already closed as completed; nothing to flag.');
+              return;
+            }
+
+            // Create the label if it does not exist yet (ignoring "already
+            // exists"), then apply it.
             const label = 'possible-duplicate';
+            try {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: label,
+                color: 'd93f0b',
+                description: 'Linked issue is already closed as completed',
+              });
+            } catch (err) {
+              core.info(`Label create skipped: ${err.message}`);
+            }
             try {
               await github.rest.issues.addLabels({
                 owner,
@@ -72,24 +83,7 @@ jobs:
                 labels: [label],
               });
             } catch (err) {
-              // Label may not exist yet — create it once, then retry.
-              try {
-                await github.rest.issues.createLabel({
-                  owner,
-                  repo,
-                  name: label,
-                  color: 'd93f0b',
-                  description: 'Linked issue is already closed as completed',
-                });
-                await github.rest.issues.addLabels({
-                  owner,
-                  repo,
-                  issue_number: pr.number,
-                  labels: [label],
-                });
-              } catch (inner) {
-                core.info(`Could not apply label: ${inner.message}`);
-              }
+              core.info(`Could not apply label: ${err.message}`);
             }
 
             const marker = '<!-- duplicate-issue-guard -->';

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,27 @@ documentation.
 
 Toolchain (Node 24 + pnpm 11) is the dev floor; the published package still runs on Node 20+ (a CI job exercises the packed tarball on Node 20).
 
+## Claim before you build — no duplicate work
+
+Before writing a single line for an issue, confirm nobody already did. Two
+contributors (or agents) shipping the same feature in parallel is pure waste and
+has happened here. Pre-flight, in order:
+
+1. **Re-read the issue live.** If it is closed as `completed` or carries a
+   `released` label, the work is done — stop. A merged PR already shipped it; do
+   not reopen the same ground.
+2. **Search PRs for the issue number** — open *and* closed/merged (`is:pr #<n>`,
+   plus the `Closes #<n>` / `Fixes #<n>` links on the issue). A merged PR means
+   ship-ed; an open PR means someone is mid-flight — coordinate, don't fork.
+3. **Claim it visibly.** Self-assign the issue and drop a one-line "picking this
+   up" comment, so the next person sees it is taken.
+4. **Open your PR as a draft early** — the earliest public WIP signal others can
+   see. This repo already defaults PRs to draft.
+
+If a merged/released PR already closed the issue and a follow-up is genuinely
+needed, open a *new* issue describing the delta rather than duplicating the old
+one.
+
 ## Architecture
 
 Standard MCP server under `src/` (entry `index.ts` → `server.ts`). Auth in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,24 +17,12 @@ Toolchain (Node 24 + pnpm 11) is the dev floor; the published package still runs
 
 ## Claim before you build — no duplicate work
 
-Before writing a single line for an issue, confirm nobody already did. Two
-contributors (or agents) shipping the same feature in parallel is pure waste and
-has happened here. Pre-flight, in order:
-
-1. **Re-read the issue live.** If it is closed as `completed` or carries a
-   `released` label, the work is done — stop. A merged PR already shipped it; do
-   not reopen the same ground.
-2. **Search PRs for the issue number** — open *and* closed/merged (`is:pr #<n>`,
-   plus the `Closes #<n>` / `Fixes #<n>` links on the issue). A merged PR means
-   ship-ed; an open PR means someone is mid-flight — coordinate, don't fork.
-3. **Claim it visibly.** Self-assign the issue and drop a one-line "picking this
-   up" comment, so the next person sees it is taken.
-4. **Open your PR as a draft early** — the earliest public WIP signal others can
-   see. This repo already defaults PRs to draft.
-
-If a merged/released PR already closed the issue and a follow-up is genuinely
-needed, open a *new* issue describing the delta rather than duplicating the old
-one.
+Parallel duplicate work has happened here. Before coding an issue: re-read it
+live (closed `completed` / `released` → it already shipped, stop); search open
+*and* merged PRs for its number (`is:pr #<n>`) — coordinate on an open one,
+don't fork; then self-assign, drop a "picking this up" comment, and open your PR
+as a draft early. Need a follow-up on already-shipped work? Open a *new* issue
+for the delta. Fuller checklist in `CONTRIBUTING.md`.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,22 @@ npx -y github:fruggr/zendesk-mcp-server#my-feature-branch <your-subdomain>
 Architecture, code style, submission bar and release workflow live in
 [`AGENTS.md`](AGENTS.md).
 
+## Before you start — avoid duplicate work
+
+Two people building the same feature in parallel is wasted effort, and it has
+happened here. Before writing any code for an issue:
+
+1. **Check the issue is still live.** If it is closed as *completed* or labelled
+   `released`, it already shipped — stop and, if a follow-up is needed, open a
+   new issue for the delta.
+2. **Search open *and* merged PRs for the issue number** (`is:pr #<n>`). A merged
+   PR means it is done; an open PR means someone is mid-flight — comment there
+   and coordinate instead of starting your own.
+3. **Claim it.** Self-assign the issue and leave a short "I'm picking this up"
+   comment so others see it is taken.
+4. **Open your PR as a draft as early as possible** — the earliest signal to
+   others that the work is in flight.
+
 ## Opening a pull request
 
 1. Fork the repository.
@@ -79,6 +95,8 @@ Architecture, code style, submission bar and release workflow live in
 The same checklist appears on the
 [PR template](.github/pull_request_template.md):
 
+- [ ] No open or merged PR already addresses the linked issue, and it is not
+      already closed as completed / `released`.
 - [ ] `pnpm test` passes locally.
 - [ ] `pnpm test:coverage` meets the thresholds.
 - [ ] `pnpm check` is clean (Biome lint + format).


### PR DESCRIPTION
## Summary

PR #147 re-implemented `list_ticket_fields` **the day after** #143 shipped the
same feature in v2.9.0 and closed #119 — duplicate work done in parallel because
the issue's "already done / released" state wasn't checked before starting. This
PR adds a pre-flight guardrail so it doesn't recur. No product/runtime code
changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [x] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [ ] `pnpm test` passes locally
- [ ] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [ ] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [ ] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`

_No `src/` or `tests/` code changed — this is docs + one CI workflow, so the test/coverage/typecheck items are N/A. `pnpm check` (Biome over `src/tests/scripts`) is clean._

## Notes for the reviewer (human or AI)

Three layers, all warn-only (nothing blocks a merge):

- **`AGENTS.md` / `CONTRIBUTING.md`** — a mandatory "Claim before you build"
  pre-work checklist: re-read the issue live (stop if closed `completed` /
  `released`), search open **and** merged PRs for its number, self-assign and
  drop a claim comment, open the PR as a draft early.
- **`pull_request_template.md` + CONTRIBUTING author checklist** — a checkbox
  confirming no open/merged PR already covers the linked issue.
- **`.github/workflows/duplicate-issue-guard.yml`** — on PR open/edit/reopen,
  parses `Closes/Fixes/Resolves #<n>` and, if that issue is already closed as
  *completed*, adds a `possible-duplicate` label and one warning comment.
  Design notes: uses `pull_request_target` (base-repo token) so it can comment
  on fork PRs without checking out untrusted head code; only fires on
  `state_reason === 'completed'` (not "not planned"); skips PR references;
  comments at most once via an HTML marker; creates the label on first use.
  Because `pull_request_target` runs the workflow from the **base** branch, it
  takes effect only once merged to `main`.

No functional validation plan: there is no runtime-observable product behaviour
here (docs + a CI-only workflow). The workflow logic is straightforward and was
YAML-validated locally.

https://claude.ai/code/session_01UoeEGQH5j6aAqu4sN75kmP

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoeEGQH5j6aAqu4sN75kmP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an automated check that flags pull requests linked to already completed issues.
  - Posts a warning and applies a `possible-duplicate` label when applicable.

- **Documentation**
  - Added contributor guidance for checking existing work and claiming tasks before development.
  - Updated pull request checklists to include duplicate-work verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->