### PR TITLE
fix(help-center): degrade topology gracefully when Guide-admin endpoints 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,12 @@ disabled together with `--no-topology`):
   read on demand, it returns Markdown describing the active locales (and the
   default), the category → section tree with IDs, the visibility user segments,
   the permission groups, and the calling user's role. It is fetched **with the
-  caller's own token**, so it respects that user's read permissions. On a very
-  large Help Center the section tree is summarized (per-category, with a pointer
-  to `list_sections`) to stay concise.
+  caller's own token**, so it respects that user's read permissions. Listing the
+  permission groups and user segments needs Guide-admin / Help Center manager
+  rights; with a content-editor token those two sections are marked *unavailable*
+  (not empty) and the rest still renders — reuse those IDs from an existing
+  article (`get_article`) instead. On a very large Help Center the section tree is
+  summarized (per-category, with a pointer to `list_sections`) to stay concise.
 
 Clients that don't consume `instructions` or `resources` simply ignore them —
 the feature degrades silently. Use `--no-topology` to turn both off server-wide.

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -48,10 +48,10 @@ out every `write` tool before the proxies are built.
 | `list_articles` | List articles with sorting and translation info | read |
 | `list_article_translations` | List available translations for an article | read |
 | `list_article_attachments` | List attachments on an article | read |
-| `list_permission_groups` | List Guide permission groups (needed to create articles) | read |
+| `list_permission_groups` | List Guide permission groups (needed to create articles; requires Guide-admin / Help Center manager rights) | read |
 | `list_content_tags` | List Guide content tags (end-user visible), cursor-paginated with name-prefix filter and sort | read |
 | `list_labels` | List article labels (search ranking, not user-visible) | read |
-| `list_user_segments` | List user segments (article visibility) | read |
+| `list_user_segments` | List user segments (article visibility; requires Guide-admin / Help Center manager rights) | read |
 | `compare_translations` | Section-level diff between two locales of an article | read |
 | `create_article` | Create a new article in a section | write |
 | `update_article` | Update article metadata (draft, labels, tags, visibility, section, sort position) | write |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,6 +39,19 @@ reused across restarts, so this shouldn't happen. If it does, check that the fil
 is writable (`ZENDESK_TOKEN_FILE` to relocate it) and look for
 `token_persist_failed` in the logs.
 
+## `Permission denied` on `list_permission_groups`, `list_user_segments`, or the topology resource
+
+Enumerating Guide permission groups and Help Center user segments requires
+**Guide-admin / Help Center manager** rights — a tier above the per-article edit
+rights an agent may already have. A content-editor token gets HTTP `403` on those
+two endpoints. This does **not** block content editing: the `zendesk-hc://topology`
+resource degrades gracefully (the two admin-only sections are marked *unavailable*
+rather than failing the whole resource), and the two tools return guidance instead
+of a bare error. When you need a `permission_group_id` or `user_segment_id` without
+those rights, read an existing article with `get_article` and reuse the IDs it
+reports; omitting `user_segment_id` on create/update keeps the default visibility
+(everyone).
+
 Where each client writes the server's stderr:
 
 | Client | Log location |

--- a/src/guidance/instructions.ts
+++ b/src/guidance/instructions.ts
@@ -25,10 +25,13 @@ export const buildInstructions = (config: Config): string | undefined => {
   return [
     `This MCP server is connected to the Zendesk Help Center of "${config.subdomain}".`,
     '',
-    `Before creating or editing Help Center content, read the resource ${TOPOLOGY_RESOURCE_URI}.`,
-    'It describes the active locales (and the default one), the category → section tree with IDs,',
+    `When creating or editing Help Center content, the resource ${TOPOLOGY_RESOURCE_URI} is useful context:`,
+    'it lists the active locales (and the default one), the category → section tree with IDs,',
     'the visibility user segments, the permission groups, and your current role.',
-    'Prefer the IDs from that resource (section_id, permission_group_id, user_segment_id, locale)',
-    'over guessing from names.',
+    'Prefer its IDs (section_id, permission_group_id, user_segment_id, locale) over guessing from names.',
+    '',
+    'It degrades gracefully: without Guide-admin / Help Center manager rights the permission-groups and',
+    'user-segments sections are marked unavailable (not empty). In that case reuse a permission_group_id',
+    'or user_segment_id from an existing article (get_article) instead.',
   ].join('\n');
 };

--- a/src/guidance/topology.ts
+++ b/src/guidance/topology.ts
@@ -29,9 +29,35 @@ export interface TopologyData {
   /** True when the tenant has more categories than a single page (tree omitted). */
   categoriesHasMore: boolean;
   userSegments: ZendeskUserSegment[];
+  /** True when listing user segments was forbidden (403), not merely empty. */
+  userSegmentsDenied: boolean;
   permissionGroups: ZendeskPermissionGroup[];
+  /** True when listing permission groups was forbidden (403), not merely empty. */
+  permissionGroupsDenied: boolean;
   currentUser: ZendeskUser;
 }
+
+/**
+ * Resolve an admin-gated fetch to a sentinel on HTTP 403 instead of rejecting.
+ * Enumerating permission groups and user segments requires Guide-admin / Help
+ * Center manager rights — a tier above per-article editing — so a content-editor
+ * token gets 403 there while the rest of the topology is readable (#161). Any
+ * other failure rethrows; crucially a 401 still propagates so the stale token
+ * gets invalidated (see `onUnauthorized` in `createTopologyProvider`).
+ */
+const tolerate403 = async <T>(
+  promise: Promise<T>,
+  fallback: T,
+): Promise<{ value: T; denied: boolean }> => {
+  try {
+    return { value: await promise, denied: false };
+  } catch (error) {
+    if (error instanceof ZendeskApiError && error.status === 403) {
+      return { value: fallback, denied: true };
+    }
+    throw error;
+  }
+};
 
 /**
  * Fetch the structural topology with the CALLER'S token, so the result respects
@@ -41,7 +67,7 @@ export interface TopologyData {
  */
 export const fetchTopology = async (subdomain: string, token: string): Promise<TopologyData> => {
   const pageParams = { 'page[size]': String(MAX_PAGE_SIZE) };
-  const [locales, categoriesRes, sectionsRes, segmentsRes, permsRes, meRes] = await Promise.all([
+  const [locales, categoriesRes, sectionsRes, segments, perms, meRes] = await Promise.all([
     helpCenterGet<ZendeskLocalesResponse>(subdomain, token, '/locales'),
     helpCenterGet<ZendeskListResponse<ZendeskCategory>>(
       subdomain,
@@ -50,11 +76,18 @@ export const fetchTopology = async (subdomain: string, token: string): Promise<T
       pageParams,
     ),
     helpCenterGet<ZendeskListResponse<ZendeskSection>>(subdomain, token, '/sections', pageParams),
-    helpCenterGet<{ user_segments: ZendeskUserSegment[] }>(subdomain, token, '/user_segments'),
-    zendeskGet<{ permission_groups: ZendeskPermissionGroup[] }>(
-      subdomain,
-      token,
-      '/guide/permission_groups',
+    // Admin-gated: degrade to empty on 403 rather than failing the whole resource.
+    tolerate403(
+      helpCenterGet<{ user_segments: ZendeskUserSegment[] }>(subdomain, token, '/user_segments'),
+      { user_segments: [] },
+    ),
+    tolerate403(
+      zendeskGet<{ permission_groups: ZendeskPermissionGroup[] }>(
+        subdomain,
+        token,
+        '/guide/permission_groups',
+      ),
+      { permission_groups: [] },
     ),
     zendeskGet<{ user: ZendeskUser }>(subdomain, token, '/users/me'),
   ]);
@@ -68,8 +101,10 @@ export const fetchTopology = async (subdomain: string, token: string): Promise<T
     sections,
     sectionsHasMore: extractPaginationMeta(sectionsRes, sections.length).has_more,
     categoriesHasMore: extractPaginationMeta(categoriesRes, categories.length).has_more,
-    userSegments: segmentsRes.user_segments ?? [],
-    permissionGroups: permsRes.permission_groups ?? [],
+    userSegments: segments.value.user_segments ?? [],
+    userSegmentsDenied: segments.denied,
+    permissionGroups: perms.value.permission_groups ?? [],
+    permissionGroupsDenied: perms.denied,
     currentUser: meRes.user,
   };
 };
@@ -111,6 +146,16 @@ const renderTree = (data: TopologyData): string[] => {
   return lines.length ? lines : ['_(no categories)_'];
 };
 
+/**
+ * Render an admin-gated section as one of three states so the LLM never mistakes
+ * "you can't see this" for "there are none": the formatted list, `_(none)_` when
+ * genuinely empty, or `deniedNote` when the token was forbidden (403).
+ */
+const renderAdminSection = (items: string[], denied: boolean, deniedNote: string): string[] => {
+  if (denied) return [deniedNote];
+  return items.length ? items : ['_(none)_'];
+};
+
 /** Render the topology as a compact Markdown document for the LLM context. */
 export const formatTopology = (data: TopologyData): string => {
   const text = [
@@ -126,12 +171,18 @@ export const formatTopology = (data: TopologyData): string => {
     ...renderTree(data),
     '',
     '## Visibility (user segments)',
-    ...(data.userSegments.length ? data.userSegments.map(formatUserSegment) : ['_(none)_']),
+    ...renderAdminSection(
+      data.userSegments.map(formatUserSegment),
+      data.userSegmentsDenied,
+      '_Unavailable: listing user segments requires Guide-admin / Help Center manager rights, which this token lacks (HTTP 403). To set visibility, reuse the user_segment_id of an existing article (get_article), or omit it to default to everyone._',
+    ),
     '',
     '## Permission groups',
-    ...(data.permissionGroups.length
-      ? data.permissionGroups.map(formatPermissionGroup)
-      : ['_(none)_']),
+    ...renderAdminSection(
+      data.permissionGroups.map(formatPermissionGroup),
+      data.permissionGroupsDenied,
+      '_Unavailable: listing permission groups requires Guide-admin / Help Center manager rights, which this token lacks (HTTP 403). To create or edit an article, reuse the permission_group_id of an existing article (get_article)._',
+    ),
   ].join('\n');
 
   return truncateIfNeeded(text);

--- a/src/server.ts
+++ b/src/server.ts
@@ -304,7 +304,7 @@ export const registerToolset = (
           {
             title: 'Zendesk Help Center topology',
             description:
-              'Active locales, category → section tree, visibility segments, permission groups, and your role. Read before creating or editing content.',
+              'Active locales, category → section tree, visibility segments, permission groups, and your role. Useful context when creating or editing content; admin-only sections (permission groups, user segments) are marked unavailable rather than empty when your role lacks Guide-admin rights.',
             mimeType: 'text/markdown',
           },
           async (uri) => ({

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -643,7 +643,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           .int()
           .optional()
           .describe(
-            'User segment ID for visibility (use list_user_segments to find it). Defaults to everyone.',
+            'User segment ID for visibility (use list_user_segments to find it; if that is forbidden because the token is not a Guide admin, reuse the user_segment_id of an existing article from get_article). Defaults to everyone.',
           ),
         author_id: z
           .number()
@@ -739,7 +739,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           .int()
           .optional()
           .describe(
-            'User segment that controls who can see the article (id from list_user_segments).',
+            'User segment that controls who can see the article (id from list_user_segments; if that is forbidden because the token is not a Guide admin, reuse the user_segment_id of an existing article from get_article).',
           ),
         author_id: z
           .number()
@@ -751,7 +751,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           .int()
           .optional()
           .describe(
-            'Guide permission group controlling who can edit (id from list_permission_groups).',
+            'Guide permission group controlling who can edit (id from list_permission_groups; if that is forbidden because the token is not a Guide admin, reuse the permission_group_id of an existing article from get_article).',
           ),
         section_id: z
           .number()

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -5,6 +5,7 @@ import {
   helpCenterPost,
   helpCenterPut,
   helpCenterUpload,
+  ZendeskApiError,
   zendeskGet,
   zendeskPost,
 } from '../client/zendesk-api';
@@ -586,10 +587,24 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       },
       handler: async () => {
         const token = await getToken();
-        const response = await zendeskGet<{
-          permission_groups: ZendeskPermissionGroup[];
-          count: number;
-        }>(subdomain, token, '/guide/permission_groups');
+        let response: { permission_groups: ZendeskPermissionGroup[]; count: number };
+        try {
+          response = await zendeskGet<{
+            permission_groups: ZendeskPermissionGroup[];
+            count: number;
+          }>(subdomain, token, '/guide/permission_groups');
+        } catch (error) {
+          // GET /guide/permission_groups requires Guide-admin / Help Center manager
+          // rights, a tier above per-article editing. Rewrite the generic 403 into
+          // guidance the LLM can act on, pointing at the content-editor fallback.
+          if (error instanceof ZendeskApiError && error.status === 403) {
+            throw new Error(
+              'list_permission_groups reads Guide permission groups (GET /guide/permission_groups), which Zendesk restricts to Guide admins / Help Center managers. The current token lacks that role (HTTP 403). To obtain a permission_group_id without it, read an existing article with get_article and reuse its permission_group_id.',
+              { cause: error },
+            );
+          }
+          throw error;
+        }
         return {
           content: [
             {
@@ -620,7 +635,9 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         permission_group_id: z
           .number()
           .int()
-          .describe('Permission group ID (use list_permission_groups to find it)'),
+          .describe(
+            'Permission group ID (use list_permission_groups to find it; if that is forbidden because the token is not a Guide admin, reuse the permission_group_id of an existing article from get_article).',
+          ),
         user_segment_id: z
           .number()
           .int()
@@ -969,10 +986,24 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       },
       handler: async () => {
         const token = await getToken();
-        const response = await helpCenterGet<{
-          user_segments: ZendeskUserSegment[];
-          count: number;
-        }>(subdomain, token, '/user_segments');
+        let response: { user_segments: ZendeskUserSegment[]; count: number };
+        try {
+          response = await helpCenterGet<{
+            user_segments: ZendeskUserSegment[];
+            count: number;
+          }>(subdomain, token, '/user_segments');
+        } catch (error) {
+          // GET /help_center/user_segments requires Guide-admin / Help Center manager
+          // rights. Rewrite the generic 403 into actionable guidance with the
+          // content-editor fallback for setting article visibility.
+          if (error instanceof ZendeskApiError && error.status === 403) {
+            throw new Error(
+              "list_user_segments reads Help Center user segments (GET /help_center/user_segments), which Zendesk restricts to Guide admins / Help Center managers. The current token lacks that role (HTTP 403). To set an article's visibility without it, reuse the user_segment_id of an existing article (get_article), or omit user_segment_id when creating/updating to default to everyone.",
+              { cause: error },
+            );
+          }
+          throw error;
+        }
         return {
           content: [
             { type: 'text', text: formatList(response.user_segments ?? [], formatUserSegment) },

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,6 +291,8 @@ export interface ZendeskArticle {
   author_id: number;
   section_id: number;
   permission_group_id: number;
+  /** Visibility segment; null/absent means the article is visible to everyone. */
+  user_segment_id?: number | null;
   draft: boolean;
   promoted: boolean;
   position: number;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -374,7 +374,7 @@ export const formatArticleSummary = (article: ZendeskArticle): string =>
     // Surface the visibility/edit IDs so an editor without Guide-admin rights can
     // reuse them (list_permission_groups / list_user_segments are admin-gated, #161).
     `- **Permission group**: ${article.permission_group_id} | **User segment**: ${
-      article.user_segment_id == null ? 'everyone (no segment)' : article.user_segment_id
+      article.user_segment_id ?? 'everyone (no segment)'
     }`,
     typeof article.position === 'number' ? `- **Position**: ${article.position}` : '',
     article.label_names.length > 0 ? `- **Labels**: ${article.label_names.join(', ')}` : '',

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -371,6 +371,11 @@ export const formatArticleSummary = (article: ZendeskArticle): string =>
     `## ${article.title} (${article.id})`,
     `- **Locale**: ${article.locale} | **Source locale**: ${article.source_locale}`,
     `- **Section**: ${article.section_id} | **Draft**: ${article.draft}`,
+    // Surface the visibility/edit IDs so an editor without Guide-admin rights can
+    // reuse them (list_permission_groups / list_user_segments are admin-gated, #161).
+    `- **Permission group**: ${article.permission_group_id} | **User segment**: ${
+      article.user_segment_id == null ? 'everyone (no segment)' : article.user_segment_id
+    }`,
     typeof article.position === 'number' ? `- **Position**: ${article.position}` : '',
     article.label_names.length > 0 ? `- **Labels**: ${article.label_names.join(', ')}` : '',
     `- **Created**: ${article.created_at} | **Updated**: ${article.updated_at}`,

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -77,6 +77,22 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(text).toContain('(600)'); // section FAQ
         expect(text).toContain('admin'); // current user role
       });
+
+      it('still renders the topology for a content-editor token that is forbidden the admin-only parts (#161)', async () => {
+        mswServer.use(errorHandlers.permissionGroupsForbidden);
+        connected = await harness.connect(makeConfig());
+
+        const read = await connected.client.readResource({ uri: 'zendesk-hc://topology' });
+        const text = (read.contents ?? [])
+          .map((c) => (typeof c.text === 'string' ? c.text : ''))
+          .join('\n');
+        // The readable structure still comes back instead of a -32603 failure.
+        expect(text).toContain('(800)');
+        expect(text).toContain('(600)');
+        expect(text).toContain('admin');
+        // The admin-only section is flagged unavailable, not silently empty.
+        expect(text).toMatch(/Guide.?admin/i);
+      });
     });
 
     describe('tools/list', () => {

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -187,6 +187,8 @@ export const MOCK_ARTICLE = {
   source_locale: 'en-us',
   author_id: 9999,
   section_id: 600,
+  permission_group_id: 12001,
+  user_segment_id: 15001,
   draft: false,
   promoted: false,
   position: 0,
@@ -430,6 +432,20 @@ export const errorHandlers = {
   ),
   localesUnauthorized: http.get(
     `${HC_BASE}/locales`,
+    () => new HttpResponse('unauthorized', { status: 401 }),
+  ),
+  // Guide admin / Help Center manager gate: a content-editor token gets 403 on
+  // the permission-groups and user-segments endpoints (issue #161).
+  permissionGroupsForbidden: http.get(`${BASE}/guide/permission_groups`, () =>
+    HttpResponse.json({ error: 'Forbidden' }, { status: 403 }),
+  ),
+  userSegmentsForbidden: http.get(`${HC_BASE}/user_segments`, () =>
+    HttpResponse.json({ error: 'Forbidden' }, { status: 403 }),
+  ),
+  // A 401 (not 403) on the same admin endpoint must still hard-fail topology, so
+  // the stale-token invalidation path keeps firing (guards against swallowing it).
+  permissionGroupsUnauthorized: http.get(
+    `${BASE}/guide/permission_groups`,
     () => new HttpResponse('unauthorized', { status: 401 }),
   ),
 };

--- a/tests/unit/guidance/topology.test.ts
+++ b/tests/unit/guidance/topology.test.ts
@@ -40,6 +40,36 @@ describe('fetchTopology', () => {
     const data = await fetchTopology(SUBDOMAIN, TOKEN);
     expect(data.categoriesHasMore).toBe(true);
   });
+
+  it('degrades gracefully when permission_groups is forbidden (403), keeping the rest', async () => {
+    mswServer.use(errorHandlers.permissionGroupsForbidden);
+    const data = await fetchTopology(SUBDOMAIN, TOKEN);
+
+    expect(data.permissionGroups).toEqual([]);
+    expect(data.permissionGroupsDenied).toBe(true);
+    // Everything the content-editor token *can* read still comes back.
+    expect(data.userSegmentsDenied).toBe(false);
+    expect(data.userSegments.map((s) => s.id)).toEqual([15001]);
+    expect(data.categories.map((c) => c.id)).toEqual([800]);
+    expect(data.sections.map((s) => s.id)).toEqual([600]);
+    expect(data.currentUser.id).toBe(9999);
+  });
+
+  it('degrades gracefully when user_segments is forbidden (403), keeping the rest', async () => {
+    mswServer.use(errorHandlers.userSegmentsForbidden);
+    const data = await fetchTopology(SUBDOMAIN, TOKEN);
+
+    expect(data.userSegments).toEqual([]);
+    expect(data.userSegmentsDenied).toBe(true);
+    expect(data.permissionGroupsDenied).toBe(false);
+    expect(data.permissionGroups.map((g) => g.id)).toEqual([12001]);
+    expect(data.currentUser.id).toBe(9999);
+  });
+
+  it('still hard-fails on a 401 from an admin endpoint (not swallowed as degradation)', async () => {
+    mswServer.use(errorHandlers.permissionGroupsUnauthorized);
+    await expect(fetchTopology(SUBDOMAIN, TOKEN)).rejects.toBeInstanceOf(ZendeskApiError);
+  });
 });
 
 const baseData = (): TopologyData => ({
@@ -70,6 +100,8 @@ const baseData = (): TopologyData => ({
   ],
   sectionsHasMore: false,
   categoriesHasMore: false,
+  userSegmentsDenied: false,
+  permissionGroupsDenied: false,
   userSegments: [
     {
       id: 15001,
@@ -125,6 +157,32 @@ describe('formatTopology', () => {
     expect(text).toContain('list_categories');
     // Tree is omitted (categories list is itself partial), so the section is not shown.
     expect(text).not.toContain('FAQ');
+  });
+
+  it('marks permission groups as unavailable (not empty) when denied by permissions', () => {
+    const text = formatTopology({
+      ...baseData(),
+      permissionGroups: [],
+      permissionGroupsDenied: true,
+    });
+    // The section must read as "you cannot see this" rather than "there are none".
+    expect(text).toMatch(/Guide.?admin/i);
+    expect(text).toContain('get_article');
+    // The tree and role the token *can* read are still rendered.
+    expect(text).toContain('General');
+    expect(text).toContain('admin');
+    // "_(none)_" would falsely tell the LLM there are zero permission groups.
+    expect(text).not.toContain('## Permission groups\n_(none)_');
+  });
+
+  it('marks user segments as unavailable (not empty) when denied by permissions', () => {
+    const text = formatTopology({
+      ...baseData(),
+      userSegments: [],
+      userSegmentsDenied: true,
+    });
+    expect(text).toMatch(/Guide.?admin/i);
+    expect(text).not.toContain('## Visibility (user segments)\n_(none)_');
   });
 });
 

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -215,6 +215,23 @@ describe('help center tools', () => {
       expect(result.content[0]?.text).toContain('Editors');
       expect(result.content[0]?.text).toContain('12001');
     });
+
+    it('explains the Guide-admin requirement (and the fallback) on a 403', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/guide/permission_groups', () =>
+          HttpResponse.json({ error: 'Forbidden' }, { status: 403 }),
+        ),
+      );
+      const tool = findTool('list_permission_groups');
+      const error = await tool.handler({}).then(
+        () => {
+          throw new Error('expected list_permission_groups to reject on 403');
+        },
+        (err: unknown) => err as Error,
+      );
+      expect(error.message).toMatch(/Guide.?admin|admin/i);
+      expect(error.message).toMatch(/get_article/);
+    });
   });
 
   describe('create_article', () => {
@@ -356,6 +373,23 @@ describe('help center tools', () => {
       const result = await tool.handler({});
       expect(result.content[0]?.text).toContain('Signed-in users');
       expect(result.content[0]?.text).toContain('15001');
+    });
+
+    it('explains the Guide-admin requirement (and the fallback) on a 403', async () => {
+      mswServer.use(
+        http.get(`${HC_BASE}/user_segments`, () =>
+          HttpResponse.json({ error: 'Forbidden' }, { status: 403 }),
+        ),
+      );
+      const tool = findTool('list_user_segments');
+      const error = await tool.handler({}).then(
+        () => {
+          throw new Error('expected list_user_segments to reject on 403');
+        },
+        (err: unknown) => err as Error,
+      );
+      expect(error.message).toMatch(/Guide.?admin|admin/i);
+      expect(error.message).toMatch(/get_article/);
     });
   });
 

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -340,6 +340,21 @@ describe('formatArticleSummary', () => {
     expect(result).toContain('guide');
   });
 
+  it('surfaces the permission group and user segment so their IDs can be reused', () => {
+    const result = formatArticleSummary(MOCK_ARTICLE);
+    expect(result).toContain('12001');
+    expect(result).toContain('15001');
+  });
+
+  it('marks visibility as everyone when the article has no user segment', () => {
+    const result = formatArticleSummary({
+      ...MOCK_ARTICLE,
+      user_segment_id: null,
+    });
+    expect(result).toContain('12001');
+    expect(result).toMatch(/everyone/i);
+  });
+
   it('omits labels when empty', () => {
     const result = formatArticleSummary({ ...MOCK_ARTICLE, label_names: [] });
     expect(result).not.toContain('Labels');


### PR DESCRIPTION
## Summary

Enumerating Guide permission groups (`GET /guide/permission_groups`) and Help
Center user segments (`GET /help_center/user_segments`) requires **Guide-admin /
Help Center manager** rights — a tier above the per-article edit rights an agent
may already hold. A content-editor token gets `403` on both, and because the
server's usage instructions made *reading `zendesk-hc://topology` a required first
step*, a single admin-only dependency took down an otherwise fully-working
content-editing flow: the whole topology resource failed with `-32603 Permission
denied`, and both list tools returned a bare "Permission denied".

This makes the 403 tier a soft edge instead of a hard wall.

Closes #161

## Changes

- **Topology degrades gracefully** (`src/guidance/topology.ts`). A local
  `tolerate403` helper wraps only the two admin-gated calls: on `403` they resolve
  to an empty sentinel and the section is rendered as **unavailable** (not empty),
  while locales / category→section tree / current role still render. Every other
  error — crucially `401` — still propagates, so stale-token invalidation
  (`onUnauthorized`) keeps working. `Promise.all` parallelism is preserved.
- **The two tools return actionable guidance on 403**
  (`list_permission_groups`, `list_user_segments`). Mirrors the existing
  `tickets.ts` 403 handlers: the generic error is remapped to name the required
  role and point at the content-editor fallback (reuse the id from an existing
  article via `get_article`).
- **Article summaries surface the IDs** (`formatArticleSummary`,
  `ZendeskArticle.user_segment_id`). `permission_group_id` and `user_segment_id`
  now appear on every article-returning tool, so an editor can reuse them without
  the admin-only endpoints — this is the data that makes the advertised fallback
  real.
- **Instructions / resource description / docs reworded** so topology is *useful
  context*, not a hard admin-gated prerequisite (`instructions.ts`, `server.ts`,
  `README.md`, `docs/mcp-tools-reference.md`, `docs/troubleshooting.md`).

## Tests

- `tests/unit/guidance/topology.test.ts`: 403 on each admin endpoint degrades to
  `[]` + `*Denied=true` with the rest intact; **401 still hard-fails** (guards
  against swallowing it); `formatTopology` renders the tri-state note.
- `tests/unit/tools/help-center.test.ts`: both tools reject on 403 with a message
  naming Guide-admin and the `get_article` fallback.
- `tests/unit/utils/formatting.test.ts`: the two IDs are surfaced; `null` segment
  renders "everyone".
- `tests/integration/core-scenarios.ts`: end-to-end repro of #161 — the topology
  resource still renders for a token forbidden the admin-only parts.

No tools added; no JSON Schema field dropped or loosened (superset preserved).
`pnpm check`, `pnpm typecheck`, and `pnpm test:coverage` all green.

## Functional validation plan

**Validated commit:** `3edffb5` (capture your actual `git rev-parse HEAD`).

### Context

The change is exercised through the `mcp__zendesk-local__*` tool surface and the
`zendesk-hc://topology` resource. The behaviour split hinges on **the role of the
token the running server is authenticated with**:

- The **article-ID surfacing** (S1) and **topology renders at all** (S2) are
  observable with **any** token.
- The **403 degradation itself** (S3–S5) is only reproducible with a
  **non-Guide-admin (content-editor)** token. With a Guide-admin token you instead
  validate the **non-regression** (lists still populate). There is no MCP lever to
  inject a 403, so if the token is an admin, S3–S5's *degradation* path is
  `BLOCKED` for live validation and is covered by the automated tests above —
  report it as such, do not try to build a downgraded token.

First, determine the token's role: call `mcp__zendesk-local__get_current_user`
and note `role` (`admin`/`agent`/`end-user`) — this decides the S3–S5 branch.

### Setup & prerequisites

None beyond the ready environment. No state to seed; all scenarios are read-only
except none write. Observe results directly in the returned tool output / resource
text. No `LOG_LEVEL` change needed.

### Scenarios

| id | Validates | Manipulation / call | Expected observable |
|----|-----------|---------------------|---------------------|
| S1 | Article summaries surface the reuse IDs | `list_articles` (or `search_articles`) to pick a real article id, then `get_article` on it | Output contains a line with **Permission group** `<id>` and **User segment** `<id>` (or "everyone (no segment)" when the article has none). This is the fallback data path. |
| S2 | Topology resource reads and renders | Read resource `zendesk-hc://topology` | Markdown with active locales, the category → section tree with IDs, and "Your access … role" — returns content, not an error. |
| S3 | Topology degrades (content-editor) **or** non-regression (admin) | Read `zendesk-hc://topology` | **Non-admin token:** the *Visibility (user segments)* and *Permission groups* sections read "Unavailable … requires Guide-admin / Help Center manager rights … reuse … get_article", and the tree/role above still render (no `-32603`). **Admin token:** those two sections list real entries → validates non-regression; mark the degradation path itself as covered-by-tests. |
| S4 | `list_permission_groups` 403 guidance **or** success | Call `mcp__zendesk-local__list_permission_groups` (proxy: `zendesk_help_center` op `list_permission_groups` in namespace mode; direct tool in `--mode all`) | **Non-admin:** rejects with a message naming Guide-admin / Help Center manager, `HTTP 403`, and the `get_article` fallback. **Admin:** returns the permission-group list (non-regression). |
| S5 | `list_user_segments` 403 guidance **or** success | Call `mcp__zendesk-local__list_user_segments` | **Non-admin:** rejects with a message naming Guide-admin, `403`, and the `get_article` / "omit to default to everyone" fallback. **Admin:** returns the user-segment list. |

### Long-running behaviours

None. Nothing is time-based; no fake-timer levers needed.

### Priorities

1. **S1** — the user-facing enablement (reuse IDs), observable regardless of role.
2. **S2** — topology still usable.
3. **S3–S5** — the core fix; full live proof needs a non-admin token, otherwise
   non-regression + automated-test coverage.

### Reporting instructions

Post a PR comment (English) with a per-id verdict (`OK` / `FAIL` / `BLOCKED`) and
the concrete evidence (the relevant tool output / resource excerpt). State the
token role you observed in S0 (get_current_user) so the S3–S5 branch is
unambiguous. Finish with an overall green/failing summary against the tested SHA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Help Center article summaries now show permission group and audience segment details.
  - Topology information remains available when admin-only data cannot be accessed, clearly marking those sections as unavailable.
  - Added guidance for reusing article IDs or applying default visibility when permissions are limited.

- **Bug Fixes**
  - Permission errors now provide clearer, actionable messages instead of appearing as empty results.

- **Documentation**
  - Updated Help Center permissions, topology behavior, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->