### PR TITLE
feat(help_center): add reorder_article tool

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,6 +160,11 @@ Maximum number of images embedded as native image content in a single tool call.
 
 Hard cap on the number of comment pages fetched when collecting a ticket's attachments (raise it for tickets with very long comment threads).
 
+### `ZENDESK_REORDER_CONFIRM_THRESHOLD`
+**Required:** no · **Default:** `20`
+
+Safety threshold for `reorder_article`. When moving an article would rewrite more than this many article positions (for example moving an article to the top of a large or heavily tied section), the tool refuses and reports the count until the call is retried with `confirm: true`. Lower it to be prompted sooner, raise it to reorder large sections without confirmation.
+
 ---
 
 ← Back to the [README](../README.md).

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -55,6 +55,7 @@ out every `write` tool before the proxies are built.
 | `compare_translations` | Section-level diff between two locales of an article | read |
 | `create_article` | Create a new article in a section | write |
 | `update_article` | Update article metadata (draft, labels, tags, visibility, section, sort position) | write |
+| `reorder_article` | Move an article within its section (top/bottom/before/after), breaking position ties deterministically | write |
 | `archive_article` | Archive (soft-delete) an article; recoverable only via the Guide admin UI | write |
 | `create_article_translation` | Create a translation for an article | write |
 | `update_article_translation` | Update an article's translation (full body) | write |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,13 @@ export const MAX_EMBEDDED_IMAGE_COUNT = positiveIntEnv('ZENDESK_MAX_EMBEDDED_IMA
 // Overridable via ZENDESK_MAX_COMMENT_PAGES for tickets with many comments.
 export const MAX_COMMENT_PAGES = positiveIntEnv('ZENDESK_MAX_COMMENT_PAGES', 10);
 
+// Blast-radius guard for reorder_article. Reordering an article can require
+// rewriting the `position` of several neighbours (to break ties or shift a run);
+// if that write set exceeds this many articles the tool refuses unless the caller
+// passes confirm:true, so a single "move to top" can't silently rewrite hundreds
+// of articles. Override via ZENDESK_REORDER_CONFIRM_THRESHOLD.
+export const REORDER_CONFIRM_THRESHOLD = positiveIntEnv('ZENDESK_REORDER_CONFIRM_THRESHOLD', 20);
+
 // Thresholds used to nudge callers toward section-scoped article tools
 // (get_article_outline / get_article_section / update_article_section)
 // instead of fetching/rewriting the full body.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,12 +6,14 @@ export const TOKEN_CACHE_TTL_MS = 5 * 60 * 1000;
 // Read a positive-integer override from the environment, falling back to a safe
 // default. Unchecked Number() coercion is unsafe here: an empty string yields 0
 // and a typo yields NaN, either of which would silently break the guardrail that
-// relies on the value. Missing/empty/non-finite/non-positive values fall back.
+// relies on the value. Missing/empty/non-positive values and anything that is not
+// a positive safe integer (fractions like "1.5", values beyond 2^53) fall back —
+// these constants are all counts/sizes, so a fractional or unsafe value is a typo.
 const positiveIntEnv = (name: string, fallback: number): number => {
   const raw = process.env[name];
   if (raw === undefined || raw.trim() === '') return fallback;
   const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 };
 
 // TTL for the per-session Help Center topology cache (zendesk-hc://topology).

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -944,11 +944,12 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           };
         }
 
-        // If the section provably ignores position (its effective order is not
-        // sorted by position) and the reorder would be large, refuse up front
-        // rather than fire many writes that will be silently ignored.
-        const autoSorted = hasPositionInversion(effective);
-        if (autoSorted && writes.length > REORDER_CONFIRM_THRESHOLD) {
+        // A strict inversion in the effective order is definitive proof the
+        // section ignores `position` (it is auto-sorted). Short-circuit before any
+        // write, at any size — writing would be silently ignored regardless. The
+        // post-write verification below still backstops the cases an inversion
+        // cannot reveal up front (e.g. an auto order that happens to be ascending).
+        if (hasPositionInversion(effective)) {
           return { content: [{ type: 'text', text: autoSortNotice(sectionId) }] };
         }
 

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -104,14 +104,25 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
   // Fetch a section's articles in their EFFECTIVE display order (no sort_by), the
   // order an end user sees. Fully paginated so reorder decisions and verification
   // see every article, not just the first page. Used by reorder_article.
-  const fetchSectionOrder = async (sectionId: number, token: string): Promise<OrderedArticle[]> => {
+  //
+  // The listing MUST be locale-scoped: without sort_by the endpoint falls back to
+  // the section's configured "Order articles by", and a locale-dependent mode
+  // (title / recent activity / edited_at) makes the non-locale endpoint reject the
+  // request with HTTP 400 ("must specify a locale in order to sort by title…").
+  // Scoping by the article's locale both satisfies that requirement and still
+  // surfaces the auto-sorted order so the inversion probe can detect it.
+  const fetchSectionOrder = async (
+    sectionId: number,
+    locale: string,
+    token: string,
+  ): Promise<OrderedArticle[]> => {
     const order: OrderedArticle[] = [];
     let cursor: string | undefined;
     do {
       const response = await helpCenterGet<ZendeskListResponse<ZendeskArticle>>(
         subdomain,
         token,
-        `/sections/${sectionId}/articles`,
+        `/${locale}/sections/${sectionId}/articles`,
         buildCursorParams(MAX_PAGE_SIZE, cursor),
       );
       const articles = response.articles ?? [];
@@ -906,8 +917,12 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           `/articles/${article_id}`,
         );
         const sectionId = article.section_id;
+        // Scope every section listing to the article's locale — the endpoint
+        // rejects a locale-less request when the section's default sort is
+        // locale-dependent (see fetchSectionOrder).
+        const locale = article.source_locale;
 
-        const effective = await fetchSectionOrder(sectionId, token);
+        const effective = await fetchSectionOrder(sectionId, locale, token);
 
         // For before/after, the reference must be in the same section. Disambiguate
         // not-found vs wrong-section so the caller gets an actionable message.
@@ -984,7 +999,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         }
 
         // Verify the move took effect (the definitive auto-sort check).
-        const after = await fetchSectionOrder(sectionId, token);
+        const after = await fetchSectionOrder(sectionId, locale, token);
         if (!isPlacedAsRequested(after, article_id, target, reference_article_id)) {
           return { content: [{ type: 'text', text: autoSortNotice(sectionId, applied) }] };
         }

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -13,6 +13,7 @@ import {
   LARGE_ARTICLE_BODY_CHARS,
   LARGE_ARTICLE_SECTION_COUNT,
   MAX_PAGE_SIZE,
+  REORDER_CONFIRM_THRESHOLD,
 } from '../constants';
 import type {
   ZendeskArticle,
@@ -26,6 +27,14 @@ import type {
   ZendeskTranslation,
   ZendeskUserSegment,
 } from '../types';
+import {
+  arrangeDesiredOrder,
+  computePositionWrites,
+  hasPositionInversion,
+  isPlacedAsRequested,
+  type OrderedArticle,
+  type ReorderTarget,
+} from '../utils/article-order';
 import {
   htmlToMarkdown,
   markdownToHtml,
@@ -76,8 +85,44 @@ const largeArticleHint = (body: string, sectionCount: number): string | null => 
   ].join('\n');
 };
 
+// Message returned when a reorder's position writes are (or would be) silently
+// ignored because the section is sorted automatically rather than manually. There
+// is no API field exposing the sort mode, so we name the section and the exact UI
+// steps rather than fabricate an admin deep-link (none is stable across Guide
+// versions). `applied` is set only after writes were attempted (post-verify path).
+const autoSortNotice = (sectionId: number, applied?: number): string =>
+  [
+    applied === undefined
+      ? `Section #${sectionId} looks like it is sorted automatically, so a manual reorder would have no visible effect.`
+      : `Wrote ${applied} article position(s), but the display order of section #${sectionId} did not change — the section is sorted automatically, so positions are ignored.`,
+    'To order its articles manually: in Guide, open the section, choose "Edit section", set "Order articles by" to Manual, then re-run this tool.',
+  ].join(' ');
+
 export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
   const { subdomain, getToken } = ctx;
+
+  // Fetch a section's articles in their EFFECTIVE display order (no sort_by), the
+  // order an end user sees. Fully paginated so reorder decisions and verification
+  // see every article, not just the first page. Used by reorder_article.
+  const fetchSectionOrder = async (sectionId: number, token: string): Promise<OrderedArticle[]> => {
+    const order: OrderedArticle[] = [];
+    let cursor: string | undefined;
+    do {
+      const response = await helpCenterGet<ZendeskListResponse<ZendeskArticle>>(
+        subdomain,
+        token,
+        `/sections/${sectionId}/articles`,
+        buildCursorParams(MAX_PAGE_SIZE, cursor),
+      );
+      const articles = response.articles ?? [];
+      for (const article of articles) {
+        order.push({ id: article.id, position: article.position });
+      }
+      const meta = extractPaginationMeta(response, articles.length);
+      cursor = meta.has_more && meta.after_cursor ? meta.after_cursor : undefined;
+    } while (cursor);
+    return order;
+  };
 
   return [
     {
@@ -771,6 +816,184 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         return {
           content: [
             { type: 'text', text: `Article #${article.id} updated.\n\n${formatArticle(article)}` },
+          ],
+        };
+      },
+    },
+    {
+      name: 'reorder_article',
+      namespace: 'help_center',
+      readOnly: false,
+      title: 'Reorder Help Center Article',
+      description:
+        'Reorder an article within its current section by moving it relative to its siblings (top, bottom, or before/after another article), and return whether the new order was applied. This is the reliable way to satisfy "put this article first/last" requests: it writes the minimal set of article positions needed to make the order deterministic, because Zendesk leaves newly created articles tied at position 0 where a plain position update is silently ambiguous. It does NOT move the article to a different section — use update_article with section_id for that. Zendesk exposes no way to read whether a section is manually or automatically sorted, so when the section is sorted automatically (by date or alphabetically) the position writes are ignored; this tool detects that after the fact and returns guidance to switch the section to manual ordering in Guide. A move may reposition several neighbouring articles; when that count exceeds a configurable safety threshold the call is refused unless confirm is set to true.',
+      inputSchema: z.object({
+        article_id: z
+          .number()
+          .int()
+          .describe(
+            'Article ID — the numeric id of the article to move within its section. Obtain it from list_articles or search_articles.',
+          ),
+        target: z
+          .enum(['top', 'bottom', 'before', 'after'])
+          .describe(
+            'Where to move the article relative to its section siblings: "top" (becomes first), "bottom" (becomes last), or "before"/"after" a specific reference article. "before" and "after" require reference_article_id.',
+          ),
+        reference_article_id: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            'The sibling article to position next to when target is "before" or "after" (numeric id from list_articles). Must belong to the same section and differ from article_id; leave it unset for "top" or "bottom".',
+          ),
+        normalize: z
+          .boolean()
+          .default(false)
+          .describe(
+            'When true, also renumber every article in the section to contiguous positions (0, 1, 2, …) so the stored positions stay tidy. Defaults to false, which writes the fewest positions possible and lets gaps remain. Either way the confirmation threshold still applies.',
+          ),
+        confirm: z
+          .boolean()
+          .default(false)
+          .describe(
+            'Safety guard for large reorders. When the move would rewrite more article positions than the configured threshold (ZENDESK_REORDER_CONFIRM_THRESHOLD, default 20), the tool refuses and reports the count until you pass true here. Has no effect on small reorders.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const {
+          article_id,
+          target,
+          reference_article_id,
+          normalize = false,
+          confirm = false,
+        } = params as {
+          article_id: number;
+          target: ReorderTarget;
+          reference_article_id?: number;
+          normalize?: boolean;
+          confirm?: boolean;
+        };
+
+        // Cross-field validation (the schema is a plain object; enforce the
+        // target/reference relationship here, like archive_article's confirm guard).
+        const needsReference = target === 'before' || target === 'after';
+        if (needsReference && reference_article_id === undefined) {
+          throw new Error(
+            `target "${target}" requires reference_article_id (the article to move ${target}).`,
+          );
+        }
+        if (!needsReference && reference_article_id !== undefined) {
+          throw new Error(
+            `reference_article_id must be omitted when target is "${target}" (it only applies to "before"/"after").`,
+          );
+        }
+        if (reference_article_id !== undefined && reference_article_id === article_id) {
+          throw new Error('reference_article_id must differ from article_id.');
+        }
+
+        const token = await getToken();
+
+        // Resolve the article's section (also validates the article exists).
+        const { article } = await helpCenterGet<{ article: ZendeskArticle }>(
+          subdomain,
+          token,
+          `/articles/${article_id}`,
+        );
+        const sectionId = article.section_id;
+
+        const effective = await fetchSectionOrder(sectionId, token);
+
+        // For before/after, the reference must be in the same section. Disambiguate
+        // not-found vs wrong-section so the caller gets an actionable message.
+        if (needsReference && !effective.some((a) => a.id === reference_article_id)) {
+          let detail = 'was not found';
+          try {
+            const { article: ref } = await helpCenterGet<{ article: ZendeskArticle }>(
+              subdomain,
+              token,
+              `/articles/${reference_article_id}`,
+            );
+            detail = `is in section #${ref.section_id}, not section #${sectionId}`;
+          } catch {
+            // 404 or similar → keep the "was not found" wording.
+          }
+          throw new Error(
+            `Reference article #${reference_article_id} ${detail}. It must be in the same section (#${sectionId}) as article #${article_id}.`,
+          );
+        }
+
+        const targetLabel = needsReference ? `${target} article #${reference_article_id}` : target;
+
+        const desired = arrangeDesiredOrder(effective, article_id, target, reference_article_id);
+        const writes = computePositionWrites(desired, article_id, normalize);
+
+        if (writes.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Article #${article_id} is already positioned ${targetLabel} in section #${sectionId}. No changes made.`,
+              },
+            ],
+          };
+        }
+
+        // If the section provably ignores position (its effective order is not
+        // sorted by position) and the reorder would be large, refuse up front
+        // rather than fire many writes that will be silently ignored.
+        const autoSorted = hasPositionInversion(effective);
+        if (autoSorted && writes.length > REORDER_CONFIRM_THRESHOLD) {
+          return { content: [{ type: 'text', text: autoSortNotice(sectionId) }] };
+        }
+
+        // Blast-radius guard.
+        if (writes.length > REORDER_CONFIRM_THRESHOLD && confirm !== true) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Reordering article #${article_id} to ${targetLabel} would reposition ${writes.length} articles in section #${sectionId}, above the safety threshold of ${REORDER_CONFIRM_THRESHOLD}. Re-run with confirm: true to proceed.`,
+              },
+            ],
+          };
+        }
+
+        // Apply the writes. Positions are absolute, so a re-run after a failure
+        // recomputes against the current state and resumes — it never double-applies.
+        let applied = 0;
+        for (const write of writes) {
+          try {
+            await helpCenterPut(subdomain, token, `/articles/${write.id}`, {
+              article: { position: write.position },
+            });
+            applied += 1;
+          } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            throw new Error(
+              `Reorder of article #${article_id} failed after ${applied}/${writes.length} position write(s) (on article #${write.id}): ${reason} Positions are written absolutely, so re-running the identical call is safe and resumes where it stopped.`,
+              { cause: error },
+            );
+          }
+        }
+
+        // Verify the move took effect (the definitive auto-sort check).
+        const after = await fetchSectionOrder(sectionId, token);
+        if (!isPlacedAsRequested(after, article_id, target, reference_article_id)) {
+          return { content: [{ type: 'text', text: autoSortNotice(sectionId, applied) }] };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Article #${article_id} moved to ${targetLabel} in section #${sectionId} (${applied} article${applied === 1 ? '' : 's'} repositioned).`,
+            },
           ],
         };
       },

--- a/src/utils/article-order.ts
+++ b/src/utils/article-order.ts
@@ -96,12 +96,16 @@ export const computePositionWrites = (
   const moved = desired[movedIndex];
   if (!moved) return writes;
 
-  // bottom: no right neighbour. Anchor above the section maximum (not just the
-  // left neighbour) so the article lands last even if positions are unsorted.
+  // bottom: no right neighbour. Anchor above the maximum of the OTHER articles
+  // (not the whole section — that includes the moved article's own position) so
+  // an article that is already last is a no-op, and the move stays idempotent
+  // instead of bumping the position higher on every call.
   if (movedIndex === desired.length - 1) {
-    const maxPos = desired.reduce((max, a) => Math.max(max, a.position), 0);
-    const target = maxPos + 1;
-    if (moved.position !== target) writes.push({ id: moved.id, position: target });
+    const maxOthers = desired
+      .slice(0, movedIndex)
+      .reduce((max, a) => Math.max(max, a.position), -1);
+    if (moved.position > maxOthers) return writes; // already strictly last
+    writes.push({ id: moved.id, position: maxOthers + 1 });
     return writes;
   }
 
@@ -123,6 +127,13 @@ export const computePositionWrites = (
 // After the writes, re-read the effective order and confirm the article landed at
 // the requested spot. A failure here (writes accepted but order unchanged) means
 // the section is auto-sorted and `position` is being ignored.
+//
+// before/after are checked by SIDE (moved comes before/after the reference), not
+// strict index adjacency: when the reference shares a position with another
+// article (the tie case this tool exists to fix), Zendesk breaks the display tie
+// arbitrarily, so an adjacent placement can legitimately show a co-tied sibling
+// between the two. Side ordering is the property we actually control and is
+// enough to tell a manual section (writes honoured) from an auto-sorted one.
 export const isPlacedAsRequested = (
   effectiveAfter: readonly OrderedArticle[],
   movedId: number,
@@ -135,5 +146,5 @@ export const isPlacedAsRequested = (
   if (target === 'bottom') return movedIndex === effectiveAfter.length - 1;
   const refIndex = effectiveAfter.findIndex((a) => a.id === referenceId);
   if (refIndex === -1) return false;
-  return target === 'before' ? movedIndex === refIndex - 1 : movedIndex === refIndex + 1;
+  return target === 'before' ? movedIndex < refIndex : movedIndex > refIndex;
 };

--- a/src/utils/article-order.ts
+++ b/src/utils/article-order.ts
@@ -1,0 +1,139 @@
+// Pure ordering logic for reorder_article (see src/tools/help-center.ts).
+//
+// Zendesk exposes no bulk-reorder endpoint and no "sort mode" field: the only
+// lever is each article's integer `position` (>= 0), and several articles
+// routinely share position 0, so ties resolve in an undefined display order.
+// These helpers turn a "move article X relative to the section" request into the
+// MINIMAL set of absolute position writes that realises it deterministically,
+// leaving unrelated articles untouched. All functions are pure so the tricky
+// numeric transform can be unit-tested without any network.
+
+export type ReorderTarget = 'top' | 'bottom' | 'before' | 'after';
+
+// One article's identity and current sort position within its section.
+export interface OrderedArticle {
+  id: number;
+  position: number;
+}
+
+// A single absolute position assignment to PUT back to Zendesk.
+export interface ReorderWrite {
+  id: number;
+  position: number;
+}
+
+// A section is manually sorted iff its effective display order is non-decreasing
+// in `position`. A STRICT decrease means the display ignores `position` (the
+// section is auto-sorted by date/alphabetical), so any position write would be
+// silently ignored. Ties (equal positions) are NOT an inversion — they are the
+// undefined-order bug this tool fixes, not evidence of auto-sort.
+export const hasPositionInversion = (order: readonly OrderedArticle[]): boolean => {
+  for (let i = 0; i < order.length - 1; i += 1) {
+    const here = order[i];
+    const next = order[i + 1];
+    if (here && next && here.position > next.position) return true;
+  }
+  return false;
+};
+
+// Rearrange `effective` (the current display order) into the desired final order
+// by moving `movedId` to the slot implied by target/referenceId. Returns the new
+// ordering as ids-with-current-positions; callers pass it to computePositionWrites.
+// Assumes the moved article (and, for before/after, the reference) are present —
+// the handler validates presence first to produce friendly error messages.
+export const arrangeDesiredOrder = (
+  effective: readonly OrderedArticle[],
+  movedId: number,
+  target: ReorderTarget,
+  referenceId?: number,
+): OrderedArticle[] => {
+  const moved = effective.find((a) => a.id === movedId);
+  if (!moved) throw new Error(`Article ${movedId} is not in the section.`);
+  const rest = effective.filter((a) => a.id !== movedId);
+
+  let slot: number;
+  if (target === 'top') {
+    slot = 0;
+  } else if (target === 'bottom') {
+    slot = rest.length;
+  } else {
+    const refIndex = rest.findIndex((a) => a.id === referenceId);
+    if (refIndex === -1) throw new Error(`Reference article ${referenceId} is not in the section.`);
+    slot = target === 'before' ? refIndex : refIndex + 1;
+  }
+  return [...rest.slice(0, slot), moved, ...rest.slice(slot)];
+};
+
+// Given the desired final order, return the minimal set of position writes that
+// realises it as a strictly-increasing sequence.
+//
+// normalize=true: renumber the whole section contiguously 0..N-1 (tidy positions,
+//   up to N writes — guarded by the confirm threshold in the handler).
+// normalize=false (default, gap-aware):
+//   - bottom (moved is last): one write, position = max(section) + 1.
+//   - otherwise: a right-cascade starting at the moved article — place it just
+//     above its left neighbour, then bump only the following articles that would
+//     otherwise tie/precede it, stopping at the first one already clear of the
+//     running maximum. On a section with integer slack this is a single write;
+//     with pervasive ties (all at 0) it degrades to renumbering the affected run,
+//     which is the genuine lower bound for that case.
+// Only articles whose position actually changes are returned.
+export const computePositionWrites = (
+  desired: readonly OrderedArticle[],
+  movedId: number,
+  normalize: boolean,
+): ReorderWrite[] => {
+  const writes: ReorderWrite[] = [];
+
+  if (normalize) {
+    desired.forEach((a, index) => {
+      if (a.position !== index) writes.push({ id: a.id, position: index });
+    });
+    return writes;
+  }
+
+  const movedIndex = desired.findIndex((a) => a.id === movedId);
+  const moved = desired[movedIndex];
+  if (!moved) return writes;
+
+  // bottom: no right neighbour. Anchor above the section maximum (not just the
+  // left neighbour) so the article lands last even if positions are unsorted.
+  if (movedIndex === desired.length - 1) {
+    const maxPos = desired.reduce((max, a) => Math.max(max, a.position), 0);
+    const target = maxPos + 1;
+    if (moved.position !== target) writes.push({ id: moved.id, position: target });
+    return writes;
+  }
+
+  // top / middle: cascade right from the moved article, healing only the run that
+  // blocks its placement.
+  const left = desired[movedIndex - 1];
+  let running = left ? left.position : -1;
+  for (let i = movedIndex; i < desired.length; i += 1) {
+    const article = desired[i];
+    if (!article) break;
+    if (i !== movedIndex && article.position > running) break; // already clear — stop
+    const target = running + 1;
+    if (article.position !== target) writes.push({ id: article.id, position: target });
+    running = target;
+  }
+  return writes;
+};
+
+// After the writes, re-read the effective order and confirm the article landed at
+// the requested spot. A failure here (writes accepted but order unchanged) means
+// the section is auto-sorted and `position` is being ignored.
+export const isPlacedAsRequested = (
+  effectiveAfter: readonly OrderedArticle[],
+  movedId: number,
+  target: ReorderTarget,
+  referenceId?: number,
+): boolean => {
+  const movedIndex = effectiveAfter.findIndex((a) => a.id === movedId);
+  if (movedIndex === -1) return false;
+  if (target === 'top') return movedIndex === 0;
+  if (target === 'bottom') return movedIndex === effectiveAfter.length - 1;
+  const refIndex = effectiveAfter.findIndex((a) => a.id === referenceId);
+  if (refIndex === -1) return false;
+  return target === 'before' ? movedIndex === refIndex - 1 : movedIndex === refIndex + 1;
+};

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -261,6 +261,17 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(textOf(result)).toContain('Article #5000 archived');
       });
 
+      it('reorders a Help Center article over the wire', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'reorder_article',
+          arguments: { article_id: 5000, target: 'bottom' },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('section #600');
+      });
+
       it('surfaces a Zendesk API error as an MCP tool error', async () => {
         mswServer.use(errorHandlers.usersMeUnauthorized);
 

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -705,6 +705,13 @@ export const handlers = [
       count: 1,
     }),
   ),
+  http.get(`${HC_BASE}/:locale/sections/:sid/articles`, () =>
+    HttpResponse.json({
+      articles: [MOCK_ARTICLE],
+      meta: { has_more: false, after_cursor: '' },
+      count: 1,
+    }),
+  ),
   http.post(`${HC_BASE}/sections/:sid/articles`, () =>
     HttpResponse.json({ article: MOCK_ARTICLE }),
   ),

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getBaseUrl, getHelpCenterBaseUrl, getOAuthUrls } from '../../src/constants';
 
 describe('getBaseUrl', () => {
@@ -20,5 +20,40 @@ describe('getOAuthUrls', () => {
     const urls = getOAuthUrls('mycompany');
     expect(urls.authorizeUrl).toBe('https://mycompany.zendesk.com/oauth/authorizations/new');
     expect(urls.tokenUrl).toBe('https://mycompany.zendesk.com/oauth/tokens');
+  });
+});
+
+describe('REORDER_CONFIRM_THRESHOLD (positiveIntEnv)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  const load = async () => (await import('../../src/constants')).REORDER_CONFIRM_THRESHOLD;
+
+  it('defaults to 20 when unset', async () => {
+    vi.resetModules();
+    expect(await load()).toBe(20);
+  });
+
+  it('honors a valid positive integer', async () => {
+    vi.resetModules();
+    vi.stubEnv('ZENDESK_REORDER_CONFIRM_THRESHOLD', '5');
+    expect(await load()).toBe(5);
+  });
+
+  it('falls back to the default on a fractional value', async () => {
+    vi.resetModules();
+    vi.stubEnv('ZENDESK_REORDER_CONFIRM_THRESHOLD', '1.5');
+    expect(await load()).toBe(20);
+  });
+
+  it('falls back to the default on a non-numeric or non-positive value', async () => {
+    vi.resetModules();
+    vi.stubEnv('ZENDESK_REORDER_CONFIRM_THRESHOLD', 'lots');
+    expect(await load()).toBe(20);
+    vi.resetModules();
+    vi.stubEnv('ZENDESK_REORDER_CONFIRM_THRESHOLD', '0');
+    expect(await load()).toBe(20);
   });
 });

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getBaseUrl, getHelpCenterBaseUrl, getOAuthUrls } from '../../src/constants';
 
 describe('getBaseUrl', () => {
@@ -24,34 +24,34 @@ describe('getOAuthUrls', () => {
 });
 
 describe('REORDER_CONFIRM_THRESHOLD (positiveIntEnv)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
-    vi.resetModules();
   });
 
   const load = async () => (await import('../../src/constants')).REORDER_CONFIRM_THRESHOLD;
 
   it('defaults to 20 when unset', async () => {
-    vi.resetModules();
     expect(await load()).toBe(20);
   });
 
   it('honors a valid positive integer', async () => {
-    vi.resetModules();
     vi.stubEnv('ZENDESK_REORDER_CONFIRM_THRESHOLD', '5');
     expect(await load()).toBe(5);
   });
 
   it('falls back to the default on a fractional value', async () => {
-    vi.resetModules();
     vi.stubEnv('ZENDESK_REORDER_CONFIRM_THRESHOLD', '1.5');
     expect(await load()).toBe(20);
   });
 
   it('falls back to the default on a non-numeric or non-positive value', async () => {
-    vi.resetModules();
     vi.stubEnv('ZENDESK_REORDER_CONFIRM_THRESHOLD', 'lots');
     expect(await load()).toBe(20);
+    // Re-evaluate the module a second time within this test with a new value.
     vi.resetModules();
     vi.stubEnv('ZENDESK_REORDER_CONFIRM_THRESHOLD', '0');
     expect(await load()).toBe(20);

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -65,7 +65,7 @@ describe('groupByNamespace', () => {
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
     expect(ticketCount).toBe(18); // 17 ticket tools + 1 search
-    expect(hcCount).toBe(22);
+    expect(hcCount).toBe(23);
     expect(userCount).toBe(5);
   });
 });

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -426,15 +426,20 @@ describe('help center tools', () => {
       expect(done.content[0]?.text).toContain('moved to top');
     });
 
-    it('refuses up front when the section is auto-sorted and the reorder is large', async () => {
-      // Inverted + tied tail so the write set is large AND an inversion is present.
-      const articles = [
-        ...Array.from({ length: 24 }, (_, i) => ({ id: i + 1, position: i })), // 1..24 at 0..23
-        { id: 25, position: 0 }, // tail tie -> boundary inversion (23 > 0)
-      ];
-      const { writes } = seedSection(600, articles, { fixedOrder: articles.map((a) => a.id) });
-      const result = await findTool('reorder_article').handler({ article_id: 25, target: 'top' });
-      expect(writes).toEqual([]); // refused before any write
+    it('short-circuits an auto-sorted section up front without writing, at any size', async () => {
+      // A strict inversion in the effective order is proof the section ignores
+      // position; the tool must refuse before writing regardless of the write count.
+      const { writes } = seedSection(
+        600,
+        [
+          { id: 1, position: 5 },
+          { id: 2, position: 3 },
+          { id: 3, position: 8 },
+        ],
+        { fixedOrder: [1, 2, 3] }, // positions 5,3,8 along the display order → inversion
+      );
+      const result = await findTool('reorder_article').handler({ article_id: 3, target: 'top' });
+      expect(writes).toEqual([]); // refused before any write, even though it's a small reorder
       expect(result.content[0]?.text).toContain('sorted automatically');
     });
 

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -498,6 +498,17 @@ describe('help center tools', () => {
       ).rejects.toThrow(/section #700/);
     });
 
+    it('reports when the reference article does not exist', async () => {
+      seedSection(600, [{ id: 1, position: 0 }], { missing: [2] });
+      await expect(
+        findTool('reorder_article').handler({
+          article_id: 1,
+          target: 'before',
+          reference_article_id: 2,
+        }),
+      ).rejects.toThrow(/#2 was not found/);
+    });
+
     it('validates the target enum via the schema', () => {
       const tool = findTool('reorder_article');
       expect(() => tool.inputSchema.parse({ article_id: 1, target: 'sideways' })).toThrow();

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -275,6 +275,7 @@ describe('help center tools', () => {
     ) => {
       const state = new Map(articles.map((a) => [a.id, a.position]));
       const writes: Array<{ id: number; position: number }> = [];
+      const listPaths: string[] = [];
       const article = (id: number, secId: number) => ({
         ...MOCK_ARTICLE,
         id,
@@ -289,7 +290,11 @@ describe('help center tools', () => {
             article: article(id, opts.foreignSections?.[id] ?? sectionId),
           });
         }),
-        http.get(`${HC_BASE}/sections/${sectionId}/articles`, () => {
+        // Locale-scoped path: reorder_article lists the section under the
+        // article's locale (Zendesk 400s the locale-less endpoint when the
+        // section's default sort is locale-dependent).
+        http.get(`${HC_BASE}/:locale/sections/${sectionId}/articles`, ({ request }) => {
+          listPaths.push(new URL(request.url).pathname);
           const ids = opts.fixedOrder
             ? opts.fixedOrder
             : [...state.entries()].sort((a, b) => a[1] - b[1] || a[0] - b[0]).map(([id]) => id);
@@ -314,11 +319,22 @@ describe('help center tools', () => {
           return HttpResponse.json({ article: { ...MOCK_ARTICLE, id, position } });
         }),
       );
-      return { writes };
+      return { writes, listPaths };
     };
 
     const seq = (n: number, position: number) =>
       Array.from({ length: n }, (_, i) => ({ id: i + 1, position }));
+
+    it('lists the section scoped to the article locale (avoids the locale-less 400)', async () => {
+      const { listPaths } = seedSection(600, [
+        { id: 1, position: 0 },
+        { id: 2, position: 1 },
+      ]);
+      await findTool('reorder_article').handler({ article_id: 1, target: 'bottom' });
+      // MOCK_ARTICLE.source_locale is "en-us"; every section listing must carry it.
+      expect(listPaths.length).toBeGreaterThan(0);
+      expect(listPaths.every((p) => p.includes('/en-us/sections/600/articles'))).toBe(true);
+    });
 
     it('moves an article to the bottom in a single write', async () => {
       const { writes } = seedSection(600, [

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -16,8 +16,8 @@ const findTool = (name: string) => {
 };
 
 describe('help center tools', () => {
-  it('creates 22 tools', () => {
-    expect(createHelpCenterTools(ctx)).toHaveLength(22);
+  it('creates 23 tools', () => {
+    expect(createHelpCenterTools(ctx)).toHaveLength(23);
   });
 
   describe('search_articles', () => {
@@ -252,6 +252,254 @@ describe('help center tools', () => {
       expect(field.description).toContain('P + 1');
       expect(tool.inputSchema.parse({ article_id: 5000, position: 3 })).toMatchObject({
         position: 3,
+      });
+    });
+  });
+
+  describe('reorder_article', () => {
+    // Stateful section mock: GET returns the section's articles in effective order,
+    // PUT mutates positions and records the write sequence. This lets the tool's
+    // post-write verification observe the effect, the way a real manual section
+    // behaves. Pass fixedOrder to simulate an auto-sorted section (GET ignores the
+    // written positions). Pass foreignSections to place a looked-up article in
+    // another section.
+    const seedSection = (
+      sectionId: number,
+      articles: Array<{ id: number; position: number }>,
+      opts: {
+        fixedOrder?: number[];
+        foreignSections?: Record<number, number>;
+        missing?: number[];
+        failPutOn?: number;
+      } = {},
+    ) => {
+      const state = new Map(articles.map((a) => [a.id, a.position]));
+      const writes: Array<{ id: number; position: number }> = [];
+      const article = (id: number, secId: number) => ({
+        ...MOCK_ARTICLE,
+        id,
+        section_id: secId,
+        position: state.get(id) ?? 0,
+      });
+      mswServer.use(
+        http.get(`${HC_BASE}/articles/:id`, ({ params }) => {
+          const id = Number(params['id']);
+          if (opts.missing?.includes(id)) return new HttpResponse(null, { status: 404 });
+          return HttpResponse.json({
+            article: article(id, opts.foreignSections?.[id] ?? sectionId),
+          });
+        }),
+        http.get(`${HC_BASE}/sections/${sectionId}/articles`, () => {
+          const ids = opts.fixedOrder
+            ? opts.fixedOrder
+            : [...state.entries()].sort((a, b) => a[1] - b[1] || a[0] - b[0]).map(([id]) => id);
+          const ordered = ids.map((id) => article(id, sectionId));
+          return HttpResponse.json({
+            articles: ordered,
+            meta: { has_more: false, after_cursor: '' },
+            count: ordered.length,
+          });
+        }),
+        http.put(`${HC_BASE}/articles/:id`, async ({ request, params }) => {
+          const id = Number(params['id']);
+          if (opts.failPutOn === id) return new HttpResponse(null, { status: 500 });
+          const body = (await request.json().catch(() => ({}))) as {
+            article?: { position?: number };
+          };
+          const position = body.article?.position;
+          if (typeof position === 'number') {
+            state.set(id, position);
+            writes.push({ id, position });
+          }
+          return HttpResponse.json({ article: { ...MOCK_ARTICLE, id, position } });
+        }),
+      );
+      return { writes };
+    };
+
+    const seq = (n: number, position: number) =>
+      Array.from({ length: n }, (_, i) => ({ id: i + 1, position }));
+
+    it('moves an article to the bottom in a single write', async () => {
+      const { writes } = seedSection(600, [
+        { id: 1, position: 0 },
+        { id: 2, position: 1 },
+        { id: 3, position: 2 },
+      ]);
+      const result = await findTool('reorder_article').handler({ article_id: 1, target: 'bottom' });
+      expect(writes).toEqual([{ id: 1, position: 3 }]);
+      expect(result.content[0]?.text).toContain('moved to bottom');
+      expect(result.content[0]?.text).toContain('1 article repositioned');
+    });
+
+    it('moves an article before a reference using an existing gap (single write)', async () => {
+      const { writes } = seedSection(600, [
+        { id: 1, position: 0 },
+        { id: 2, position: 10 },
+        { id: 3, position: 20 },
+      ]);
+      const result = await findTool('reorder_article').handler({
+        article_id: 3,
+        target: 'before',
+        reference_article_id: 2,
+      });
+      expect(writes).toEqual([{ id: 3, position: 1 }]);
+      expect(result.content[0]?.text).toContain('before article #2');
+    });
+
+    it('breaks ties to move a tied article to the top (the #134 case)', async () => {
+      const { writes } = seedSection(600, [
+        { id: 1, position: 0 },
+        { id: 2, position: 0 },
+        { id: 3, position: 0 },
+        { id: 4, position: 0 },
+      ]);
+      const result = await findTool('reorder_article').handler({ article_id: 4, target: 'top' });
+      // id 4 already at 0 is left alone; siblings bumped so it is uniquely first.
+      expect(writes).toEqual([
+        { id: 1, position: 1 },
+        { id: 2, position: 2 },
+        { id: 3, position: 3 },
+      ]);
+      expect(result.content[0]?.text).toContain('moved to top');
+    });
+
+    it('renumbers the section contiguously when normalize is true', async () => {
+      const { writes } = seedSection(600, [
+        { id: 1, position: 0 },
+        { id: 2, position: 5 },
+        { id: 3, position: 9 },
+      ]);
+      await findTool('reorder_article').handler({
+        article_id: 3,
+        target: 'top',
+        normalize: true,
+      });
+      expect(writes).toEqual([
+        { id: 3, position: 0 },
+        { id: 1, position: 1 },
+        { id: 2, position: 2 },
+      ]);
+    });
+
+    it('reports a no-op when the article is already in place', async () => {
+      const { writes } = seedSection(600, [
+        { id: 1, position: 0 },
+        { id: 2, position: 1 },
+      ]);
+      const result = await findTool('reorder_article').handler({ article_id: 1, target: 'top' });
+      expect(writes).toEqual([]);
+      expect(result.content[0]?.text).toContain('already positioned');
+    });
+
+    it('detects an auto-sorted section after writing and returns guidance', async () => {
+      // GET always returns the same order regardless of written positions.
+      const { writes } = seedSection(
+        600,
+        [
+          { id: 1, position: 0 },
+          { id: 2, position: 1 },
+          { id: 3, position: 2 },
+        ],
+        { fixedOrder: [1, 2, 3] },
+      );
+      const result = await findTool('reorder_article').handler({ article_id: 3, target: 'top' });
+      expect(writes.length).toBeGreaterThan(0); // writes were attempted
+      expect(result.content[0]?.text).toContain('sorted automatically');
+      expect(result.content[0]?.text).toContain('Order articles by');
+    });
+
+    it('refuses a large reorder without confirm, then proceeds with confirm', async () => {
+      const seeded = seedSection(600, seq(25, 0)); // 25 articles tied at 0
+      const tool = findTool('reorder_article');
+      const refused = await tool.handler({ article_id: 25, target: 'top' });
+      expect(seeded.writes).toEqual([]); // nothing written
+      expect(refused.content[0]?.text).toContain('above the safety threshold');
+
+      const seeded2 = seedSection(600, seq(25, 0));
+      const done = await findTool('reorder_article').handler({
+        article_id: 25,
+        target: 'top',
+        confirm: true,
+      });
+      expect(seeded2.writes.length).toBe(24); // 24 siblings bumped, id 25 stays at 0
+      expect(done.content[0]?.text).toContain('moved to top');
+    });
+
+    it('refuses up front when the section is auto-sorted and the reorder is large', async () => {
+      // Inverted + tied tail so the write set is large AND an inversion is present.
+      const articles = [
+        ...Array.from({ length: 24 }, (_, i) => ({ id: i + 1, position: i })), // 1..24 at 0..23
+        { id: 25, position: 0 }, // tail tie -> boundary inversion (23 > 0)
+      ];
+      const { writes } = seedSection(600, articles, { fixedOrder: articles.map((a) => a.id) });
+      const result = await findTool('reorder_article').handler({ article_id: 25, target: 'top' });
+      expect(writes).toEqual([]); // refused before any write
+      expect(result.content[0]?.text).toContain('sorted automatically');
+    });
+
+    it('reports how far it got and that a re-run is safe when a write fails midway', async () => {
+      const { writes } = seedSection(
+        600,
+        [
+          { id: 1, position: 0 },
+          { id: 2, position: 0 },
+          { id: 3, position: 0 },
+          { id: 4, position: 0 },
+        ],
+        { failPutOn: 2 },
+      );
+      // Moving id 4 to top writes 1->1, 2->2, 3->3; the write to id 2 fails.
+      await expect(
+        findTool('reorder_article').handler({ article_id: 4, target: 'top' }),
+      ).rejects.toThrow(/failed after 1\/3 position write\(s\) \(on article #2\)[\s\S]*re-running/);
+      expect(writes).toEqual([{ id: 1, position: 1 }]); // only the write before the failure applied
+    });
+
+    it('rejects target before/after without a reference', async () => {
+      await expect(
+        findTool('reorder_article').handler({ article_id: 1, target: 'before' }),
+      ).rejects.toThrow(/requires reference_article_id/);
+    });
+
+    it('rejects a reference on top/bottom targets', async () => {
+      await expect(
+        findTool('reorder_article').handler({
+          article_id: 1,
+          target: 'top',
+          reference_article_id: 2,
+        }),
+      ).rejects.toThrow(/must be omitted/);
+    });
+
+    it('rejects a reference equal to the moved article', async () => {
+      await expect(
+        findTool('reorder_article').handler({
+          article_id: 1,
+          target: 'before',
+          reference_article_id: 1,
+        }),
+      ).rejects.toThrow(/must differ/);
+    });
+
+    it('reports when the reference is in a different section', async () => {
+      seedSection(600, [{ id: 1, position: 0 }], { foreignSections: { 2: 700 } });
+      await expect(
+        findTool('reorder_article').handler({
+          article_id: 1,
+          target: 'after',
+          reference_article_id: 2,
+        }),
+      ).rejects.toThrow(/section #700/);
+    });
+
+    it('validates the target enum via the schema', () => {
+      const tool = findTool('reorder_article');
+      expect(() => tool.inputSchema.parse({ article_id: 1, target: 'sideways' })).toThrow();
+      expect(tool.inputSchema.parse({ article_id: 1, target: 'top' })).toMatchObject({
+        target: 'top',
+        normalize: false,
+        confirm: false,
       });
     });
   });

--- a/tests/unit/utils/article-order.test.ts
+++ b/tests/unit/utils/article-order.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import {
+  arrangeDesiredOrder,
+  computePositionWrites,
+  hasPositionInversion,
+  isPlacedAsRequested,
+  type OrderedArticle,
+} from '../../../src/utils/article-order';
+
+const ord = (pairs: Array<[number, number]>): OrderedArticle[] =>
+  pairs.map(([id, position]) => ({ id, position }));
+
+describe('hasPositionInversion', () => {
+  it('is false for a strictly increasing order', () => {
+    expect(
+      hasPositionInversion(
+        ord([
+          [1, 0],
+          [2, 1],
+          [3, 2],
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false for ties (equal positions are not an inversion)', () => {
+    expect(
+      hasPositionInversion(
+        ord([
+          [1, 0],
+          [2, 0],
+          [3, 0],
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it('is true when a later article has a strictly smaller position', () => {
+    expect(
+      hasPositionInversion(
+        ord([
+          [1, 5],
+          [2, 3],
+          [3, 8],
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false for empty or single-element orders', () => {
+    expect(hasPositionInversion([])).toBe(false);
+    expect(hasPositionInversion(ord([[1, 9]]))).toBe(false);
+  });
+});
+
+describe('arrangeDesiredOrder', () => {
+  const section = ord([
+    [1, 0],
+    [2, 1],
+    [3, 2],
+    [4, 3],
+  ]);
+
+  it('moves an article to the top', () => {
+    expect(arrangeDesiredOrder(section, 3, 'top').map((a) => a.id)).toEqual([3, 1, 2, 4]);
+  });
+
+  it('moves an article to the bottom', () => {
+    expect(arrangeDesiredOrder(section, 2, 'bottom').map((a) => a.id)).toEqual([1, 3, 4, 2]);
+  });
+
+  it('places an article before a reference', () => {
+    expect(arrangeDesiredOrder(section, 4, 'before', 2).map((a) => a.id)).toEqual([1, 4, 2, 3]);
+  });
+
+  it('places an article after a reference', () => {
+    expect(arrangeDesiredOrder(section, 1, 'after', 3).map((a) => a.id)).toEqual([2, 3, 1, 4]);
+  });
+
+  it('throws when the moved article is absent', () => {
+    expect(() => arrangeDesiredOrder(section, 99, 'top')).toThrow(/not in the section/);
+  });
+
+  it('throws when the reference is absent', () => {
+    expect(() => arrangeDesiredOrder(section, 1, 'before', 99)).toThrow(/not in the section/);
+  });
+});
+
+describe('computePositionWrites (gap-aware, default)', () => {
+  it('bottom on a clean section is a single write above the max', () => {
+    const section = ord([
+      [1, 0],
+      [2, 1],
+      [3, 2],
+    ]);
+    const desired = arrangeDesiredOrder(section, 1, 'bottom');
+    expect(computePositionWrites(desired, 1, false)).toEqual([{ id: 1, position: 3 }]);
+  });
+
+  it('bottom anchors above the global max even when positions are unsorted', () => {
+    const section = ord([
+      [1, 10],
+      [2, 3],
+      [3, 5],
+    ]);
+    const desired = arrangeDesiredOrder(section, 2, 'bottom');
+    expect(computePositionWrites(desired, 2, false)).toEqual([{ id: 2, position: 11 }]);
+  });
+
+  it('top with slack below is a single write (position 0)', () => {
+    const section = ord([
+      [1, 5],
+      [2, 6],
+      [3, 7],
+    ]);
+    const desired = arrangeDesiredOrder(section, 3, 'top');
+    expect(computePositionWrites(desired, 3, false)).toEqual([{ id: 3, position: 0 }]);
+  });
+
+  it('top on a fully-contiguous section cascades over the head only', () => {
+    const section = ord([
+      [1, 0],
+      [2, 1],
+      [3, 2],
+      [4, 3],
+      [5, 4],
+    ]);
+    const desired = arrangeDesiredOrder(section, 4, 'top');
+    // 4 -> 0, then 1,2,3 shift up by one; article 5 (pos 4) is already clear → untouched.
+    expect(computePositionWrites(desired, 4, false)).toEqual([
+      { id: 4, position: 0 },
+      { id: 1, position: 1 },
+      { id: 2, position: 2 },
+      { id: 3, position: 3 },
+    ]);
+  });
+
+  it('breaks ties so a tied article becomes deterministically first (the #134 case)', () => {
+    const section = ord([
+      [1, 0],
+      [2, 0],
+      [3, 0],
+      [4, 0],
+    ]);
+    const desired = arrangeDesiredOrder(section, 4, 'top');
+    // id 4 is already at 0, so it is left alone; the tied siblings are bumped up so
+    // id 4 becomes uniquely first. Minimal: 3 writes, not 4.
+    expect(computePositionWrites(desired, 4, false)).toEqual([
+      { id: 1, position: 1 },
+      { id: 2, position: 2 },
+      { id: 3, position: 3 },
+    ]);
+  });
+
+  it('before with an integer gap is a single write', () => {
+    const section = ord([
+      [1, 0],
+      [2, 10],
+      [3, 20],
+    ]);
+    const desired = arrangeDesiredOrder(section, 3, 'before', 2);
+    expect(computePositionWrites(desired, 3, false)).toEqual([{ id: 3, position: 1 }]);
+  });
+
+  it('after a reference with no room cascades minimally', () => {
+    const section = ord([
+      [1, 0],
+      [2, 1],
+      [3, 2],
+    ]);
+    // move 1 to after 2: desired [2,1,3]; 1 must sit between 2(pos1) and 3(pos2) → no room.
+    const desired = arrangeDesiredOrder(section, 1, 'after', 2);
+    expect(computePositionWrites(desired, 1, false)).toEqual([
+      { id: 1, position: 2 },
+      { id: 3, position: 3 },
+    ]);
+  });
+
+  it('returns no writes when the article is already correctly placed', () => {
+    const section = ord([
+      [1, 0],
+      [2, 1],
+      [3, 2],
+    ]);
+    const desired = arrangeDesiredOrder(section, 1, 'top');
+    expect(computePositionWrites(desired, 1, false)).toEqual([]);
+  });
+});
+
+describe('computePositionWrites (normalize)', () => {
+  it('renumbers the whole section contiguously and only emits changed positions', () => {
+    const section = ord([
+      [1, 0],
+      [2, 0],
+      [3, 7],
+      [4, 9],
+    ]);
+    const desired = arrangeDesiredOrder(section, 4, 'top');
+    // desired ids [4,1,2,3] → contiguous 0,1,2,3. id 1 moves 0→1, id 4 moves 9→0, etc.
+    expect(computePositionWrites(desired, 4, true)).toEqual([
+      { id: 4, position: 0 },
+      { id: 1, position: 1 },
+      { id: 2, position: 2 },
+      { id: 3, position: 3 },
+    ]);
+  });
+});
+
+describe('isPlacedAsRequested', () => {
+  const after = ord([
+    [3, 0],
+    [1, 1],
+    [2, 2],
+    [4, 3],
+  ]);
+
+  it('confirms a top placement', () => {
+    expect(isPlacedAsRequested(after, 3, 'top')).toBe(true);
+    expect(isPlacedAsRequested(after, 1, 'top')).toBe(false);
+  });
+
+  it('confirms a bottom placement', () => {
+    expect(isPlacedAsRequested(after, 4, 'bottom')).toBe(true);
+    expect(isPlacedAsRequested(after, 2, 'bottom')).toBe(false);
+  });
+
+  it('confirms before/after placements', () => {
+    expect(isPlacedAsRequested(after, 1, 'after', 3)).toBe(true);
+    expect(isPlacedAsRequested(after, 1, 'before', 2)).toBe(true);
+    expect(isPlacedAsRequested(after, 1, 'before', 4)).toBe(false);
+  });
+
+  it('is false when the article or reference is missing', () => {
+    expect(isPlacedAsRequested(after, 99, 'top')).toBe(false);
+    expect(isPlacedAsRequested(after, 1, 'after', 99)).toBe(false);
+  });
+});

--- a/tests/unit/utils/article-order.test.ts
+++ b/tests/unit/utils/article-order.test.ts
@@ -107,6 +107,22 @@ describe('computePositionWrites (gap-aware, default)', () => {
     expect(computePositionWrites(desired, 2, false)).toEqual([{ id: 2, position: 11 }]);
   });
 
+  it('bottom is a no-op when the article is already last (idempotent)', () => {
+    const section = ord([
+      [1, 0],
+      [2, 1],
+      [3, 5],
+    ]);
+    const desired = arrangeDesiredOrder(section, 3, 'bottom');
+    expect(computePositionWrites(desired, 3, false)).toEqual([]);
+  });
+
+  it('bottom on a single-article section is a no-op', () => {
+    const section = ord([[1, 4]]);
+    const desired = arrangeDesiredOrder(section, 1, 'bottom');
+    expect(computePositionWrites(desired, 1, false)).toEqual([]);
+  });
+
   it('top with slack below is a single write (position 0)', () => {
     const section = ord([
       [1, 5],
@@ -224,10 +240,12 @@ describe('isPlacedAsRequested', () => {
     expect(isPlacedAsRequested(after, 2, 'bottom')).toBe(false);
   });
 
-  it('confirms before/after placements', () => {
-    expect(isPlacedAsRequested(after, 1, 'after', 3)).toBe(true);
-    expect(isPlacedAsRequested(after, 1, 'before', 2)).toBe(true);
-    expect(isPlacedAsRequested(after, 1, 'before', 4)).toBe(false);
+  it('confirms before/after placements by side, not strict adjacency', () => {
+    // after = [3, 1, 2, 4]; article 1 is at index 1.
+    expect(isPlacedAsRequested(after, 1, 'after', 3)).toBe(true); // 1 is after 3
+    expect(isPlacedAsRequested(after, 1, 'before', 2)).toBe(true); // 1 is before 2
+    expect(isPlacedAsRequested(after, 1, 'before', 4)).toBe(true); // 1 is before 4 (not adjacent, still before)
+    expect(isPlacedAsRequested(after, 1, 'after', 2)).toBe(false); // 1 is NOT after 2
   });
 
   it('is false when the article or reference is missing', () => {


### PR DESCRIPTION
## Summary
Adds a `reorder_article` Help Center tool that moves an article within its section relative to its siblings — `top`, `bottom`, or `before`/`after` another article — and reports whether the new order actually took effect. This replaces the fragile, multi-call "set each `position` by hand" workaround: it writes the minimal set of positions needed to make the order deterministic even when several articles are tied at `position: 0`.

## Linked issue
Closes #134

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally (518 tests)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
- [x] If the change has runtime-observable behaviour: this PR carries a `## Functional validation plan` (authored with `/functional-validation-plan`), and it has been executed by an independent validator (`/run-validation-plan`) whose report is posted as a PR comment

## Notes for the reviewer (human or AI)
Design decisions worth validating:
- **Gap-aware placement (default).** The tool sets an article's absolute `position` on a free integer between its two new neighbours, so `bottom` and roomy `before`/`after` cost **one write**; `top` is one write when slot 0 is free. It degrades to a bounded right-cascade only when neighbours leave no integer room, and to O(N) only on a section saturated with ties (the #134 case — a genuine lower bound). Trade-off: positions drift and leave gaps (invisible to end users, and cheap for later moves). `normalize: true` renumbers the section 0..N contiguously on demand.
- **No sort-mode field exists in Zendesk's API.** Auto-sorted sections (by date / alphabetical) silently ignore `position` writes (they return 200). Detection is best-effort: an up-front inversion probe avoids mass-writing a large auto-sorted section, and a definitive post-write re-read of the effective order catches every case, returning guidance to switch the section to Manual in Guide (no fabricated admin deep-link — none is stable across Guide versions).
- **Blast-radius guard** `ZENDESK_REORDER_CONFIRM_THRESHOLD` (default 20): refuses without `confirm: true` and reports the count.
- **Idempotency:** positions are absolute, so a re-run after a partial failure recomputes against current state and resumes without double-applying.
- Pure ordering logic is isolated in `src/utils/article-order.ts` (unit-tested directly); the handler in `src/tools/help-center.ts` does only I/O. Namespace/tool counts and doc tables were bumped/synced.
- Follow-up: MCP elicitation for the confirm guard is tracked separately in #158 (kept out of scope to preserve multi-agent compatibility).

## Functional validation plan

### Context
The feature is the `reorder_article` MCP tool (namespace `help_center`). It is exercised **only** by calling `mcp__zendesk-local__reorder_article`; it reads a section's effective order via the articles list and writes `position` via the article-update endpoint. No other tool or transport exercises this code. `update_article`'s `section_id` (moving an article *between* sections) is a different path and out of scope here.

Everything numeric and every branch (gap-aware math, normalize, tie-breaking, threshold refusal, auto-sort detection, partial-failure) is already covered by unit tests (`tests/unit/utils/article-order.test.ts`, the `reorder_article` block in `tests/unit/tools/help-center.test.ts`) and an over-the-wire integration round-trip (`tests/integration/core-scenarios.ts`). This plan validates the behaviour against the **real Zendesk Help Center**, which the mocks cannot prove.

### Setup & prerequisites
The environment is already on the branch with the authenticated server running; drive it via the `mcp__zendesk-local__*` tools. Record the commit under test with `git rev-parse HEAD`.

**Pick a throwaway, manually-sorted section** (ideally a small test/sandbox section, ≥ 4 articles). Use `mcp__zendesk-local__list_sections` and `mcp__zendesk-local__list_articles` to choose one.

**Snapshot first, restore last (mandatory).** Before any scenario, capture the section's current order and each article's `position`:
`mcp__zendesk-local__list_articles { section_id: <S>, sort_by: "position", sort_order: "asc" }` — save the id→position map. After all scenarios, restore it (reorder or `update_article` per article, or one `reorder_article … normalize:true` pass followed by re-applying the saved order). Confirm the restored order matches the snapshot.

**Bounding real writes.** Prefer short-distance moves and a small section so each scenario is a handful of PUTs. Treat a hundreds-of-article section only as an optional documented stress check (measure the reported "N repositioned" count and the threshold refusal), not the default.

### Scenarios
| id | Validates | Manipulation & call | Expected observable |
|----|-----------|---------------------|---------------------|
| V1 | Move to top (real display) | On section S with a known non-first article A: `reorder_article { article_id: A, target: "top" }` | Success text `moved to top … section #S (N … repositioned)`. Re-list without sort → A is index 0. |
| V2 | Move to bottom, single write | `reorder_article { article_id: A, target: "bottom" }` | Success text says **1 article repositioned**; re-list → A is last. |
| V3 | before / after a reference | `reorder_article { article_id: A, target: "before", reference_article_id: B }` then `"after"` | Re-list → A immediately precedes / follows B. |
| V4 | Tie-break (#134) | Create 2–3 articles (they land at `position 0`) via `create_article`; move one to top | Success; re-list → the moved one is uniquely first; `list_articles sort_by=position` shows distinct positions (ties broken). |
| V5 | normalize | `reorder_article { article_id: A, target: "top", normalize: true }` | Success; `list_articles sort_by=position` shows contiguous 0,1,2,… |
| V6 | Threshold guard | On a section with > 20 articles (or lower `ZENDESK_REORDER_CONFIRM_THRESHOLD` is NOT available to the validator — use a large section), move a deep article to top **without** confirm | Refusal text `above the safety threshold of 20`; re-list → order **unchanged**. Then repeat with `confirm: true` → success. |
| V7 | Auto-sorted section (⚠) | In Guide, set a scratch section's "Order articles by" to **Creation date**; call `reorder_article … target:"top"` | Returns guidance containing `sorted automatically` and `Order articles by`; re-list → order unchanged. (Requires Guide UI access; mark BLOCKED if unavailable.) |
| V8 | Validation errors | `target:"before"` with no `reference_article_id`; `target:"top"` with a reference; reference == article; reference in another section | Each returns a clear error and makes **no** writes. |
| V9 | Idempotent re-run | Immediately re-run a V1/V3 call | Reports `already positioned … No changes made` (0 writes). |

### Long-running behaviours
None — the tool has no time-based behaviour. All timing-independent branches are covered by the unit suite; the validator only needs to confirm the real round-trip.

### Priorities
Do **V1, V2, V4, V6** first (the core user-facing paths: first/last, tie-break, the guard). V7 depends on Guide UI access. V3/V5/V8/V9 round out coverage.

### Reporting
Post a PR comment (English) with, per scenario id, an **OK / FAIL / BLOCKED** verdict and the observed evidence (the tool's returned text and the re-listed order). Confirm the tested commit SHA and that the section was restored to its snapshot. End with a green/failing summary.

---
https://claude.ai/code/session_01F82kn9YT3MaV2cVH7Ushyd

---
_Generated by [Claude Code](https://claude.ai/code/session_01F82kn9YT3MaV2cVH7Ushyd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Help Center `reorder_article` tool to move articles (top/bottom/before/after) within a section, with deterministic tie-handling, optional normalization, no-op detection, and auto-sort awareness (with verification after writes).
  * Refuses large write sets unless confirmation is provided.
* **Documentation**
  * Documented `ZENDESK_REORDER_CONFIRM_THRESHOLD` (optional, default `20`) and updated the tools reference to include `reorder_article`.
* **Tests**
  * Expanded unit and integration tests for ordering calculations, validation, auto-sorted behavior, and mid-write failure recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->