### PR TITLE
fix(help-center): cap list_content_tags page size at the endpoint limit of 30

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,12 @@
 export const CHARACTER_LIMIT = 25_000;
 export const DEFAULT_PAGE_SIZE = 100;
 export const MAX_PAGE_SIZE = 100;
+
+// The Guide content-tags endpoint (/guide/content_tags) caps page[size] at 30
+// and 400s on anything larger, unlike the other Help Center list endpoints that
+// allow up to 100. Reusing the shared MAX_PAGE_SIZE (100) here always failed
+// (issue #162), so list_content_tags gets its own limit.
+export const CONTENT_TAGS_MAX_PAGE_SIZE = 30;
 export const TOKEN_CACHE_TTL_MS = 5 * 60 * 1000;
 
 // Read a positive-integer override from the environment, falling back to a safe

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -10,6 +10,7 @@ import {
   zendeskPost,
 } from '../client/zendesk-api';
 import {
+  CONTENT_TAGS_MAX_PAGE_SIZE,
   DEFAULT_PAGE_SIZE,
   LARGE_ARTICLE_BODY_CHARS,
   LARGE_ARTICLE_SECTION_COUNT,
@@ -859,9 +860,11 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           .number()
           .int()
           .min(1)
-          .max(MAX_PAGE_SIZE)
-          .default(DEFAULT_PAGE_SIZE)
-          .describe('Content tags per page (1-100, default 100).'),
+          .max(CONTENT_TAGS_MAX_PAGE_SIZE)
+          .default(CONTENT_TAGS_MAX_PAGE_SIZE)
+          .describe(
+            'Content tags per page (1-30, default 30). The Guide content-tags endpoint caps each page at 30; follow the returned cursor to enumerate the full list.',
+          ),
         cursor: z
           .string()
           .optional()

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -244,7 +244,7 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
       it('lists content tags with defaults applied and filters by name prefix (#132)', async () => {
         connected = await harness.connect(makeConfig({ mode: 'all' }));
 
-        // No arguments: the schema defaults (sort=name, page_size=100) are
+        // No arguments: the schema defaults (sort=name, page_size=30) are
         // applied by the SDK, so the full referential comes back enumerable.
         const all = await connected.client.callTool({
           name: 'list_content_tags',

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -743,6 +743,24 @@ export const handlers = [
   // pagination the way the real endpoint does so the tool's params are exercised.
   http.get(`${BASE}/guide/content_tags`, ({ request }) => {
     const url = new URL(request.url);
+    // Faithful to the real endpoint (#162): /guide/content_tags caps page[size]
+    // at 30 and 400s on anything larger, unlike the other Help Center list
+    // endpoints that allow up to 100. Reproduce that so the tool's clamp is tested.
+    const size = url.searchParams.get('page[size]');
+    if (size !== null && Number(size) > 30) {
+      return HttpResponse.json(
+        {
+          errors: [
+            {
+              title: `Value \`${size}\` for /page/size/0 is of type \`string\`; expected \`integer less than or equal to 30\``,
+              code: 'TypeError',
+              meta: null,
+            },
+          ],
+        },
+        { status: 400 },
+      );
+    }
     // Prefix match kept case-sensitive: the real endpoint's casing is
     // unverified, so the mock does not encode a case-insensitive assumption.
     const prefix = url.searchParams.get('filter[name_prefix]');

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -310,7 +310,7 @@ describe('help center tools', () => {
   describe('list_content_tags', () => {
     it('lists content tags sorted by name ascending, spanning past the old cap', async () => {
       const tool = findTool('list_content_tags');
-      const result = await tool.handler({ sort_by: 'name', sort_order: 'asc', page_size: 100 });
+      const result = await tool.handler({ sort_by: 'name', sort_order: 'asc', page_size: 30 });
       const text = result.content[0]?.text ?? '';
       expect(text).toContain('scanner');
       expect(text).toContain('ct_001');
@@ -322,7 +322,7 @@ describe('help center tools', () => {
 
     it('reverses order for descending sort', async () => {
       const tool = findTool('list_content_tags');
-      const result = await tool.handler({ sort_by: 'name', sort_order: 'desc', page_size: 100 });
+      const result = await tool.handler({ sort_by: 'name', sort_order: 'desc', page_size: 30 });
       const text = result.content[0]?.text ?? '';
       expect(text.indexOf('mistral')).toBeLessThan(text.indexOf('ai'));
     });
@@ -333,7 +333,7 @@ describe('help center tools', () => {
         name_prefix: 'mi',
         sort_by: 'name',
         sort_order: 'asc',
-        page_size: 100,
+        page_size: 30,
       });
       const text = result.content[0]?.text ?? '';
       expect(text).toContain('mistral');
@@ -347,6 +347,16 @@ describe('help center tools', () => {
       const text = result.content[0]?.text ?? '';
       expect(text).toContain('More available');
       expect(text).toContain('next-page-cursor');
+    });
+
+    it('caps page_size at the content-tags endpoint limit of 30 (#162)', () => {
+      const tool = findTool('list_content_tags');
+      // The Guide content-tags endpoint 400s on page[size] > 30, so the schema
+      // rejects out-of-range values instead of letting them hit the API.
+      expect(() => tool.inputSchema.parse({ page_size: 31 })).toThrow();
+      expect(tool.inputSchema.parse({ page_size: 30 })).toMatchObject({ page_size: 30 });
+      // Default is the endpoint's max, not the shared 100 that used to leak in.
+      expect(tool.inputSchema.parse({}).page_size).toBe(30);
     });
   });
 


### PR DESCRIPTION
## Summary

`list_content_tags` failed on **every** call with an HTTP 400. The Guide
`/api/v2/guide/content_tags` endpoint caps `page[size]` at **30**, but the tool
reused the shared `MAX_PAGE_SIZE` / `DEFAULT_PAGE_SIZE` (`100`) used by the other
Help Center list endpoints, so the request was always rejected:

```
Zendesk API error 400: Value `100` for /page/size/0 is of type `string`;
expected `integer less than or equal to 30`
```

This made the documented "check existing content tags before `create_content_tag`"
workflow impossible, risking blind duplicate tags.

**Root cause.** Introduced in #132, which added pagination to `list_content_tags`
using the shared page-size constants without knowing this endpoint's lower cap.
The MSW mock did not enforce the 30 limit, so the bug slipped past the tests.

## Changes

- **`src/constants.ts`** — new `CONTENT_TAGS_MAX_PAGE_SIZE = 30`, dedicated to
  this endpoint (documented inline).
- **`src/tools/help-center.ts`** — `list_content_tags` `page_size` now uses
  `.max(30).default(30)` and its description explains the cap and points at the
  cursor for full enumeration. Handler unchanged (Zod enforces the cap, including
  in proxy modes).
- **`tests/msw-handlers.ts`** — the content-tags mock is now faithful: it returns
  the real 400 when `page[size] > 30`, so the constraint is regression-tested.
- **Tests updated** — the unit tests that passed `page_size: 100` now use `30`; a
  new test locks the schema cap (`page_size: 31` rejected, default is `30`); the
  integration comment reflects the new default.

## ⚠️ Deliberate non-superset schema change

Per the multi-agent compatibility rule (`docs/mcp-metadata.md`), a tool change
should keep the exposed JSON Schema a **superset** of the previous one. This PR
knowingly narrows it: `page_size` `maximum` `100 → 30`, `default` `100 → 30`, and
the description text changes.

This is intentional and, I'd argue, the correct fix: **the old `maximum: 100` was
itself a bug** — it advertised a capability the endpoint has never honored. Every
value in the removed range (31–100) always produced a 400, so **no working input
is being taken away**; callers only get a clear local validation error instead of
a wire round-trip that fails. The alternative (keep `max: 100`, clamp internally
to 30) preserves the schema byte-for-byte but keeps advertising a false limit —
we chose honesty over a literal-but-misleading superset.

No mechanical CI gate enforces the superset diff (no schema snapshot test);
CodeRabbit may flag it — this section is the justification.

## Verification performed

- **Bug reproduced live** against the real Zendesk (`list_content_tags` → the exact
  400 above).
- **TDD**: hardening the mock + the new cap test go red first (the `page_size: 100`
  tests hit the faithful 400); the fix turns everything green.
- `pnpm test` — 491 passed. `pnpm check` (Biome) clean. `pnpm typecheck` clean.
  `pnpm test:coverage` — thresholds held. `pnpm build` — OK.
- Dev-mode note: because the new constant lives in shared infra (`constants.ts`),
  `reload_tools` alone is insufficient to hot-reload this change — a full server
  restart is required to see the fix on a live `--dev` session.

## Docs

No `docs/mcp-tools-reference.md` sync needed — the `list_content_tags` row carries
no page-size range or count.

Closes #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated content tag listing to respect the endpoint’s maximum page size of 30.
  * Requests exceeding the 30-item limit now return a clear validation error.
  * Corrected the default page size for content tag listings from 100 to 30.

* **Tests**
  * Added coverage for page-size validation, defaults, sorting, and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->