### PR TITLE
chore(renovate): constrain the typescript-legacy alias to the 6.x line

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -67,6 +67,11 @@
       "description": "Hold @tsconfig/node* updates and replacements until #28 (Node 24 runtime migration) lands. Replacement PRs (e.g. #19) bypass dependencyDashboardApproval, so we silence the whole family here. Remove this rule when #28 is merged.",
       "matchPackageNames": ["@tsconfig/node20", "@tsconfig/node22", "@tsconfig/node24"],
       "enabled": false
+    },
+    {
+      "description": "typescript-legacy is a deliberately pinned npm alias for TypeScript 6 (npm:typescript@6.0.3), the JS-compiler fallback used by scripts/typecheck.mjs on PRoot/Termux environments where TS 7's native tsgo is broken. Renovate must not manage it: any bump (including to 7.x, which npm considers the same package) defeats the pin. For npm aliases Renovate's depName is the package.json key, so this rule matches only the alias and leaves the real `typescript` dependency managed as usual. Remove this rule together with the alias and the typecheck shim once tsgo works under PRoot (see scripts/typecheck.mjs header).",
+      "matchDepNames": ["typescript-legacy"],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -69,9 +69,9 @@
       "enabled": false
     },
     {
-      "description": "typescript-legacy is a deliberately pinned npm alias for TypeScript 6 (npm:typescript@6.0.3), the JS-compiler fallback used by scripts/typecheck.mjs on PRoot/Termux environments where TS 7's native tsgo is broken. Renovate must not manage it: any bump (including to 7.x, which npm considers the same package) defeats the pin. For npm aliases Renovate's depName is the package.json key, so this rule matches only the alias and leaves the real `typescript` dependency managed as usual. Remove this rule together with the alias and the typecheck shim once tsgo works under PRoot (see scripts/typecheck.mjs header).",
+      "description": "typescript-legacy is an npm alias for TypeScript 6 (npm:typescript@6.0.3), the JS-compiler fallback used by scripts/typecheck.mjs on PRoot/Termux environments where TS 7's native tsgo is broken. Keep it on the 6.x line: Renovate still proposes 6.x patch/minor updates (and security fixes), but never 7.x — npm considers TS 7 the same package, and bumping the alias to it would remove the fallback. For npm aliases Renovate's depName is the package.json key, so this rule matches only the alias and leaves the real `typescript` dependency managed as usual. Remove this rule together with the alias and the typecheck shim once tsgo works under PRoot (see scripts/typecheck.mjs header).",
       "matchDepNames": ["typescript-legacy"],
-      "enabled": false
+      "allowedVersions": "<7.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds a Renovate `packageRule` that constrains the `typescript-legacy` npm alias (`npm:typescript@6.0.3`) to the 6.x line via `allowedVersions: "<7.0.0"`. The alias is the TypeScript 6 JS-compiler fallback that `scripts/typecheck.mjs` uses on PRoot/Termux environments where TS 7's native `tsgo` is broken. Renovate keeps managing it — 6.x patch/minor updates and security fixes still flow — but it can never propose 7.x, which npm considers the same package and which would silently remove the fallback.

## Linked issue
None

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [x] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main` (N/A — no linked issue)
- [x] `pnpm test` passes locally (N/A — config-only change, no code touched)
- [x] `pnpm test:coverage` meets the thresholds (N/A — config-only change)
- [x] `pnpm check` is clean (lint + format) (N/A — Biome does not cover `renovate.json`; validated with `renovate-config-validator` instead)
- [x] `pnpm typecheck` passes (N/A — config-only change)
- [x] I have read the diff myself, line by line
- [ ] I ran a Claude Code review on the diff and addressed its findings (5-line config addition; validated with the official validator)
- [x] Documentation is updated where needed (the rule carries its own `description`, and the removal condition is cross-referenced with the `scripts/typecheck.mjs` header)
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` (N/A)
- [x] If the change has **MCP-runtime-observable** behaviour: … (N/A — pure dev-tooling, exempt; the standard gates cover it)

## Notes for the reviewer (human or AI)
- For an npm alias, Renovate sets `depName` to the `package.json` **key** (`typescript-legacy`) and `packageName` to the real package (`typescript`). The rule therefore uses `matchDepNames` so it matches only the alias — the real `typescript` devDependency keeps its normal Renovate management.
- `allowedVersions: "<7.0.0"` was chosen over `enabled: false` (the first commit) so 6.x security fixes and patch/minor updates keep arriving for the alias; only the 7.x jump is blocked. 6.x patch/minor bumps also keep the existing devDependencies automerge behaviour.
- The rule's `description` states the removal condition: drop it together with the alias and the typecheck shim once `tsgo` works under PRoot (upstream issue referenced in `scripts/typecheck.mjs`).
- Config validated with `renovate-config-validator` (Renovate 42): `Config validated successfully`.

https://claude.ai/code/session_01Mj4dfRWeDw1Q79Cdie8WSM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to keep the legacy TypeScript package on versions below 7.0.0.
  * Regular TypeScript dependency updates remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->