### PR TITLE
feat(tickets): add get_ticket_history for a ticket's change timeline

### DIFF
--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -15,6 +15,7 @@ out every `write` tool before the proxies are built.
 | Tool | Description | Mode |
 |------|-------------|------|
 | `get_ticket` | Retrieve a ticket by ID with optional comments and its live SLA state (resolved via a scoped search) | read |
+| `get_ticket_history` | Read a ticket's change history (audit trail) as a chronological, oldest-first timeline of who changed what and when — field changes as before → after with actor names, comment presence (not bodies), system noise filtered; cursor-paginated | read |
 | `get_ticket_attachments` | Download ticket attachments — images delivered as native multimodal content for the client's own model to analyze; oversize/over-limit images and non-images come back as text references | read |
 | `search_tickets` | Search tickets using Zendesk query syntax, with per-result SLA state | read |
 | `list_tickets` | List tickets with cursor-based pagination | read |

--- a/scripts/probe-audits-shape.ts
+++ b/scripts/probe-audits-shape.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env tsx
+/**
+ * Ground-truth capture for the Ticket Audits shape (issue #123 / get_ticket_history).
+ *
+ * The MCP tools only ever return *formatted text*, never the raw Zendesk JSON,
+ * so the exact shape the new get_ticket_history formatter depends on cannot be
+ * observed through them. This one-shot probe hits the live tenant directly and
+ * prints the RAW JSON (comment bodies redacted) for the sources the tool relies
+ * on, so the maintainer can confirm the implementation matches reality before
+ * trusting the rest of the validation plan:
+ *   - GET /api/v2/users/me.json                          (token identity)
+ *   - GET /api/v2/tickets/{id}/audits.json?page[size]=   (the audit trail)
+ *   - GET /api/v2/users/show_many.json?ids=              (author/assignee names)
+ *   - GET /api/v2/groups/show_many.json?ids=             (group names — least documented)
+ *
+ * It confirms the pieces the formatter assumes:
+ *   - the response envelope: `audits` array + `meta.{has_more,after_cursor}` (cursor pagination);
+ *   - each audit's `created_at`, `author_id`, `via.channel`, `events[]`;
+ *   - `Change`/`Create` events carrying `field_name` / `value` / `previous_value`
+ *     (strings, except `tags` = array and SLA metrics = `{minutes,...}` object);
+ *   - which event `type`s actually occur on this tenant (so the meaningful/noise
+ *     split is grounded, not guessed);
+ *   - that /users/show_many and /groups/show_many return `{users:[{id,name}]}` /
+ *     `{groups:[{id,name}]}`.
+ *
+ * Comment/voice bodies are redacted to "[redacted]" (the tool never renders them
+ * anyway), so there is minimal PII to scrub; ticket subjects are never printed.
+ *
+ * Usage (zero setup in an env where the zendesk-local MCP server is configured):
+ *   pnpm tsx scripts/probe-audits-shape.ts [ticket_id]
+ *
+ * Pass a ticket_id with a rich history (reassigned, status-changed), or omit it
+ * to let the probe pick the most-updated ticket it can find. Subdomain is read
+ * from ZENDESK_SUBDOMAIN, else the zendesk-local entry in .mcp.json; the token
+ * from ZENDESK_OAUTH_TOKEN, else the on-disk cached access token. Override:
+ *   ZENDESK_SUBDOMAIN=fruggr ZENDESK_OAUTH_TOKEN=<token> \
+ *     pnpm tsx scripts/probe-audits-shape.ts [ticket_id]
+ *
+ * Paste the output into a PR comment so the maintainer can align types, the
+ * meaningful-event set, and the test mocks to the tenant's real audit shape.
+ */
+import { readFileSync } from 'node:fs';
+import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';
+import { zendeskGet } from '../src/client/zendesk-api';
+
+const cliTicketId = process.argv[2];
+if (cliTicketId && !/^\d+$/.test(cliTicketId)) {
+  console.error(
+    'Usage: pnpm tsx scripts/probe-audits-shape.ts [ticket_id]\n' +
+      '  ticket_id (optional) must be numeric; omit it to auto-pick a recently-updated ticket.',
+  );
+  process.exit(1);
+}
+
+const resolveSubdomain = (): string => {
+  const fromEnv = process.env['ZENDESK_SUBDOMAIN'];
+  if (fromEnv) return fromEnv;
+  try {
+    const mcp = JSON.parse(readFileSync(new URL('../.mcp.json', import.meta.url), 'utf8'));
+    const sub = mcp?.mcpServers?.['zendesk-local']?.env?.ZENDESK_SUBDOMAIN;
+    if (typeof sub === 'string' && sub) return sub;
+  } catch {
+    // fall through to the error below
+  }
+  console.error(
+    'No Zendesk subdomain. Set ZENDESK_SUBDOMAIN, or run from a checkout whose ' +
+      '.mcp.json configures the zendesk-local server.',
+  );
+  process.exit(1);
+};
+
+const subdomain = resolveSubdomain();
+
+const resolveToken = (): string => {
+  const fromEnv = process.env['ZENDESK_OAUTH_TOKEN'];
+  if (fromEnv) return fromEnv;
+  const cached = loadToken(resolveTokenPath(subdomain));
+  if (cached?.accessToken) return cached.accessToken;
+  console.error(
+    `No token available. Export ZENDESK_OAUTH_TOKEN, or authenticate the server once for "${subdomain}" ` +
+      `so a token is cached at ${resolveTokenPath(subdomain)}.`,
+  );
+  process.exit(1);
+};
+
+const dump = (label: string, value: unknown): void => {
+  console.log(`\n===== ${label} =====`);
+  console.log(JSON.stringify(value, null, 2));
+};
+
+// Redact free-text bodies from an event so the shape is visible without PII.
+const redactEvent = (ev: unknown): unknown => {
+  const e = { ...(ev as Record<string, unknown>) };
+  for (const key of ['body', 'html_body', 'plain_body', 'recipients']) {
+    if (key in e) e[key] = '[redacted]';
+  }
+  return e;
+};
+
+const redactAudit = (audit: unknown): unknown => {
+  const a = { ...(audit as Record<string, unknown>) };
+  if (Array.isArray(a['events'])) a['events'] = a['events'].map(redactEvent);
+  return a;
+};
+
+// The user/group id fields a Change/Create value carries — mirrors the tool.
+const USER_FIELDS = new Set(['assignee_id', 'requester_id', 'submitter_id']);
+
+const main = async (): Promise<void> => {
+  const token = resolveToken();
+
+  // (0) Token identity — some audit detail is role-sensitive.
+  try {
+    const me = await zendeskGet<Record<string, unknown>>(subdomain, token, '/users/me');
+    const user = (me['user'] as Record<string, unknown> | undefined) ?? {};
+    dump('GET /users/me — token identity', {
+      id: user['id'],
+      role: user['role'],
+      role_type: user['role_type'],
+    });
+  } catch (e) {
+    console.log(`\n(could not read /users/me: ${e instanceof Error ? e.message : e})`);
+  }
+
+  // (1) Pick a target ticket. Prefer a CLI id; else the most-recently-updated
+  // ticket (likely to have a non-trivial history: reassignments, status moves).
+  let targetId = cliTicketId;
+  if (!targetId) {
+    try {
+      const search = await zendeskGet<{ results?: Array<Record<string, unknown>> }>(
+        subdomain,
+        token,
+        '/search',
+        { query: 'type:ticket order_by:updated_at sort:desc', per_page: '5' },
+      );
+      const first = (search.results ?? [])[0];
+      if (first?.['id'] != null) {
+        targetId = String(first['id']);
+        console.log(`\n-> No ticket_id passed; probing most-recently-updated ticket ${targetId}.`);
+      }
+    } catch (e) {
+      console.log(`\n(auto-pick failed: ${e instanceof Error ? e.message : e})`);
+    }
+  }
+  if (!targetId) {
+    console.error('\nNo ticket to probe (none passed and auto-pick found none). Pass a ticket_id.');
+    process.exit(1);
+  }
+
+  // (2) The audit trail — the envelope, the meta (cursor pagination), and the
+  // event shapes the formatter reads.
+  const audits = await zendeskGet<Record<string, unknown>>(
+    subdomain,
+    token,
+    `/tickets/${targetId}/audits`,
+    { 'page[size]': '100' },
+  );
+  dump('GET /tickets/{id}/audits — top-level keys', Object.keys(audits));
+  dump('audits meta (cursor pagination — expected has_more/after_cursor)', audits['meta']);
+
+  const list = Array.isArray(audits['audits'])
+    ? (audits['audits'] as Record<string, unknown>[])
+    : [];
+  console.log(`\n(${list.length} audits on the first page)`);
+
+  // First two audits verbatim (redacted) — the founding Create audit and the
+  // next update, so `created_at` / `author_id` / `via` / events are all visible.
+  dump('First 2 audits (comment bodies redacted)', list.slice(0, 2).map(redactAudit));
+
+  // Distinct event types across the page, plus one redacted sample per type, so
+  // the meaningful-vs-noise split (and the Change field_name/value/previous_value
+  // assumption) is grounded in what this tenant actually emits.
+  const byType = new Map<unknown, unknown>();
+  const fieldNames = new Set<unknown>();
+  const userIds = new Set<number>();
+  const groupIds = new Set<number>();
+  const addId = (set: Set<number>, raw: unknown): void => {
+    const n = Number(raw);
+    if (Number.isInteger(n) && n > 0) set.add(n);
+  };
+  for (const audit of list) {
+    addId(userIds, audit['author_id']);
+    const events = Array.isArray(audit['events'])
+      ? (audit['events'] as Record<string, unknown>[])
+      : [];
+    for (const ev of events) {
+      if (!byType.has(ev['type'])) byType.set(ev['type'], redactEvent(ev));
+      if (ev['type'] === 'Change' || ev['type'] === 'Create') {
+        fieldNames.add(ev['field_name']);
+        const field = ev['field_name'] as string;
+        if (USER_FIELDS.has(field)) {
+          addId(userIds, ev['value']);
+          addId(userIds, ev['previous_value']);
+        } else if (field === 'group_id') {
+          addId(groupIds, ev['value']);
+          addId(groupIds, ev['previous_value']);
+        }
+      }
+    }
+  }
+  dump('Distinct event `type`s on this page', [...byType.keys()]);
+  dump('One redacted sample per event type', [...byType.values()]);
+  dump('Distinct Change/Create field_names on this page', [...fieldNames]);
+
+  // (3) Name resolution endpoints — confirm the show_many shapes the tool joins
+  // against. /groups/show_many is the least-documented dependency.
+  if (userIds.size > 0) {
+    const users = await zendeskGet<Record<string, unknown>>(subdomain, token, '/users/show_many', {
+      ids: [...userIds].join(','),
+    });
+    dump('GET /users/show_many — top-level keys', Object.keys(users));
+    const arr = Array.isArray(users['users']) ? (users['users'] as Record<string, unknown>[]) : [];
+    dump(
+      'users show_many — {id,name} sample',
+      arr.slice(0, 3).map((u) => ({ id: u['id'], name: u['name'] })),
+    );
+  } else {
+    console.log('\n(no user ids referenced on this page; skipping /users/show_many)');
+  }
+
+  if (groupIds.size > 0) {
+    try {
+      const groups = await zendeskGet<Record<string, unknown>>(
+        subdomain,
+        token,
+        '/groups/show_many',
+        { ids: [...groupIds].join(',') },
+      );
+      dump('GET /groups/show_many — top-level keys', Object.keys(groups));
+      const arr = Array.isArray(groups['groups'])
+        ? (groups['groups'] as Record<string, unknown>[])
+        : [];
+      dump(
+        'groups show_many — {id,name} sample',
+        arr.slice(0, 3).map((g) => ({ id: g['id'], name: g['name'] })),
+      );
+    } catch (e) {
+      console.log(
+        `\n!!! /groups/show_many failed (${e instanceof Error ? e.message : e}). ` +
+          'The tool tolerates this (falls back to bare group ids), but flag it so the ' +
+          'endpoint/shape can be confirmed.',
+      );
+    }
+  } else {
+    console.log('\n(no group_id changes on this page; skipping /groups/show_many)');
+  }
+};
+
+main().catch((error) => {
+  console.error('probe-audits-shape failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/probe-audits-shape.ts
+++ b/scripts/probe-audits-shape.ts
@@ -88,18 +88,50 @@ const dump = (label: string, value: unknown): void => {
   console.log(JSON.stringify(value, null, 2));
 };
 
-// Redact free-text bodies from an event so the shape is visible without PII.
+// Free-text Change/Create fields whose value carries content (not shape) — their
+// before/after values are redacted so a captured payload never leaks them.
+const FREE_TEXT_FIELDS = new Set(['subject', 'description']);
+
+// Redact free-text content from an event so the shape stays visible without PII:
+// comment bodies/recipients, and the value/previous_value of free-text fields.
 const redactEvent = (ev: unknown): unknown => {
   const e = { ...(ev as Record<string, unknown>) };
   for (const key of ['body', 'html_body', 'plain_body', 'recipients']) {
     if (key in e) e[key] = '[redacted]';
   }
+  if (
+    (e['type'] === 'Change' || e['type'] === 'Create') &&
+    FREE_TEXT_FIELDS.has(String(e['field_name']))
+  ) {
+    if ('value' in e) e['value'] = '[redacted]';
+    if ('previous_value' in e) e['previous_value'] = '[redacted]';
+  }
   return e;
+};
+
+// Redact the audit `via.source` email addresses (from/to) that email-channel
+// tickets carry, while keeping `via.channel` and the rest of the shape.
+const redactVia = (via: unknown): unknown => {
+  if (!via || typeof via !== 'object') return via;
+  const v = { ...(via as Record<string, unknown>) };
+  const source = v['source'];
+  if (source && typeof source === 'object') {
+    const s = { ...(source as Record<string, unknown>) };
+    for (const dir of ['from', 'to']) {
+      const entry = s[dir];
+      if (entry && typeof entry === 'object' && 'address' in entry) {
+        s[dir] = { ...(entry as Record<string, unknown>), address: '[redacted]' };
+      }
+    }
+    v['source'] = s;
+  }
+  return v;
 };
 
 const redactAudit = (audit: unknown): unknown => {
   const a = { ...(audit as Record<string, unknown>) };
   if (Array.isArray(a['events'])) a['events'] = a['events'].map(redactEvent);
+  if ('via' in a) a['via'] = redactVia(a['via']);
   return a;
 };
 

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -16,7 +16,9 @@ import {
 } from '../constants';
 import type {
   PaginationMeta,
+  ZendeskAudit,
   ZendeskComment,
+  ZendeskGroup,
   ZendeskListResponse,
   ZendeskMacro,
   ZendeskMacroApplyComment,
@@ -27,6 +29,7 @@ import type {
   ZendeskTicketAttachment,
   ZendeskTicketField,
   ZendeskUpload,
+  ZendeskUser,
   ZendeskView,
   ZendeskViewCount,
   ZendeskViewCountManyResponse,
@@ -34,12 +37,17 @@ import type {
   ZendeskViewExecuteRow,
 } from '../types';
 import {
+  AUDIT_USER_VALUE_FIELDS,
+  type AuditNames,
+  auditHasMeaningfulEvent,
+  formatAudit,
   formatComment,
   formatFieldValue,
   formatList,
   formatMacro,
   formatSlaBlock,
   formatSlaPolicy,
+  formatTagDiff,
   formatTicket,
   formatTicketField,
   formatView,
@@ -310,6 +318,74 @@ const hydrateViewTickets = async (
   return ids.map((id) => byId.get(id)).filter((t): t is ZendeskTicket => t !== undefined);
 };
 
+// Collect the user and group ids referenced across a page of audits so their
+// names can be resolved in one batched call each: users = every audit author plus
+// assignee/requester/submitter change values; groups = group_id change values.
+const collectAuditIds = (audits: ZendeskAudit[]): { userIds: number[]; groupIds: number[] } => {
+  const userIds = new Set<number>();
+  const groupIds = new Set<number>();
+  const addId = (set: Set<number>, raw: unknown): void => {
+    const n = Number(raw);
+    if (Number.isInteger(n) && n > 0) set.add(n);
+  };
+  for (const audit of audits) {
+    addId(userIds, audit.author_id);
+    for (const event of audit.events) {
+      if (event.type !== 'Change' && event.type !== 'Create') continue;
+      const field = event.field_name;
+      if (!field) continue;
+      if (AUDIT_USER_VALUE_FIELDS.has(field)) {
+        addId(userIds, event.value);
+        addId(userIds, event.previous_value);
+      } else if (field === 'group_id') {
+        addId(groupIds, event.value);
+        addId(groupIds, event.previous_value);
+      }
+    }
+  }
+  return { userIds: [...userIds], groupIds: [...groupIds] };
+};
+
+// Resolve user and group ids to names via batched show_many look-ups (chunked to
+// the 100-id endpoint cap). Best-effort: a failed look-up degrades to id-only
+// rendering rather than failing the whole history — names are supplementary.
+const resolveAuditNames = async (
+  subdomain: string,
+  token: string,
+  userIds: number[],
+  groupIds: number[],
+): Promise<AuditNames> => {
+  const users = new Map<number, string>();
+  const groups = new Map<number, string>();
+  for (const batch of chunk(userIds, 100)) {
+    try {
+      const { users: list } = await zendeskGet<{ users: ZendeskUser[] }>(
+        subdomain,
+        token,
+        '/users/show_many',
+        { ids: batch.join(',') },
+      );
+      for (const u of list ?? []) users.set(u.id, u.name);
+    } catch {
+      // Best-effort: leave these ids unresolved (rendered as bare ids).
+    }
+  }
+  for (const batch of chunk(groupIds, 100)) {
+    try {
+      const { groups: list } = await zendeskGet<{ groups: ZendeskGroup[] }>(
+        subdomain,
+        token,
+        '/groups/show_many',
+        { ids: batch.join(',') },
+      );
+      for (const g of list ?? []) groups.set(g.id, g.name);
+    } catch {
+      // Best-effort: leave these ids unresolved (rendered as bare ids).
+    }
+  }
+  return { users, groups };
+};
+
 // Keys the generic field diff must not emit. Two reasons, both in this set:
 //   - `comment`/`fields`/`custom_fields` are routed to their own render paths, so
 //     the scalar loop skips them regardless of whether they changed.
@@ -350,19 +426,6 @@ const diffLine = (label: string, before: unknown, after: unknown): string | null
   const b = shownValue(before);
   const a = shownValue(after);
   return b === a ? null : `- **${label}**: ${b} → ${a}`;
-};
-
-// Tags diff as added/removed tokens rather than a full before/after list — that
-// is what a macro's `set_tags`/`remove_tags` actions actually express. Returns
-// null when the tag set is unchanged.
-const formatTagDiff = (before: unknown, after: unknown): string | null => {
-  const b = new Set(Array.isArray(before) ? before.map(String) : []);
-  const a = new Set(Array.isArray(after) ? after.map(String) : []);
-  const added = [...a].filter((t) => !b.has(t)).map((t) => `+${t}`);
-  const removed = [...b].filter((t) => !a.has(t)).map((t) => `-${t}`);
-  return added.length + removed.length === 0
-    ? null
-    : `- **tags**: ${[...added, ...removed].join(', ')}`;
 };
 
 // Preview a macro's effect on a ticket as a real before → after diff. The apply
@@ -476,7 +539,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Get Zendesk Ticket',
       description:
-        'Retrieve a Zendesk ticket by ID, including its live SLA state (per-metric stage and breach countdown) when an SLA policy applies, plus its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The per-ticket Show endpoint exposes no SLA, so the SLA block is resolved via a scoped search and may be absent for a very high-volume requester or a just-updated ticket; SLA targets and policy conditions live in list_sla_policies.',
+        'Retrieve a Zendesk ticket by ID, including its live SLA state (per-metric stage and breach countdown) when an SLA policy applies, plus its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The per-ticket Show endpoint exposes no SLA, so the SLA block is resolved via a scoped search and may be absent for a very high-volume requester or a just-updated ticket; SLA targets and policy conditions live in list_sla_policies. This returns the ticket as it stands now; for the history of changes behind that state (who changed what, and when), use get_ticket_history.',
       inputSchema: z.object({
         ticket_id: z
           .number()
@@ -521,6 +584,77 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           text += `\n\n---\n# Comments\n\n${comments.map(formatComment).join('\n\n')}`;
         }
         return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
+      },
+    },
+    {
+      name: 'get_ticket_history',
+      namespace: 'tickets',
+      readOnly: true,
+      title: 'Get Zendesk Ticket History',
+      description:
+        'Read a ticket\'s change history — its audit trail — as a chronological, oldest-first timeline of who changed what and when. Each entry shows the actor (name and id) and the channel, then the field changes that update carried (status, priority, assignee, group, tags, custom fields) as before → after, with assignee/requester/group ids resolved to names. Comments appear as one-line presence markers (public comment vs internal note added), not their text — fetch the bodies with get_ticket(include_comments=true). Purely system-generated events (trigger notifications, CCs, pushes) are filtered out, and an update carrying only those produces no entry, so the timeline stays a readable narrative rather than a raw log. Use it to answer "what happened on this ticket?", "why was it reassigned?" or "when did it go to pending?", reading oldest-first so the founding context is not missed. Read-only, and cursor-paginated oldest-first: pass the returned cursor to page a long-lived ticket toward its most recent changes.',
+      inputSchema: z.object({
+        ticket_id: z
+          .number()
+          .int()
+          .describe(
+            'Ticket ID — the numeric id of the ticket whose change history to read. Obtain it from search_tickets or list_tickets.',
+          ),
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe(
+            'Audits (ticket updates) per page (1-100, default 100). Each audit is one update to the ticket and may expand to several change lines; audits carrying only system events are dropped, so a page can render fewer entries than this.',
+          ),
+        cursor: z
+          .string()
+          .optional()
+          .describe(
+            'Pagination cursor from a previous response; omit for the first page. The timeline is ordered oldest-first, so paging forward moves toward the most recent changes.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { ticket_id, page_size, cursor } = params as {
+          ticket_id: number;
+          page_size: number;
+          cursor?: string;
+        };
+        const token = await getToken();
+        const response = await zendeskGet<ZendeskListResponse<ZendeskAudit>>(
+          subdomain,
+          token,
+          `/tickets/${ticket_id}/audits`,
+          buildCursorParams(page_size, cursor),
+        );
+        const audits = response.audits ?? [];
+        const meta = extractPaginationMeta(response, audits.length);
+        // Drop all-noise audits before resolving names and rendering, so a
+        // trigger-only update never triggers a look-up or an empty block.
+        const visible = audits.filter(auditHasMeaningfulEvent);
+        const { userIds, groupIds } = collectAuditIds(visible);
+        const names = await resolveAuditNames(subdomain, token, userIds, groupIds);
+        const blocks = visible
+          .map((audit) => formatAudit(audit, names))
+          .filter((block): block is string => block !== null);
+        if (blocks.length === 0) {
+          const text = meta.has_more
+            ? `No changes to show on this page of ticket #${ticket_id}'s history (system events only). More available (cursor: ${meta.after_cursor}).`
+            : `No change history to show for ticket #${ticket_id}.`;
+          return { content: [{ type: 'text', text }] };
+        }
+        const list = formatList(blocks, (block) => block, { ...meta, count: blocks.length });
+        return {
+          content: [{ type: 'text', text: `# Change history for ticket #${ticket_id}\n\n${list}` }],
+        };
       },
     },
     {

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -37,9 +37,8 @@ import type {
   ZendeskViewExecuteRow,
 } from '../types';
 import {
-  AUDIT_USER_VALUE_FIELDS,
+  AUDIT_ENTITY_FIELDS,
   type AuditNames,
-  auditHasMeaningfulEvent,
   formatAudit,
   formatComment,
   formatFieldValue,
@@ -332,15 +331,11 @@ const collectAuditIds = (audits: ZendeskAudit[]): { userIds: number[]; groupIds:
     addId(userIds, audit.author_id);
     for (const event of audit.events) {
       if (event.type !== 'Change' && event.type !== 'Create') continue;
-      const field = event.field_name;
-      if (!field) continue;
-      if (AUDIT_USER_VALUE_FIELDS.has(field)) {
-        addId(userIds, event.value);
-        addId(userIds, event.previous_value);
-      } else if (field === 'group_id') {
-        addId(groupIds, event.value);
-        addId(groupIds, event.previous_value);
-      }
+      const entity = event.field_name ? AUDIT_ENTITY_FIELDS[event.field_name] : undefined;
+      if (!entity) continue;
+      const set = entity === 'user' ? userIds : groupIds;
+      addId(set, event.value);
+      addId(set, event.previous_value);
     }
   }
   return { userIds: [...userIds], groupIds: [...groupIds] };
@@ -355,34 +350,32 @@ const resolveAuditNames = async (
   userIds: number[],
   groupIds: number[],
 ): Promise<AuditNames> => {
-  const users = new Map<number, string>();
-  const groups = new Map<number, string>();
-  for (const batch of chunk(userIds, 100)) {
-    try {
-      const { users: list } = await zendeskGet<{ users: ZendeskUser[] }>(
-        subdomain,
-        token,
-        '/users/show_many',
-        { ids: batch.join(',') },
-      );
-      for (const u of list ?? []) users.set(u.id, u.name);
-    } catch {
-      // Best-effort: leave these ids unresolved (rendered as bare ids).
+  // Resolve one entity kind to an id->name map via batched show_many (chunked to
+  // the 100-id endpoint cap). Best-effort: a failed batch leaves those ids
+  // unresolved (rendered as bare ids) rather than failing the whole history.
+  const resolve = async <T extends { id: number; name: string }>(
+    path: string,
+    key: 'users' | 'groups',
+    ids: number[],
+  ): Promise<Map<number, string>> => {
+    const map = new Map<number, string>();
+    for (const batch of chunk(ids, 100)) {
+      try {
+        const res = await zendeskGet<Record<string, T[]>>(subdomain, token, path, {
+          ids: batch.join(','),
+        });
+        for (const entity of res[key] ?? []) map.set(entity.id, entity.name);
+      } catch {
+        // Best-effort: leave these ids unresolved.
+      }
     }
-  }
-  for (const batch of chunk(groupIds, 100)) {
-    try {
-      const { groups: list } = await zendeskGet<{ groups: ZendeskGroup[] }>(
-        subdomain,
-        token,
-        '/groups/show_many',
-        { ids: batch.join(',') },
-      );
-      for (const g of list ?? []) groups.set(g.id, g.name);
-    } catch {
-      // Best-effort: leave these ids unresolved (rendered as bare ids).
-    }
-  }
+    return map;
+  };
+  // The two look-ups hit independent endpoints — run them concurrently.
+  const [users, groups] = await Promise.all([
+    resolve<ZendeskUser>('/users/show_many', 'users', userIds),
+    resolve<ZendeskGroup>('/groups/show_many', 'groups', groupIds),
+  ]);
   return { users, groups };
 };
 
@@ -637,12 +630,12 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         );
         const audits = response.audits ?? [];
         const meta = extractPaginationMeta(response, audits.length);
-        // Drop all-noise audits before resolving names and rendering, so a
-        // trigger-only update never triggers a look-up or an empty block.
-        const visible = audits.filter(auditHasMeaningfulEvent);
-        const { userIds, groupIds } = collectAuditIds(visible);
+        const { userIds, groupIds } = collectAuditIds(audits);
         const names = await resolveAuditNames(subdomain, token, userIds, groupIds);
-        const blocks = visible
+        // formatAudit returns null for an all-noise update (e.g. a trigger that
+        // only sent a notification), so this single filter both drops those and
+        // yields the rendered blocks.
+        const blocks = audits
           .map((audit) => formatAudit(audit, names))
           .filter((block): block is string => block !== null);
         if (blocks.length === 0) {
@@ -651,6 +644,8 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
             : `No change history to show for ticket #${ticket_id}.`;
           return { content: [{ type: 'text', text }] };
         }
+        // Count reflects rendered entries, not raw audits (all-noise updates drop
+        // out); pagination is preserved from the response. Same as get_view_tickets.
         const list = formatList(blocks, (block) => block, { ...meta, count: blocks.length });
         return {
           content: [{ type: 'text', text: `# Change history for ticket #${ticket_id}\n\n${list}` }],

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -585,7 +585,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Get Zendesk Ticket History',
       description:
-        'Read a ticket\'s change history — its audit trail — as a chronological, oldest-first timeline of who changed what and when. Each entry shows the actor (name and id) and the channel, then the field changes that update carried (status, priority, assignee, group, tags, custom fields) as before → after, with assignee/requester/group ids resolved to names. Comments appear as one-line presence markers (public comment vs internal note added), not their text — fetch the bodies with get_ticket(include_comments=true). Purely system-generated events (trigger notifications, CCs, pushes) are filtered out, and an update carrying only those produces no entry, so the timeline stays a readable narrative rather than a raw log. Use it to answer "what happened on this ticket?", "why was it reassigned?" or "when did it go to pending?", reading oldest-first so the founding context is not missed. Read-only, and cursor-paginated oldest-first: pass the returned cursor to page a long-lived ticket toward its most recent changes.',
+        'Read a ticket\'s change history — its audit trail — as a chronological, oldest-first timeline of who changed what and when. Each entry shows the actor (name and id) and the channel, then the field changes that update carried (status, priority, assignee, group, tags, custom fields) as before → after, with assignee/requester/group ids resolved to names. Comments appear as one-line presence markers (public comment vs internal note added), not their text — fetch the bodies with get_ticket(include_comments=true). Purely system-generated notification events (trigger emails, collaborator/CC notifications, pushes) are filtered out — note this filters notification delivery, not CC-list edits, which are shown as changes — and an update carrying only such events produces no entry, so the timeline stays a readable narrative rather than a raw log. Use it to answer "what happened on this ticket?", "why was it reassigned?" or "when did it go to pending?", reading oldest-first so the founding context is not missed. Read-only, and cursor-paginated oldest-first: pass the returned cursor to page a long-lived ticket toward its most recent changes.',
       inputSchema: z.object({
         ticket_id: z
           .number()
@@ -622,12 +622,27 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           cursor?: string;
         };
         const token = await getToken();
-        const response = await zendeskGet<ZendeskListResponse<ZendeskAudit>>(
-          subdomain,
-          token,
-          `/tickets/${ticket_id}/audits`,
-          buildCursorParams(page_size, cursor),
-        );
+        let response: ZendeskListResponse<ZendeskAudit>;
+        try {
+          response = await zendeskGet<ZendeskListResponse<ZendeskAudit>>(
+            subdomain,
+            token,
+            `/tickets/${ticket_id}/audits`,
+            buildCursorParams(page_size, cursor),
+          );
+        } catch (error) {
+          // The Ticket Audits API requires the global `read` OAuth scope; a
+          // narrower scope (e.g. tickets:read) returns 403 here even though it
+          // works for the other ticket tools. Rewrite the generic error into
+          // guidance the user can act on, mirroring the SLA/view handlers.
+          if (error instanceof ZendeskApiError && error.status === 403) {
+            throw new Error(
+              "get_ticket_history reads the Ticket Audits API (GET /tickets/{id}/audits), which Zendesk gates behind the global 'read' OAuth scope. The current token lacks it (HTTP 403) -- a narrower scope such as tickets:read can read tickets and comments but not their audit history. Re-authenticate with the global read scope to use this tool.",
+              { cause: error },
+            );
+          }
+          throw error;
+        }
         const audits = response.audits ?? [];
         const meta = extractPaginationMeta(response, audits.length);
         const { userIds, groupIds } = collectAuditIds(audits);

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,40 @@ export interface ZendeskComment {
   attachments?: ZendeskTicketAttachment[];
 }
 
+// GET /api/v2/tickets/{id}/audits — the immutable, chronological record of every
+// update to a ticket. Each audit is one update; its `events` list the individual
+// changes/comments that update carried. `Change`/`Create` events expose
+// `field_name`/`value`/`previous_value` (the before→after of a field); comment
+// events carry `public` (and a body we deliberately do not render — see
+// get_ticket_history). Values are strings, except `tags` (array) and SLA-metric
+// fields (object). Many event types are system noise and are filtered out.
+export interface ZendeskAuditEvent {
+  id: number;
+  type: string;
+  field_name?: string;
+  value?: unknown;
+  previous_value?: unknown;
+  public?: boolean;
+  author_id?: number;
+  body?: string;
+}
+
+export interface ZendeskAudit {
+  id: number;
+  ticket_id: number;
+  created_at: string;
+  author_id: number;
+  via?: { channel?: string };
+  events: ZendeskAuditEvent[];
+}
+
+// Minimal Group shape — only what get_ticket_history needs to resolve a
+// group_id change to a readable name (GET /api/v2/groups/show_many).
+export interface ZendeskGroup {
+  id: number;
+  name: string;
+}
+
 export interface ZendeskUpload {
   token: string;
   expires_at: string;
@@ -362,6 +396,7 @@ export interface ZendeskListResponse<T> {
   categories?: T[];
   sections?: T[];
   comments?: T[];
+  audits?: T[];
   translations?: T[];
   permission_groups?: T[];
   sla_policies?: T[];

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -258,7 +258,11 @@ export interface AuditNames {
 }
 
 const withName = (id: unknown, names: Map<number, string>): string => {
-  const name = names.get(Number(id));
+  const n = Number(id);
+  // Zendesk attributes automation/trigger-driven updates to the system actor
+  // (author_id -1), which has no user record to resolve — label it plainly.
+  if (n === -1) return 'System (-1)';
+  const name = names.get(n);
   return name ? `${name} (${id})` : String(id);
 };
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -221,28 +221,15 @@ export const formatTagDiff = (before: unknown, after: unknown): string | null =>
     : `- **tags**: ${[...added, ...removed].join(', ')}`;
 };
 
-// A ticket audit's meaningful event types — the human/agent-driven changes worth
-// putting on a timeline. Everything else (Notification, Cc, Push, SmsNotification,
-// OrganizationActivity, Error, and other system bookkeeping) is noise and is
-// dropped so the history reads as a narrative, not a log.
-const MEANINGFUL_AUDIT_EVENTS = new Set([
-  'Create',
-  'Change',
-  'Comment',
-  'VoiceComment',
-  'CommentPrivacyChange',
-  'SatisfactionRating',
-  'FollowersChange',
-  'EmailCcChange',
-]);
-
-// Whether an audit carries at least one meaningful event — the cheap predicate
-// used to collect id look-ups and to drop all-noise audits before rendering.
-export const auditHasMeaningfulEvent = (audit: ZendeskAudit): boolean =>
-  audit.events.some((e) => MEANINGFUL_AUDIT_EVENTS.has(e.type));
-
-// Change fields whose value is a user id and reads far better as a name.
-export const AUDIT_USER_VALUE_FIELDS = new Set(['assignee_id', 'requester_id', 'submitter_id']);
+// Audit Change/Create fields whose value is an entity id, and which entity kind
+// it resolves to. The single source of truth for both id collection (what to
+// look up) and rendering (which name map to use), so the two never drift.
+export const AUDIT_ENTITY_FIELDS: Record<string, 'user' | 'group'> = {
+  assignee_id: 'user',
+  requester_id: 'user',
+  submitter_id: 'user',
+  group_id: 'group',
+};
 
 // On a Create audit, render only these founding facts instead of every column
 // Zendesk sets at creation (which would bury the timeline). Post-creation Changes
@@ -280,8 +267,9 @@ const withName = (id: unknown, names: Map<number, string>): string => {
 // formatFieldValue. Returns '' for an empty/absent side.
 const renderAuditValue = (field: string, value: unknown, names: AuditNames): string => {
   if (value === null || value === undefined || value === '') return '';
-  if (AUDIT_USER_VALUE_FIELDS.has(field)) return withName(value, names.users);
-  if (field === 'group_id') return withName(value, names.groups);
+  const entity = AUDIT_ENTITY_FIELDS[field];
+  if (entity === 'user') return withName(value, names.users);
+  if (entity === 'group') return withName(value, names.groups);
   if (typeof value === 'object' && !Array.isArray(value) && 'minutes' in value) {
     const { minutes } = value as { minutes?: unknown };
     if (typeof minutes === 'number') return `${minutes} min`;
@@ -289,28 +277,37 @@ const renderAuditValue = (field: string, value: unknown, names: AuditNames): str
   return formatFieldValue(value);
 };
 
+// A Create event's founding fact: only whitelisted fields, rendered single-sided
+// (there is no "before"). Returns null for a non-whitelisted or empty field.
+const renderCreateEvent = (event: ZendeskAuditEvent, names: AuditNames): string | null => {
+  const field = event.field_name;
+  if (!field || !AUDIT_CREATE_FIELDS.has(field)) return null;
+  if (field === 'tags') {
+    const tags = Array.isArray(event.value) ? event.value.map(String) : [];
+    return tags.length > 0 ? `- **tags**: ${tags.join(', ')}` : null;
+  }
+  const value = renderAuditValue(field, event.value, names);
+  return value === '' ? null : `- **${AUDIT_FIELD_LABELS[field] ?? field}**: ${value}`;
+};
+
+// A post-creation Change: any field, rendered as before → after. Returns null
+// when the value did not actually change after rendering.
+const renderChangeEvent = (event: ZendeskAuditEvent, names: AuditNames): string | null => {
+  const field = event.field_name;
+  if (!field) return null;
+  if (field === 'tags') return formatTagDiff(event.previous_value, event.value);
+  const after = renderAuditValue(field, event.value, names);
+  const before = renderAuditValue(field, event.previous_value, names);
+  if (before === after) return null;
+  return `- **${AUDIT_FIELD_LABELS[field] ?? field}**: ${before || '(none)'} → ${after || '(none)'}`;
+};
+
 const renderAuditEvent = (event: ZendeskAuditEvent, names: AuditNames): string | null => {
   switch (event.type) {
     case 'Create':
-    case 'Change': {
-      const field = event.field_name;
-      if (!field) return null;
-      const isCreate = event.type === 'Create';
-      if (isCreate && !AUDIT_CREATE_FIELDS.has(field)) return null;
-      if (field === 'tags') {
-        if (isCreate) {
-          const tags = Array.isArray(event.value) ? event.value.map(String) : [];
-          return tags.length > 0 ? `- **tags**: ${tags.join(', ')}` : null;
-        }
-        return formatTagDiff(event.previous_value, event.value);
-      }
-      const label = AUDIT_FIELD_LABELS[field] ?? field;
-      const after = renderAuditValue(field, event.value, names);
-      if (isCreate) return after === '' ? null : `- **${label}**: ${after}`;
-      const before = renderAuditValue(field, event.previous_value, names);
-      if (before === after) return null;
-      return `- **${label}**: ${before || '(none)'} → ${after || '(none)'}`;
-    }
+      return renderCreateEvent(event, names);
+    case 'Change':
+      return renderChangeEvent(event, names);
     case 'Comment':
     case 'VoiceComment':
       // Presence only — the body lives on get_ticket(include_comments), so the

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -3,6 +3,8 @@ import type {
   PaginationMeta,
   ZendeskArticle,
   ZendeskArticleAttachment,
+  ZendeskAudit,
+  ZendeskAuditEvent,
   ZendeskCategory,
   ZendeskComment,
   ZendeskContentTag,
@@ -203,6 +205,142 @@ export const formatComment = (comment: ZendeskComment): string => {
   }
   lines.push('', comment.body);
   return lines.join('\n');
+};
+
+// Tags rendered as added/removed tokens (`+new`, `-gone`) rather than a full
+// before/after list — that is what tag changes actually express. Returns null
+// when the set is unchanged. Shared by the macro preview diff and the audit
+// history timeline.
+export const formatTagDiff = (before: unknown, after: unknown): string | null => {
+  const b = new Set(Array.isArray(before) ? before.map(String) : []);
+  const a = new Set(Array.isArray(after) ? after.map(String) : []);
+  const added = [...a].filter((t) => !b.has(t)).map((t) => `+${t}`);
+  const removed = [...b].filter((t) => !a.has(t)).map((t) => `-${t}`);
+  return added.length + removed.length === 0
+    ? null
+    : `- **tags**: ${[...added, ...removed].join(', ')}`;
+};
+
+// A ticket audit's meaningful event types — the human/agent-driven changes worth
+// putting on a timeline. Everything else (Notification, Cc, Push, SmsNotification,
+// OrganizationActivity, Error, and other system bookkeeping) is noise and is
+// dropped so the history reads as a narrative, not a log.
+const MEANINGFUL_AUDIT_EVENTS = new Set([
+  'Create',
+  'Change',
+  'Comment',
+  'VoiceComment',
+  'CommentPrivacyChange',
+  'SatisfactionRating',
+  'FollowersChange',
+  'EmailCcChange',
+]);
+
+// Whether an audit carries at least one meaningful event — the cheap predicate
+// used to collect id look-ups and to drop all-noise audits before rendering.
+export const auditHasMeaningfulEvent = (audit: ZendeskAudit): boolean =>
+  audit.events.some((e) => MEANINGFUL_AUDIT_EVENTS.has(e.type));
+
+// Change fields whose value is a user id and reads far better as a name.
+export const AUDIT_USER_VALUE_FIELDS = new Set(['assignee_id', 'requester_id', 'submitter_id']);
+
+// On a Create audit, render only these founding facts instead of every column
+// Zendesk sets at creation (which would bury the timeline). Post-creation Changes
+// are never filtered this way — every field change is shown.
+const AUDIT_CREATE_FIELDS = new Set([
+  'status',
+  'priority',
+  'type',
+  'assignee_id',
+  'group_id',
+  'subject',
+  'tags',
+]);
+
+const AUDIT_FIELD_LABELS: Record<string, string> = {
+  assignee_id: 'assignee',
+  requester_id: 'requester',
+  submitter_id: 'submitter',
+  group_id: 'group',
+};
+
+// id -> display name maps resolved by the caller (batched user/group look-ups).
+export interface AuditNames {
+  users: Map<number, string>;
+  groups: Map<number, string>;
+}
+
+const withName = (id: unknown, names: Map<number, string>): string => {
+  const name = names.get(Number(id));
+  return name ? `${name} (${id})` : String(id);
+};
+
+// A Change/Create field value rendered for the timeline: user/group ids resolved
+// to "Name (id)", SLA-metric objects reduced to their minutes, everything else via
+// formatFieldValue. Returns '' for an empty/absent side.
+const renderAuditValue = (field: string, value: unknown, names: AuditNames): string => {
+  if (value === null || value === undefined || value === '') return '';
+  if (AUDIT_USER_VALUE_FIELDS.has(field)) return withName(value, names.users);
+  if (field === 'group_id') return withName(value, names.groups);
+  if (typeof value === 'object' && !Array.isArray(value) && 'minutes' in value) {
+    const { minutes } = value as { minutes?: unknown };
+    if (typeof minutes === 'number') return `${minutes} min`;
+  }
+  return formatFieldValue(value);
+};
+
+const renderAuditEvent = (event: ZendeskAuditEvent, names: AuditNames): string | null => {
+  switch (event.type) {
+    case 'Create':
+    case 'Change': {
+      const field = event.field_name;
+      if (!field) return null;
+      const isCreate = event.type === 'Create';
+      if (isCreate && !AUDIT_CREATE_FIELDS.has(field)) return null;
+      if (field === 'tags') {
+        if (isCreate) {
+          const tags = Array.isArray(event.value) ? event.value.map(String) : [];
+          return tags.length > 0 ? `- **tags**: ${tags.join(', ')}` : null;
+        }
+        return formatTagDiff(event.previous_value, event.value);
+      }
+      const label = AUDIT_FIELD_LABELS[field] ?? field;
+      const after = renderAuditValue(field, event.value, names);
+      if (isCreate) return after === '' ? null : `- **${label}**: ${after}`;
+      const before = renderAuditValue(field, event.previous_value, names);
+      if (before === after) return null;
+      return `- **${label}**: ${before || '(none)'} → ${after || '(none)'}`;
+    }
+    case 'Comment':
+    case 'VoiceComment':
+      // Presence only — the body lives on get_ticket(include_comments), so the
+      // timeline attributes the reply without duplicating (or bloating with) it.
+      return `- ${event.public === false ? 'Internal note' : 'Public comment'} added`;
+    case 'CommentPrivacyChange':
+      return '- Comment visibility changed';
+    case 'FollowersChange':
+      return '- Followers changed';
+    case 'EmailCcChange':
+      return '- Email CCs changed';
+    case 'SatisfactionRating':
+      return '- Satisfaction rating recorded';
+    default:
+      return null;
+  }
+};
+
+// One audit rendered as a timeline block: a heading (when — who — channel) plus a
+// line per meaningful change. Returns null when the audit carries only filtered
+// system-noise events, so an all-noise update (e.g. a trigger that just sent a
+// notification) produces no block rather than an empty one.
+export const formatAudit = (audit: ZendeskAudit, names: AuditNames): string | null => {
+  const lines = audit.events
+    .map((e) => renderAuditEvent(e, names))
+    .filter((l): l is string => l !== null);
+  if (lines.length === 0) return null;
+  const channel = audit.via?.channel ? ` via ${audit.via.channel}` : '';
+  const heading = `### ${audit.created_at} — ${withName(audit.author_id, names.users)}${channel}`;
+  return [heading, ...lines].join('\n');
 };
 
 export const formatUser = (user: ZendeskUser): string =>

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -163,6 +163,18 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(textOf(result)).toContain('Ticket #1');
       });
 
+      it("reads a ticket's change history over the wire", async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'get_ticket_history',
+          arguments: { ticket_id: 1 },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('Change history for ticket #1');
+        expect(textOf(result)).toContain('**status**: new → open');
+      });
+
       it('uploads and attaches a file when posting a public comment', async () => {
         connected = await harness.connect(makeConfig({ mode: 'all' }));
         const result = await connected.client.callTool({

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -340,6 +340,65 @@ export const MOCK_COMMENT = {
 
 // Uploads API response (POST /uploads). The token is what gets carried on a
 // comment via comment.uploads; subsequent files aggregate under it via ?token=.
+// A group, minimal shape used to resolve a group_id change to a name.
+export const MOCK_GROUP = { id: 300, name: 'Support' };
+
+// Ticket audits (GET /tickets/:id/audits). Three updates that together exercise
+// the timeline: a Create audit (founding facts + initial comment presence), a
+// Change audit (status/assignee/group/tags before→after + an internal note + a
+// system Notification that must be filtered), and an all-noise audit that must
+// render no block at all.
+export const MOCK_AUDIT_CREATE = {
+  id: 9001,
+  ticket_id: 1,
+  created_at: '2026-01-01T00:00:00Z',
+  author_id: 200,
+  via: { channel: 'web' },
+  events: [
+    { id: 1, type: 'Create', field_name: 'status', value: 'new' },
+    { id: 2, type: 'Create', field_name: 'priority', value: 'normal' },
+    { id: 3, type: 'Create', field_name: 'subject', value: 'Test ticket' },
+    { id: 4, type: 'Comment', body: 'Initial request body', public: true, author_id: 200 },
+    // Not in the Create whitelist — must be dropped from the founding block.
+    { id: 5, type: 'Create', field_name: 'custom_status_id', value: '1' },
+  ],
+};
+
+export const MOCK_AUDIT_CHANGE = {
+  id: 9002,
+  ticket_id: 1,
+  created_at: '2026-01-02T00:00:00Z',
+  author_id: 100,
+  via: { channel: 'web' },
+  events: [
+    { id: 6, type: 'Change', field_name: 'status', value: 'open', previous_value: 'new' },
+    { id: 7, type: 'Change', field_name: 'assignee_id', value: '100', previous_value: null },
+    { id: 8, type: 'Change', field_name: 'group_id', value: '300', previous_value: null },
+    {
+      id: 9,
+      type: 'Change',
+      field_name: 'tags',
+      value: ['test', 'mock', 'urgent'],
+      previous_value: ['test', 'mock'],
+    },
+    { id: 10, type: 'Comment', body: 'internal note body', public: false, author_id: 100 },
+    // System noise — must not surface on the timeline.
+    { id: 11, type: 'Notification', body: 'email sent to requester' },
+  ],
+};
+
+export const MOCK_AUDIT_NOISE = {
+  id: 9003,
+  ticket_id: 1,
+  created_at: '2026-01-03T00:00:00Z',
+  author_id: 999,
+  via: { channel: 'rule' },
+  events: [
+    { id: 12, type: 'Notification', body: 'trigger fired' },
+    { id: 13, type: 'Push', value: 'external' },
+  ],
+};
+
 export const MOCK_UPLOAD = {
   token: 'mock-upload-token',
   expires_at: '2026-01-01T01:00:00Z',
@@ -349,6 +408,15 @@ export const MOCK_UPLOAD = {
 
 // OAuth token endpoint used by the browser PKCE flow. Opt-in per test via
 // mswServer.use() so the OAuth roundtrip mock stays centralized here too.
+// Opt-in via mswServer.use(): a ticket-audits page that reports more to come, so
+// the cursor/"More available" footer of get_ticket_history can be asserted.
+export const auditsMorePageHandler = http.get(`${BASE}/tickets/:id/audits`, () =>
+  HttpResponse.json({
+    audits: [MOCK_AUDIT_CHANGE],
+    meta: { has_more: true, after_cursor: 'next-audit-cursor' },
+  }),
+);
+
 export const oauthTokenHandler = http.post('https://testsubdomain.zendesk.com/oauth/tokens', () =>
   HttpResponse.json({ access_token: 'token-abc', token_type: 'bearer', scope: 'read write' }),
 );
@@ -441,6 +509,13 @@ export const handlers = [
     return HttpResponse.json({ ticket: { ...MOCK_TICKET, id } });
   }),
   http.get(`${BASE}/tickets/:id/comments`, () => HttpResponse.json({ comments: [MOCK_COMMENT] })),
+  http.get(`${BASE}/tickets/:id/audits`, ({ params }) => {
+    if (params['id'] === '404') return HttpResponse.json({}, { status: 404 });
+    return HttpResponse.json({
+      audits: [MOCK_AUDIT_CREATE, MOCK_AUDIT_CHANGE, MOCK_AUDIT_NOISE],
+      meta: { has_more: false, after_cursor: '' },
+    });
+  }),
   http.get(`${BASE}/attachments/:id`, ({ params }) => {
     const id = Number(params['id']);
     if (id === MOCK_TICKET_ATTACHMENT_IMAGE.id) {
@@ -526,8 +601,26 @@ export const handlers = [
     });
   }),
 
-  // Users
+  // Users. show_many is registered before `/users/:id` so it hits its own
+  // handler instead of matching `:id` = 'show_many'. Both show_many endpoints
+  // echo a deterministic `<Entity> <id>` name so name resolution is assertable.
   http.get(`${BASE}/users/me`, () => HttpResponse.json({ user: MOCK_USER })),
+  http.get(`${BASE}/users/show_many`, ({ request }) => {
+    const ids = (new URL(request.url).searchParams.get('ids') ?? '')
+      .split(',')
+      .filter(Boolean)
+      .map(Number);
+    return HttpResponse.json({
+      users: ids.map((id) => ({ ...MOCK_USER, id, name: `User ${id}` })),
+    });
+  }),
+  http.get(`${BASE}/groups/show_many`, ({ request }) => {
+    const ids = (new URL(request.url).searchParams.get('ids') ?? '')
+      .split(',')
+      .filter(Boolean)
+      .map(Number);
+    return HttpResponse.json({ groups: ids.map((id) => ({ id, name: `Group ${id}` })) });
+  }),
   http.get(`${BASE}/users/:id`, ({ params }) =>
     HttpResponse.json({ user: { ...MOCK_USER, id: Number(params['id']) } }),
   ),

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -64,7 +64,7 @@ describe('groupByNamespace', () => {
     const ticketCount = grouped.get('tickets')?.length ?? 0;
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
-    expect(ticketCount).toBe(17); // 16 ticket tools + 1 search
+    expect(ticketCount).toBe(18); // 17 ticket tools + 1 search
     expect(hcCount).toBe(22);
     expect(userCount).toBe(5);
   });

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -159,6 +159,16 @@ describe('ticket tools', () => {
       expect(text).toContain('**group**: (none) → 300');
     });
 
+    it('rewrites a 403 into actionable OAuth-scope guidance', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/audits', () =>
+          HttpResponse.json({}, { status: 403 }),
+        ),
+      );
+      const tool = findTool('get_ticket_history');
+      await expect(tool.handler({ ticket_id: 1, page_size: 100 })).rejects.toThrow(/global 'read'/);
+    });
+
     it('returns a clear message when the ticket has no change history', async () => {
       mswServer.use(
         http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/audits', () =>

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -2,7 +2,13 @@ import { HttpResponse, http } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createTicketTools } from '../../../src/tools/tickets';
-import { MOCK_SLA_SIDELOAD, MOCK_TICKET, MOCK_UPLOAD, MOCK_VIEW } from '../../msw-handlers';
+import {
+  auditsMorePageHandler,
+  MOCK_SLA_SIDELOAD,
+  MOCK_TICKET,
+  MOCK_UPLOAD,
+  MOCK_VIEW,
+} from '../../msw-handlers';
 import { mswServer } from '../../setup';
 
 const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
@@ -21,9 +27,9 @@ const getAllText = (result: { content: Array<{ type: string; text?: string }> })
     .join('\n');
 
 describe('ticket tools', () => {
-  it('creates 16 tools (search_tickets lives here; the unified search is elsewhere)', () => {
+  it('creates 17 tools (search_tickets lives here; the unified search is elsewhere)', () => {
     const tools = createTicketTools(ctx);
-    expect(tools).toHaveLength(16);
+    expect(tools).toHaveLength(17);
   });
 
   describe('get_ticket', () => {
@@ -93,6 +99,79 @@ describe('ticket tools', () => {
 
     it('has readOnly annotation', () => {
       const tool = findTool('get_ticket');
+      expect(tool.annotations.readOnlyHint).toBe(true);
+    });
+  });
+
+  describe('get_ticket_history', () => {
+    it('renders a chronological timeline with resolved actor names', async () => {
+      const tool = findTool('get_ticket_history');
+      const result = await tool.handler({ ticket_id: 1, page_size: 100 });
+      const text = getAllText(result);
+      expect(text).toContain('Change history for ticket #1');
+      // Actors resolved to name (id) via the batched show_many look-up.
+      expect(text).toContain('User 200 (200)');
+      expect(text).toContain('**status**: new → open');
+      expect(text).toContain('**assignee**: (none) → User 100 (100)');
+      expect(text).toContain('**group**: (none) → Group 300 (300)');
+      expect(text).toContain('**tags**: +urgent');
+    });
+
+    it('shows comment presence without leaking comment bodies', async () => {
+      const tool = findTool('get_ticket_history');
+      const text = getAllText(await tool.handler({ ticket_id: 1, page_size: 100 }));
+      expect(text).toContain('Public comment added');
+      expect(text).toContain('Internal note added');
+      expect(text).not.toContain('Initial request body');
+      expect(text).not.toContain('internal note body');
+    });
+
+    it('filters out system-noise events and all-noise audits', async () => {
+      const tool = findTool('get_ticket_history');
+      const text = getAllText(await tool.handler({ ticket_id: 1, page_size: 100 }));
+      // The Notification/Push audit (author 999) produces no block.
+      expect(text).not.toContain('email sent');
+      expect(text).not.toContain('999');
+    });
+
+    it('surfaces the pagination cursor when more audits remain', async () => {
+      mswServer.use(auditsMorePageHandler);
+      const tool = findTool('get_ticket_history');
+      const text = getAllText(await tool.handler({ ticket_id: 1, page_size: 1 }));
+      expect(text).toContain('More available');
+      expect(text).toContain('next-audit-cursor');
+    });
+
+    it('still renders when name resolution fails, falling back to bare ids', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/users/show_many', () =>
+          HttpResponse.json({}, { status: 500 }),
+        ),
+        http.get('https://testsubdomain.zendesk.com/api/v2/groups/show_many', () =>
+          HttpResponse.json({}, { status: 500 }),
+        ),
+      );
+      const tool = findTool('get_ticket_history');
+      const result = await tool.handler({ ticket_id: 1, page_size: 100 });
+      const text = getAllText(result);
+      expect(result.isError).toBeFalsy();
+      expect(text).toContain('**assignee**: (none) → 100');
+      expect(text).toContain('**group**: (none) → 300');
+    });
+
+    it('returns a clear message when the ticket has no change history', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/audits', () =>
+          HttpResponse.json({ audits: [], meta: { has_more: false, after_cursor: '' } }),
+        ),
+      );
+      const tool = findTool('get_ticket_history');
+      const text = getAllText(await tool.handler({ ticket_id: 1, page_size: 100 }));
+      expect(text).toContain('No change history to show for ticket #1');
+    });
+
+    it('has readOnly annotation', () => {
+      const tool = findTool('get_ticket_history');
       expect(tool.annotations.readOnlyHint).toBe(true);
     });
   });

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -205,6 +205,22 @@ describe('formatAudit', () => {
     expect(formatAudit(MOCK_AUDIT_NOISE, names)).toBeNull();
   });
 
+  it('labels the Zendesk system actor (author_id -1) instead of a bare id', () => {
+    const audit = {
+      id: 9200,
+      ticket_id: 1,
+      created_at: '2026-01-06T00:00:00Z',
+      author_id: -1,
+      via: { channel: 'rule' },
+      events: [
+        { id: 1, type: 'Change', field_name: 'status', value: 'solved', previous_value: 'open' },
+      ],
+    };
+    const result = formatAudit(audit, names) ?? '';
+    expect(result).toContain('System (-1)');
+    expect(result).toContain('**status**: open → solved');
+  });
+
   it('falls back to bare ids when names are unresolved', () => {
     const result = formatAudit(MOCK_AUDIT_CHANGE, { users: new Map(), groups: new Map() }) ?? '';
     expect(result).toContain('**assignee**: (none) → 100');

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   formatArticle,
   formatArticleSummary,
+  formatAudit,
   formatCategory,
   formatComment,
   formatFieldValue,
@@ -19,6 +20,9 @@ import {
 } from '../../../src/utils/formatting';
 import {
   MOCK_ARTICLE,
+  MOCK_AUDIT_CHANGE,
+  MOCK_AUDIT_CREATE,
+  MOCK_AUDIT_NOISE,
   MOCK_CATEGORY,
   MOCK_COMMENT,
   MOCK_MACRO,
@@ -159,6 +163,96 @@ describe('formatComment', () => {
   it('omits the Attachments line when the attachments array is empty', () => {
     const result = formatComment({ ...MOCK_COMMENT, attachments: [] });
     expect(result).not.toContain('Attachments:');
+  });
+});
+
+describe('formatAudit', () => {
+  const names = {
+    users: new Map([
+      [100, 'Agent Smith'],
+      [200, 'Requester Jane'],
+    ]),
+    groups: new Map([[300, 'Support']]),
+  };
+
+  it('renders a Create audit as founding facts with actor, channel and comment presence', () => {
+    const result = formatAudit(MOCK_AUDIT_CREATE, names) ?? '';
+    expect(result).toContain('Requester Jane (200)');
+    expect(result).toContain('via web');
+    expect(result).toContain('**status**: new');
+    expect(result).toContain('**priority**: normal');
+    expect(result).toContain('Public comment added');
+    // Comment bodies never leak into the timeline.
+    expect(result).not.toContain('Initial request body');
+    // Non-whitelisted Create fields are dropped from the founding block.
+    expect(result).not.toContain('custom_status_id');
+  });
+
+  it('renders changes as before → after with resolved names and a tag diff', () => {
+    const result = formatAudit(MOCK_AUDIT_CHANGE, names) ?? '';
+    expect(result).toContain('Agent Smith (100)');
+    expect(result).toContain('**status**: new → open');
+    expect(result).toContain('**assignee**: (none) → Agent Smith (100)');
+    expect(result).toContain('**group**: (none) → Support (300)');
+    expect(result).toContain('**tags**: +urgent');
+    expect(result).toContain('Internal note added');
+    // System noise and comment bodies are filtered out.
+    expect(result).not.toContain('email sent');
+    expect(result).not.toContain('internal note body');
+  });
+
+  it('returns null for an audit carrying only system-noise events', () => {
+    expect(formatAudit(MOCK_AUDIT_NOISE, names)).toBeNull();
+  });
+
+  it('falls back to bare ids when names are unresolved', () => {
+    const result = formatAudit(MOCK_AUDIT_CHANGE, { users: new Map(), groups: new Map() }) ?? '';
+    expect(result).toContain('**assignee**: (none) → 100');
+    expect(result).toContain('**group**: (none) → 300');
+  });
+
+  it('renders SLA-metric changes as minutes and summarises secondary events', () => {
+    const audit = {
+      id: 9100,
+      ticket_id: 1,
+      created_at: '2026-01-04T00:00:00Z',
+      author_id: 100,
+      via: { channel: 'api' },
+      events: [
+        {
+          id: 1,
+          type: 'Change',
+          field_name: 'requester_wait_time',
+          value: { minutes: 45, in_business_hours: false },
+          previous_value: { minutes: 150, in_business_hours: false },
+        },
+        { id: 2, type: 'CommentPrivacyChange' },
+        { id: 3, type: 'FollowersChange' },
+        { id: 4, type: 'EmailCcChange' },
+        { id: 5, type: 'SatisfactionRating' },
+      ],
+    };
+    const result = formatAudit(audit, names) ?? '';
+    expect(result).toContain('150 min → 45 min');
+    expect(result).toContain('Comment visibility changed');
+    expect(result).toContain('Followers changed');
+    expect(result).toContain('Email CCs changed');
+    expect(result).toContain('Satisfaction rating recorded');
+  });
+
+  it('omits a change whose value is unchanged after rendering', () => {
+    const audit = {
+      id: 9101,
+      ticket_id: 1,
+      created_at: '2026-01-05T00:00:00Z',
+      author_id: 100,
+      via: {},
+      events: [
+        { id: 1, type: 'Change', field_name: 'status', value: 'open', previous_value: 'open' },
+      ],
+    };
+    // Only a no-op change → nothing meaningful to show → null.
+    expect(formatAudit(audit, names)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
Adds a read-only `get_ticket_history` tool (namespace `tickets`) that reads Zendesk's Ticket Audits API (`GET /tickets/{id}/audits`) and renders a chronological, oldest-first timeline of the *meaningful* changes behind a ticket's current state — status/priority transitions, assignment/group changes, tag edits and comment presence — each attributed to an actor (name + id) with a timestamp and channel. It answers the "what happened / why was it reassigned / when did it go to pending?" questions that `get_ticket` (current state + comment thread) cannot.

## Linked issue
Closes #123

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally (478 tests)
- [x] `pnpm test:coverage` meets the thresholds (statements 96.5 / branches 82.3 / functions 98.5 / lines 97.4)
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
- [x] If the change has runtime-observable behaviour: this PR carries a `## Functional validation plan` (authored with `/functional-validation-plan`), and it has been executed by an independent validator (`/run-validation-plan`) whose report is posted as a PR comment

## Notes for the reviewer (human or AI)

**Design choices** (discussed and settled before implementation):
- **Dedicated tool, not a flag on `get_ticket`.** Audits are cursor-paginated and unbounded, so they must not ride inside a single-object response. `get_ticket`'s description now cross-references this tool (additive text only — schema stays a draft-07 superset).
- **Comments are presence-only** ("Public comment added" / "Internal note added"), never bodies — those stay on `get_ticket(include_comments)`, so there is zero duplication.
- **System noise is filtered.** Only a curated set of meaningful event types render (`Create`, `Change`, `Comment`, `VoiceComment`, `CommentPrivacyChange`, `SatisfactionRating`, `FollowersChange`, `EmailCcChange`); an update carrying only noise (a trigger that just sent a notification) produces no entry. No `include_system_events` flag in v1 (adding one later is superset-safe).
- **Oldest-first ordering** — deliberately, so the founding context (why the ticket was opened, its first qualification) isn't missed the way reading newest-first invites.
- **Identity resolution via batched `show_many`, not a sideload.** `include=users` is not guaranteed on the audits endpoint, so author/assignee/requester ids resolve via `/users/show_many` and group ids via `/groups/show_many` (mirrors the existing `hydrateViewTickets` pattern). Best-effort: a failed lookup falls back to bare ids, never fails the history.

**Follow-ups already filed, deliberately out of scope:** #155 (consolidated "ticket life" summary — a rollup restitution of the same audit data) and #156 (post that summary as an internal note — a write capability).

**Not fully live-tested from the authoring session:** the dev-mode `reload_tools` only reloads tool modules, not shared infra (`formatting.ts`), which this change touches — so it needs a full server restart to exercise live. The automated tests drive the whole path (handler → mocked API → name resolution → `formatAudit` → output) including edge cases; the validation plan below closes the real-API gap.

---

## Functional validation plan

**For an independent validator.** Your session is already on this PR branch, in a live checkout, with the `zendesk-local` MCP server running, authenticated, and its tools loaded as `mcp__zendesk-local__*` (`--mode all`). Do not build, check out, or configure credentials — just call the tools. A credential/egress error is a `BLOCKED` finding, not a setup task. Capture `git rev-parse HEAD` first and name that SHA in your report.

### Context
The feature is exercised by calling `mcp__zendesk-local__get_ticket_history`. It fans out server-side to `GET /tickets/{id}/audits`, then `/users/show_many` and `/groups/show_many` for name resolution. The MCP tools return *formatted text only*, so the raw audit shape the formatter depends on is verified separately by the ground-truth probe (Scenario 0), which is **blocking** — run it first and paste its raw output into the PR.

### Setup & prerequisites
- No setup beyond the ready environment. To seed a rich history, pick a ticket that has actually been worked (reassigned, status-changed) — find candidates with `mcp__zendesk-local__search_tickets` (e.g. `status:solved`) and note an id. Call it `$TID`.
- Scenario 0 runs the read-only probe from a shell: `pnpm tsx scripts/probe-audits-shape.ts $TID` (omit `$TID` to auto-pick the most-recently-updated ticket). It reuses the already-present auth (`ZENDESK_OAUTH_TOKEN` / cached token) — do not obtain a token. If it prints a credential error, report `BLOCKED`.

### Scenarios

| id | Validates | Manipulation / call | Expected observable |
|----|-----------|---------------------|---------------------|
| **S0** (blocking) | Real audit shape matches the implementation | `pnpm tsx scripts/probe-audits-shape.ts $TID` | Output shows `audits` array + `meta.{has_more,after_cursor}`; `Change` events carry `field_name`/`value`/`previous_value`; `tags` value is an array; `via.channel` present; `/users/show_many` → `{users:[{id,name}]}` and `/groups/show_many` → `{groups:[{id,name}]}`. **Paste the raw output into a PR comment.** Any mismatch (esp. `/groups/show_many` shape/availability) → FAIL with the payload. |
| **S1** | Timeline renders, oldest-first, with resolved actors | `get_ticket_history {"ticket_id": $TID}` | A `# Change history for ticket #$TID` heading; entries in ascending time order (earliest `created_at` first); each heading shows `Name (id)`; field changes render as `**status**: X → Y`, assignee/group as `Name (id)`. |
| **S2** | Comment presence without bodies | same call, inspect a ticket known to have replies | Lines `Public comment added` / `Internal note added` appear; **no comment body text** is present in the output. |
| **S3** | System noise filtered | same call on a ticket with trigger activity | No notification/CC/push lines; an all-noise update contributes no entry (fewer blocks than raw audit count — cross-check against S0's audit count). |
| **S4** | Cursor pagination | `get_ticket_history {"ticket_id": $TID, "page_size": 1}` on a ticket with many audits | Footer shows `More available (cursor: …)`; feeding that cursor back via `{"cursor": "…"}` returns the next page and advances toward more recent changes. |
| **S5** | Graceful name-resolution fallback | Not directly forceable via the tool; covered by unit test `tickets.test.ts › still renders when name resolution fails`. Confirm by reading the test, or note it as unit-covered. | History still renders with bare ids when `show_many` fails. |
| **S6** | Empty / no-history ticket | `get_ticket_history` on a freshly created or archived ticket | A clear `No change history to show for ticket #…` message (no crash); for an archived ticket, no pagination error. |
| **S7** | Read-only + not on get_ticket | Call `get_ticket {"ticket_id": $TID, "include_comments": false}` | Its description cross-references `get_ticket_history`; `get_ticket` itself still returns only current state (no timeline). Confirms no behavior regression / no duplication. |

### Long-running behaviours
None time-based. The `MAX_*`-style internal walk is not used here (single page per call); the full-walk-with-cap belongs to the #155 summary work.

### Priorities
Do **S0 first (blocking)** — it validates the assumptions everything else rests on. Then S1–S4 (the real user-facing paths). S5–S7 are edge/regression checks.

### Reporting
Post a PR comment (English) with the SHA you tested, a per-id verdict (OK / FAIL / BLOCKED) and the observed evidence (tool output excerpts, the raw S0 payload). End with an overall green/failing summary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDtu4ZWYhHDAqZe3rGLGkg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tickets.get_ticket_history` to display chronological ticket changes.
  * History includes meaningful field updates, before-and-after values, actor names, tag changes, and comment presence without exposing comment bodies.
  * Added cursor-based pagination and graceful fallback when names cannot be resolved.
  * Updated ticket guidance to reference the new history tool.

* **Documentation**
  * Added the ticket history tool to the tools reference.

* **Tests**
  * Added coverage for rendering, filtering, pagination, and error-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->