### PR TITLE
docs: require closing keyword to auto-close issues on merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,15 @@
 ## Summary
 <!-- In 1-3 sentences, what does this PR change and why? -->
 
+## Linked issue
+<!-- If this PR resolves an issue, use a GitHub closing keyword so the issue
+     auto-closes when this PR is squash-merged into `main`:
+       Closes #123   (also accepted: Fixes #123 / Resolves #123)
+     A bare "#123", "Implements #123" or "Part of #123" references the issue
+     but does NOT close it. Keep the keyword in this description (GitHub reads
+     the PR body on squash merge). If this PR isn't tied to an issue, write "None". -->
+Closes #
+
 ## Type of change
 - [ ] Bug fix
 - [ ] New feature
@@ -10,6 +19,7 @@
 
 ## Author checklist
 - [ ] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
+- [ ] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
 - [ ] `pnpm test` passes locally
 - [ ] `pnpm test:coverage` meets the thresholds
 - [ ] `pnpm check` is clean (lint + format)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
      A bare "#123", "Implements #123" or "Part of #123" references the issue
      but does NOT close it. Keep the keyword in this description (GitHub reads
      the PR body on squash merge). If this PR isn't tied to an issue, write "None". -->
-Closes #
+Closes #<n>
 
 ## Type of change
 - [ ] Bug fix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@ Parallel duplicate work has happened here. Before coding an issue: re-read it
 live (closed `completed` / `released` → it already shipped, stop); search open
 *and* merged PRs for its number (`is:pr #<n>`) — coordinate on an open one,
 don't fork; then self-assign, drop a "picking this up" comment, and open your PR
-as a draft early. Need a follow-up on already-shipped work? Open a *new* issue
-for the delta. Fuller checklist in `CONTRIBUTING.md`.
+as a draft early. Link the issue in the PR **description** with a closing keyword
+(`Closes #<n>` — not `Implements`/bare `#<n>`, which don't close it) so it
+auto-closes on squash-merge to `main`. Need a follow-up on already-shipped work?
+Open a *new* issue for the delta. Fuller checklist in `CONTRIBUTING.md`.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,20 @@ happened here. Before writing any code for an issue:
 5. Make the author checklist below pass locally.
 6. Push your branch and open a PR against `main`.
 
+If the PR resolves an issue, link it in the PR **description** with a GitHub
+closing keyword so the issue closes automatically when the PR merges to `main`:
+
+```
+Closes #123
+```
+
+`close` / `closes` / `closed`, `fix` / `fixes` / `fixed` and
+`resolve` / `resolves` / `resolved` all work. A bare `#123`, `Implements #123`
+or `Part of #123` only *references* the issue — it does not close it. Keep the
+keyword in the PR body (not just the title): the default squash merge discards
+individual commit messages, but GitHub still reads closing keywords from the PR
+description.
+
 ## Author checklist
 
 The same checklist appears on the
@@ -97,6 +111,8 @@ The same checklist appears on the
 
 - [ ] No open or merged PR already addresses the linked issue, and it is not
       already closed as completed / `released`.
+- [ ] If the PR resolves an issue, its description links it with a closing
+      keyword (`Closes #<n>`) so it auto-closes on merge to `main`.
 - [ ] `pnpm test` passes locally.
 - [ ] `pnpm test:coverage` meets the thresholds.
 - [ ] `pnpm check` is clean (Biome lint + format).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ happened here. Before writing any code for an issue:
 If the PR resolves an issue, link it in the PR **description** with a GitHub
 closing keyword so the issue closes automatically when the PR merges to `main`:
 
-```
+```text
 Closes #123
 ```
 


### PR DESCRIPTION
## Summary
Documents the missing convention that leaves handled issues open: PRs must link the issue they resolve with a GitHub **closing keyword** (`Closes #<n>`) so it auto-closes on merge. Issues like #121 (shipped via #146) stayed open because the PR said `Implements #121` / `(#121)` — neither is a closing keyword, so GitHub never closed them.

## Linked issue
None — this is a process/documentation change, not tied to a tracked issue. (Meta: it's also a live example of the convention it documents — a real feature PR would put `Closes #<n>` here.)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [x] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released` (N/A — no linked issue)
- [x] If this PR resolves an issue, its description above links it with a closing keyword (N/A — no linked issue)
- [x] I have read the diff myself, line by line
- [ ] `pnpm test` / `pnpm check` / `pnpm typecheck` — N/A, docs-only change (no source, tests, or tool surface touched)
- [x] Documentation is updated where needed

## Notes for the reviewer (human or AI)

**Root cause.** GitHub only auto-closes a referenced issue when the PR carries a reserved closing keyword (`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`) directly before the number, *and* the PR merges into the default branch. The repo's PRs used `Implements #<n>` and bare `#<n>`, which only reference — hence issues piled up open despite being shipped and released.

**Why the PR body specifically.** The merge policy is squash merge, which discards individual commit messages. GitHub still honors closing keywords found in the PR **description**, so the guidance points authors there (not just the title).

Changes, all documentation, no runtime surface:
- `.github/pull_request_template.md` — new `## Linked issue` section prefilled with `Closes #` + an explanatory comment, and a checklist item to confirm the keyword is present.
- `CONTRIBUTING.md` — the rule in "Opening a pull request" and a matching author-checklist item.
- `AGENTS.md` — a one-line pointer in the "Claim before you build" issue-lifecycle section so coding agents apply it by default.

No functional validation plan: docs-only, no runtime-observable behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ff2utKT2mpgwRTwqYqdf8a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pull request instructions for linking and automatically closing related issues.
  * Added guidance to use closing keywords in pull request descriptions, with examples.
  * Updated author checklists to promote early draft pull requests and avoid duplicate work.
  * Clarified that bare issue references or “Implements” do not automatically close issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->