### PR TITLE
feat: make the Help Center resource URI scheme configurable (param --hc-resource-scheme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ disabled together with `--no-topology`):
 
 Clients that don't consume `instructions` or `resources` simply ignore them —
 the feature degrades silently. Use `--no-topology` to turn both off server-wide.
+The `zendesk-hc://` URI scheme is the default; a deployer can brand it with
+[`--hc-resource-scheme` / `HC_RESOURCE_SCHEME`](docs/configuration.md#hc_resource_scheme)
+(e.g. `wiki` → `wiki://topology`).
 
 ## Prerequisites
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,10 @@ Options:
   --read-only             Only expose read operations
   --no-topology           Disable the Help Center structural context
                           (instructions + zendesk-hc://topology resource)
+  --hc-resource-scheme <scheme>
+                          URI scheme of the Help Center resources
+                          (default: zendesk-hc, i.e. zendesk-hc://topology);
+                          bare RFC 3986 scheme, e.g. "wiki" — no "://"
   --log-level <level>     debug | info (default) | warn | error
   --transport <t>         stdio (default) | http
   --host <host>           HTTP bind host (default: 0.0.0.0)
@@ -139,6 +143,19 @@ Public URL advertised in OAuth discovery metadata. See [Public URL](http-deploym
 **Required:** no · **Default:** —
 
 Comma-separated browser origins added to the default CORS allowlist.
+
+### `HC_RESOURCE_SCHEME`
+**Required:** no · **Default:** `zendesk-hc`
+
+URI scheme of the Help Center MCP resources (also `--hc-resource-scheme`, which
+takes precedence). With the default, the topology resource is
+`zendesk-hc://topology`; set e.g. `wiki` to expose it as `wiki://topology` and
+have the `instructions` blob cite that URI. Strictly a **bare RFC 3986 scheme**
+— a lowercase letter followed by lowercase letters, digits, `+`, `-` or `.`;
+anything else (`wiki://`, `Wiki`, `-wiki`, `1wiki`) is rejected at startup. A
+generic scheme like `wiki` is safe collision-wise (MCP resource URIs are scoped
+per server), it is just less self-descriptive in a client connected to several
+servers.
 
 ### `LOG_LEVEL`
 **Required:** no · **Default:** `info`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,7 +152,10 @@ takes precedence). With the default, the topology resource is
 `zendesk-hc://topology`; set e.g. `wiki` to expose it as `wiki://topology` and
 have the `instructions` blob cite that URI. Strictly a **bare RFC 3986 scheme**
 — a lowercase letter followed by lowercase letters, digits, `+`, `-` or `.`;
-anything else (`wiki://`, `Wiki`, `-wiki`, `1wiki`) is rejected at startup. A
+anything else (`wiki://`, `Wiki`, `-wiki`, `1wiki`) is rejected at startup. The
+WHATWG-special schemes (`http`, `https`, `ws`, `wss`, `ftp`, `file`) are also
+rejected: URL normalization appends a trailing slash to them, which would make
+the advertised resource URI unreadable by MCP clients. A
 generic scheme like `wiki` is safe collision-wise (MCP resource URIs are scoped
 per server), it is just less self-descriptive in a client connected to several
 servers.

--- a/scripts/mcp-live.ts
+++ b/scripts/mcp-live.ts
@@ -54,6 +54,12 @@ const VALUE_FLAGS = new Set([
   '--tool',
   '--log-level',
   '--hc-resource-scheme',
+  '--transport',
+  '--host',
+  '--port',
+  '--public-url',
+  '--cors-origin',
+  '--callback-port',
 ]);
 const hasPositionalSubdomain = configArgs.some((arg, i) => {
   if (arg.startsWith('-')) return false;

--- a/scripts/mcp-live.ts
+++ b/scripts/mcp-live.ts
@@ -48,7 +48,13 @@ const fail = (message: string): never => {
 // Skip values that follow a value-taking flag (e.g. `all` in `--mode all`),
 // otherwise the placeholder is wrongly skipped. Keep in sync with the
 // value-taking flags in `src/config.ts` `parseCliArgs`.
-const VALUE_FLAGS = new Set(['--mode', '--namespace', '--tool', '--log-level']);
+const VALUE_FLAGS = new Set([
+  '--mode',
+  '--namespace',
+  '--tool',
+  '--log-level',
+  '--hc-resource-scheme',
+]);
 const hasPositionalSubdomain = configArgs.some((arg, i) => {
   if (arg.startsWith('-')) return false;
   const prev = configArgs[i - 1];

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,25 @@ export const ConfigSchema = z.object({
       message:
         'Invalid HC_RESOURCE_SCHEME / --hc-resource-scheme value. Expected a bare RFC 3986 scheme: a lowercase letter followed by lowercase letters, digits, "+", "-" or "." (no "://").',
     })
+    // WHATWG "special" schemes (http, https, ws, wss, ftp, file) serialize
+    // with a trailing slash (`new URL('http://x').toString()` === 'http://x/'),
+    // so the SDK's read handler — which normalizes the requested URI through
+    // `URL` before its exact-string registry lookup — would list the resource
+    // but never find it on read. Require the actual URI to round-trip.
+    .refine(
+      (scheme) => {
+        const uri = `${scheme}://topology`;
+        try {
+          return new URL(uri).toString() === uri;
+        } catch {
+          return false;
+        }
+      },
+      {
+        message:
+          'Invalid HC_RESOURCE_SCHEME / --hc-resource-scheme value. WHATWG-special schemes (http, https, ws, wss, ftp, file) do not survive URL normalization and would make the resource unreadable; pick a custom scheme such as "wiki".',
+      },
+    )
     .default('zendesk-hc'),
   /**
    * Dev-only (stdio): expose the `reload_tools` tool, which re-imports the tool
@@ -210,11 +229,9 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
     cli.callbackPort ??
     parsePortEnv(process.env['ZENDESK_OAUTH_CALLBACK_PORT'], 'ZENDESK_OAUTH_CALLBACK_PORT');
 
-  // Empty env means unset (same convention as parsePortEnv); undefined lets
-  // the schema default (`zendesk-hc`) apply. Format is validated by the schema.
-  const hcResourceSchemeEnv = process.env['HC_RESOURCE_SCHEME'];
-  const hcResourceScheme =
-    cli.hcResourceScheme ?? (hcResourceSchemeEnv === '' ? undefined : hcResourceSchemeEnv);
+  // `|| undefined`: an empty env means unset (same convention as parsePortEnv),
+  // letting the schema default (`zendesk-hc`) apply; format is schema-validated.
+  const hcResourceScheme = cli.hcResourceScheme ?? (process.env['HC_RESOURCE_SCHEME'] || undefined);
 
   return ConfigSchema.parse({
     subdomain,

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,9 @@ export const ConfigSchema = z.object({
     .regex(/^[a-z][a-z0-9+.-]*$/, {
       message:
         'Invalid HC_RESOURCE_SCHEME / --hc-resource-scheme value. Expected a bare RFC 3986 scheme: a lowercase letter followed by lowercase letters, digits, "+", "-" or "." (no "://").',
+      // Stop here on a format failure so the WHATWG-special refinement below
+      // does not pile a misleading second message onto e.g. `Wiki`.
+      abort: true,
     })
     // WHATWG "special" schemes (http, https, ws, wss, ftp, file) serialize
     // with a trailing slash (`new URL('http://x').toString()` === 'http://x/'),

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,12 +22,29 @@ export const ConfigSchema = z.object({
   tools: z.array(z.string()).optional(),
   /**
    * Whether to expose the Help Center structural context (the `instructions`
-   * blob + the `zendesk-hc://topology` resource). On by default; an operator
+   * blob + the topology resource, default `zendesk-hc://topology`). On by
+   * default; an operator
    * disables it server-wide with `--no-topology` (e.g. on a very large Help
    * Center, or when the context is unwanted). Only ever active when the
    * `help_center` namespace itself is active.
    */
   topology: z.boolean().default(true),
+  /**
+   * URI scheme of the Help Center MCP resources (today the topology resource,
+   * `<scheme>://topology`). Defaults to `zendesk-hc`; a deployer can brand it
+   * (`--hc-resource-scheme wiki` / `HC_RESOURCE_SCHEME=wiki`). Strictly a bare
+   * RFC 3986 scheme — clients parse resource URIs with WHATWG `URL`, so a
+   * non-conformant scheme would surface as a broken resource at runtime;
+   * reject it at config parse time instead. ASCII-only message, value not
+   * echoed (same policy as parsePort below).
+   */
+  hcResourceScheme: z
+    .string()
+    .regex(/^[a-z][a-z0-9+.-]*$/, {
+      message:
+        'Invalid HC_RESOURCE_SCHEME / --hc-resource-scheme value. Expected a bare RFC 3986 scheme: a lowercase letter followed by lowercase letters, digits, "+", "-" or "." (no "://").',
+    })
+    .default('zendesk-hc'),
   /**
    * Dev-only (stdio): expose the `reload_tools` tool, which re-imports the tool
    * modules from source and re-registers them on the live session on demand, so
@@ -74,6 +91,7 @@ interface CliResult {
   namespaces?: string[];
   tools?: string[];
   topology?: boolean;
+  hcResourceScheme?: string;
   dev?: boolean;
   logLevel?: string;
   transport?: string;
@@ -121,6 +139,9 @@ const parseCliArgs = (args: string[]): CliResult => {
       result.readOnly = true;
     } else if (arg === '--no-topology') {
       result.topology = false;
+    } else if (arg === '--hc-resource-scheme' && next) {
+      result.hcResourceScheme = next;
+      i++;
     } else if (arg === '--dev') {
       result.dev = true;
     } else if (arg === '--namespace' && next) {
@@ -189,6 +210,12 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
     cli.callbackPort ??
     parsePortEnv(process.env['ZENDESK_OAUTH_CALLBACK_PORT'], 'ZENDESK_OAUTH_CALLBACK_PORT');
 
+  // Empty env means unset (same convention as parsePortEnv); undefined lets
+  // the schema default (`zendesk-hc`) apply. Format is validated by the schema.
+  const hcResourceSchemeEnv = process.env['HC_RESOURCE_SCHEME'];
+  const hcResourceScheme =
+    cli.hcResourceScheme ?? (hcResourceSchemeEnv === '' ? undefined : hcResourceSchemeEnv);
+
   return ConfigSchema.parse({
     subdomain,
     oauthClientId,
@@ -198,6 +225,7 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
     namespaces: cli.namespaces,
     tools: cli.tools,
     topology: cli.topology ?? true,
+    hcResourceScheme,
     dev: cli.dev ?? false,
     transport,
     host,

--- a/src/guidance/instructions.ts
+++ b/src/guidance/instructions.ts
@@ -1,11 +1,18 @@
 import type { Config } from '../config';
 
-/** Stable URI of the dynamic Help Center topology resource. */
-export const TOPOLOGY_RESOURCE_URI = 'zendesk-hc://topology';
+/**
+ * URI of the dynamic Help Center topology resource. Single source of truth for
+ * every place that cites it (resource registration, `instructions` blob): the
+ * scheme comes from the config (`--hc-resource-scheme`, default `zendesk-hc`),
+ * the path is fixed. Any future Help Center resource should build its URI the
+ * same way so the whole surface follows the configured scheme.
+ */
+export const topologyResourceUri = (config: Config): string =>
+  `${config.hcResourceScheme}://topology`;
 
 /**
  * Whether the Help Center structural context (init instructions + the
- * `zendesk-hc://topology` resource) should be exposed. True only when the
+ * topology resource, default `zendesk-hc://topology`) should be exposed. True only when the
  * feature is enabled (`--no-topology` not set) AND the `help_center` namespace
  * is active (no `--namespace` filter, or one that includes it). Shared by the
  * instructions builder and the resource registration in `server.ts` so both
@@ -18,14 +25,14 @@ export const helpCenterContextEnabled = (config: Config): boolean =>
  * The static `instructions` blob sent on `initialize`. Deliberately short and
  * I/O-free: it must not trigger the lazy OAuth/PKCE flow just to connect, and
  * it stays within a tight token budget. The rich, dynamic topology lives in the
- * pull-only `zendesk-hc://topology` resource referenced here.
+ * pull-only topology resource (default `zendesk-hc://topology`) referenced here.
  */
 export const buildInstructions = (config: Config): string | undefined => {
   if (!helpCenterContextEnabled(config)) return undefined;
   return [
     `This MCP server is connected to the Zendesk Help Center of "${config.subdomain}".`,
     '',
-    `When creating or editing Help Center content, the resource ${TOPOLOGY_RESOURCE_URI} is useful context:`,
+    `When creating or editing Help Center content, the resource ${topologyResourceUri(config)} is useful context:`,
     'it lists the active locales (and the default one), the category → section tree with IDs,',
     'the visibility user segments, the permission groups, and your current role.',
     'Prefer its IDs (section_id, permission_group_id, user_segment_id, locale) over guessing from names.',

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import type { Config } from './config';
 import {
   buildInstructions,
   helpCenterContextEnabled,
-  TOPOLOGY_RESOURCE_URI,
+  topologyResourceUri,
 } from './guidance/instructions';
 import { createTopologyProvider } from './guidance/topology';
 import { filterTools, groupByNamespace } from './routing/registry';
@@ -300,7 +300,7 @@ export const registerToolset = (
       registered.push(
         server.registerResource(
           'help-center-topology',
-          TOPOLOGY_RESOURCE_URI,
+          topologyResourceUri(config),
           {
             title: 'Zendesk Help Center topology',
             description:

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -12,6 +12,10 @@ const textOf = (result: { content?: Array<{ type: string; text?: string }> }): s
 
 const toolNames = (tools: Array<{ name: string }>): string[] => tools.map((t) => t.name);
 
+/** Text of a resources/read result, joined for easy asserts. */
+const resourceTextOf = (read: { contents?: Array<{ text?: unknown }> }): string =>
+  (read.contents ?? []).map((c) => (typeof c.text === 'string' ? c.text : '')).join('\n');
+
 /**
  * Shared, transport-agnostic integration scenarios. Every assertion here goes
  * through a real MCP client over the harness's transport — `tools/list` and
@@ -69,9 +73,7 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(resources.map((r) => r.uri)).toContain('zendesk-hc://topology');
 
         const read = await connected.client.readResource({ uri: 'zendesk-hc://topology' });
-        const text = (read.contents ?? [])
-          .map((c) => (typeof c.text === 'string' ? c.text : ''))
-          .join('\n');
+        const text = resourceTextOf(read);
         expect(text).toContain('en-us'); // default locale
         expect(text).toContain('(800)'); // category General
         expect(text).toContain('(600)'); // section FAQ
@@ -90,9 +92,7 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(resources.map((r) => r.uri)).not.toContain('zendesk-hc://topology');
 
         const read = await connected.client.readResource({ uri: 'wiki://topology' });
-        const text = (read.contents ?? [])
-          .map((c) => (typeof c.text === 'string' ? c.text : ''))
-          .join('\n');
+        const text = resourceTextOf(read);
         expect(text).toContain('en-us');
         expect(text).toContain('(800)');
       });
@@ -102,9 +102,7 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         connected = await harness.connect(makeConfig());
 
         const read = await connected.client.readResource({ uri: 'zendesk-hc://topology' });
-        const text = (read.contents ?? [])
-          .map((c) => (typeof c.text === 'string' ? c.text : ''))
-          .join('\n');
+        const text = resourceTextOf(read);
         // The readable structure still comes back instead of a -32603 failure.
         expect(text).toContain('(800)');
         expect(text).toContain('(600)');

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -78,6 +78,25 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(text).toContain('admin'); // current user role
       });
 
+      it('exposes the resource and instructions under a custom scheme when --hc-resource-scheme is set (#169)', async () => {
+        connected = await harness.connect(makeConfig({ hcResourceScheme: 'wiki' }));
+
+        const instructions = connected.client.getInstructions();
+        expect(instructions).toContain('wiki://topology');
+        expect(instructions).not.toContain('zendesk-hc://');
+
+        const { resources } = await connected.client.listResources();
+        expect(resources.map((r) => r.uri)).toContain('wiki://topology');
+        expect(resources.map((r) => r.uri)).not.toContain('zendesk-hc://topology');
+
+        const read = await connected.client.readResource({ uri: 'wiki://topology' });
+        const text = (read.contents ?? [])
+          .map((c) => (typeof c.text === 'string' ? c.text : ''))
+          .join('\n');
+        expect(text).toContain('en-us');
+        expect(text).toContain('(800)');
+      });
+
       it('still renders the topology for a content-editor token that is forbidden the admin-only parts (#161)', async () => {
         mswServer.use(errorHandlers.permissionGroupsForbidden);
         connected = await harness.connect(makeConfig());

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -246,6 +246,14 @@ describe('loadConfig', () => {
       }
     });
 
+    it('rejects WHATWG-special schemes whose URL normalization would make the resource unreadable', () => {
+      for (const special of ['http', 'https', 'ws', 'wss', 'ftp', 'file']) {
+        expect(() => loadConfig(['mycompany', '--hc-resource-scheme', special])).toThrow(
+          /WHATWG-special/,
+        );
+      }
+    });
+
     it('treats an empty HC_RESOURCE_SCHEME env as unset (same as PORT-style envs)', () => {
       process.env['HC_RESOURCE_SCHEME'] = '';
       const config = loadConfig(['mycompany']);

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -10,6 +10,7 @@ describe('loadConfig', () => {
     delete process.env['HOST'];
     delete process.env['PORT'];
     delete process.env['ZENDESK_OAUTH_CALLBACK_PORT'];
+    delete process.env['HC_RESOURCE_SCHEME'];
   });
 
   it('parses subdomain from CLI positional arg', () => {
@@ -198,6 +199,62 @@ describe('loadConfig', () => {
 
     it('rejects values that are not URLs', () => {
       expect(() => loadConfig(['mycompany', '--cors-origin', 'not-a-url'])).toThrow();
+    });
+  });
+
+  describe('hcResourceScheme', () => {
+    it('defaults to zendesk-hc', () => {
+      const config = loadConfig(['mycompany']);
+      expect(config.hcResourceScheme).toBe('zendesk-hc');
+    });
+
+    it('parses --hc-resource-scheme flag', () => {
+      const config = loadConfig(['mycompany', '--hc-resource-scheme', 'wiki']);
+      expect(config.hcResourceScheme).toBe('wiki');
+    });
+
+    it('reads HC_RESOURCE_SCHEME from env', () => {
+      process.env['HC_RESOURCE_SCHEME'] = 'docs';
+      const config = loadConfig(['mycompany']);
+      expect(config.hcResourceScheme).toBe('docs');
+    });
+
+    it('prefers --hc-resource-scheme over the env var', () => {
+      process.env['HC_RESOURCE_SCHEME'] = 'docs';
+      const config = loadConfig(['mycompany', '--hc-resource-scheme', 'wiki']);
+      expect(config.hcResourceScheme).toBe('wiki');
+    });
+
+    it('accepts any RFC 3986 scheme: letter then letters, digits, "+", "-", "."', () => {
+      expect(
+        loadConfig(['mycompany', '--hc-resource-scheme', 'fruggr-wiki']).hcResourceScheme,
+      ).toBe('fruggr-wiki');
+      expect(loadConfig(['mycompany', '--hc-resource-scheme', 'z6+x.y-w']).hcResourceScheme).toBe(
+        'z6+x.y-w',
+      );
+    });
+
+    it('rejects a scheme carrying the "://" separator (strict bare scheme, no normalization)', () => {
+      expect(() => loadConfig(['mycompany', '--hc-resource-scheme', 'wiki://'])).toThrow(
+        /HC_RESOURCE_SCHEME|--hc-resource-scheme/,
+      );
+    });
+
+    it('rejects schemes that are not RFC 3986 conformant', () => {
+      for (const bad of ['Wiki', '-wiki', '1wiki', 'wi ki']) {
+        expect(() => loadConfig(['mycompany', '--hc-resource-scheme', bad])).toThrow();
+      }
+    });
+
+    it('treats an empty HC_RESOURCE_SCHEME env as unset (same as PORT-style envs)', () => {
+      process.env['HC_RESOURCE_SCHEME'] = '';
+      const config = loadConfig(['mycompany']);
+      expect(config.hcResourceScheme).toBe('zendesk-hc');
+    });
+
+    it('rejects an invalid HC_RESOURCE_SCHEME env value', () => {
+      process.env['HC_RESOURCE_SCHEME'] = 'wiki://';
+      expect(() => loadConfig(['mycompany'])).toThrow(/HC_RESOURCE_SCHEME|--hc-resource-scheme/);
     });
   });
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -246,6 +246,17 @@ describe('loadConfig', () => {
       }
     });
 
+    it('reports only the format error for format-rejected values, not the WHATWG-special one', () => {
+      let thrown: unknown;
+      try {
+        loadConfig(['mycompany', '--hc-resource-scheme', 'Wiki']);
+      } catch (error) {
+        thrown = error;
+      }
+      expect(String(thrown)).toContain('RFC 3986');
+      expect(String(thrown)).not.toContain('WHATWG-special');
+    });
+
     it('rejects WHATWG-special schemes whose URL normalization would make the resource unreadable', () => {
       for (const special of ['http', 'https', 'ws', 'wss', 'ftp', 'file']) {
         expect(() => loadConfig(['mycompany', '--hc-resource-scheme', special])).toThrow(

--- a/tests/unit/guidance/instructions.test.ts
+++ b/tests/unit/guidance/instructions.test.ts
@@ -1,13 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { buildInstructions, TOPOLOGY_RESOURCE_URI } from '../../../src/guidance/instructions';
+import { buildInstructions, topologyResourceUri } from '../../../src/guidance/instructions';
 import { makeConfig } from '../../integration/harness';
+
+describe('topologyResourceUri', () => {
+  it('builds the URI from the configured scheme (default zendesk-hc)', () => {
+    expect(topologyResourceUri(makeConfig())).toBe('zendesk-hc://topology');
+    expect(topologyResourceUri(makeConfig({ hcResourceScheme: 'wiki' }))).toBe('wiki://topology');
+  });
+});
 
 describe('buildInstructions', () => {
   it('returns a blob mentioning the subdomain and the topology URI when help_center is active', () => {
-    const text = buildInstructions(makeConfig({ subdomain: 'acme' }));
+    const config = makeConfig({ subdomain: 'acme' });
+    const text = buildInstructions(config);
     expect(text).toBeDefined();
     expect(text).toContain('acme');
-    expect(text).toContain(TOPOLOGY_RESOURCE_URI);
+    expect(text).toContain(topologyResourceUri(config));
+  });
+
+  it('cites the custom scheme in the blob when one is configured', () => {
+    const text = buildInstructions(makeConfig({ hcResourceScheme: 'wiki' }));
+    expect(text).toContain('wiki://topology');
+    expect(text).not.toContain('zendesk-hc://');
   });
 
   it('returns the blob when the namespace filter explicitly includes help_center', () => {


### PR DESCRIPTION
## Summary
The Help Center topology resource URI scheme was hardcoded as `zendesk-hc://`. This PR adds a `--hc-resource-scheme` CLI flag / `HC_RESOURCE_SCHEME` env var (CLI wins) so a deployer can brand it (e.g. `wiki` → `wiki://topology`), defaulting to the current `zendesk-hc` — no behavior change unless opted in. `TOPOLOGY_RESOURCE_URI` becomes `topologyResourceUri(config)`, the single source of truth shared by the resource registration and the `instructions` blob.

## Linked issue
Closes #169

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` (n/a — no tool change)
- [x] If the change has **MCP-runtime-observable** behaviour (tool surface, transports, auth, resources, prompts, persistence, timing): this PR carries a `## Functional validation plan` (authored with `/functional-validation-plan`), executed by an independent validator (`/run-validation-plan`) whose report is posted as a PR comment. Pure tooling / dev-tooling is exempt — the standard gates cover it.

## Notes for the reviewer (human or AI)
- **Strict validation, no normalization** (agreed in the issue discussion): the value must be a bare RFC 3986 scheme (`[a-z][a-z0-9+.-]*`). `wiki://`, `Wiki`, `-wiki`, `1wiki` are rejected at config parse time with an ASCII message that does not echo the value (same policy as `parsePort`). Note the issue's `-wiki` example is unattainable by design — RFC 3986 schemes must start with a letter.
- **WHATWG-special schemes are rejected** (`http`, `https`, `ws`, `wss`, `ftp`, `file`): their URL serialization appends a trailing slash, and the MCP SDK's read handler normalizes the requested URI through WHATWG `URL` before its exact-string registry lookup — the resource would be listed but never readable. The check validates the actual URI round-trips through `URL`, so it covers the whole class rather than a hand-kept denylist. Found by the Claude Code review pass, reproduced end-to-end.
- **No denylist for "generic" schemes** like `wiki`: MCP resource URIs are scoped per server, so cross-server collisions are not a functional concern; the trade-off is documented in `docs/configuration.md` instead.
- Empty env (`HC_RESOURCE_SCHEME=`) means unset (default applies), matching the `parsePortEnv` convention.
- `scripts/mcp-live.ts` `VALUE_FLAGS` was completed with the six value-taking flags it was already missing (pre-existing gap; its comment mandates sync with `parseCliArgs`).
- Known pre-existing parser trait, unchanged: a value-taking flag given as the last argument (or with an empty value) is silently ignored by the `&& next` guard — this applies to every flag (`--mode`, `--host`, …), not just the new one. Fixing it is a cross-cutting parser change out of scope here.

## Functional validation plan

**Context.** This PR makes the Help Center resource URI scheme configurable (`--hc-resource-scheme` / `HC_RESOURCE_SCHEME`, default `zendesk-hc`). Observable surface: the `instructions` blob sent on `initialize`, `resources/list`, `resources/read`. Tool calls do NOT exercise this change. Default behaviour must be identical to `main`.

**Setup.** The running server (default config) covers the default-scheme scenarios. A startup flag cannot be observed on an already-running instance: for custom-scheme scenarios use the sanctioned no-restart lever `pnpm mcp:live … -- --hc-resource-scheme wiki`, which spawns a short-lived instance (its `list` path is credential-free; `read` reuses `ZENDESK_OAUTH_TOKEN` if present — a missing token is a BLOCKED finding for the read step only, `list` still validates the surface). Capture `git rev-parse HEAD` in the report.

**Scenarios.**

| id | validates | manipulation | expected observable |
|----|-----------|--------------|---------------------|
| V1 | default unchanged — resource | none (running server) | `resources/list` contains `zendesk-hc://topology`; reading it returns the topology Markdown (locales, category tree, role) |
| V2 | default unchanged — instructions | none | server `instructions` cite exactly `zendesk-hc://topology` |
| V3 | custom scheme end-to-end | `pnpm mcp:live list -- --hc-resource-scheme wiki` (and `read wiki://topology` if a token is available) | listing shows `wiki://topology` and no `zendesk-hc://` URI; read (if run) returns the same topology content |
| V4 | env var + CLI precedence | `HC_RESOURCE_SCHEME=docs pnpm mcp:live list`; then same env + `-- --hc-resource-scheme wiki` | env alone → `docs://topology` listed; with the flag → `wiki://topology` (CLI wins) |
| V5 | strict rejection at startup | `pnpm mcp:live list -- --hc-resource-scheme 'wiki://'` (also try `Wiki`) | process exits at config parse with an error naming `HC_RESOURCE_SCHEME` / `--hc-resource-scheme`; no server starts |
| V6 | WHATWG-special scheme rejection | `pnpm mcp:live list -- --hc-resource-scheme http` | startup rejected with the WHATWG-special message (resource would be unreadable) |

**Long-running behaviours.** None (no timing involved). The full validation matrix (regex classes, env precedence, empty env) is covered by unit tests in `tests/unit/config.test.ts`; one rejected value per class is enough live.

**Priorities.** V1/V2 first (non-regression is the contract), then V3 (the feature), V4–V6 last.

**Reporting.** Post a PR comment (English): per-id OK/FAIL/BLOCKED verdict with the observed evidence (tool output / stderr excerpt) and the tested commit SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the Help Center resource URI scheme via `--hc-resource-scheme` or `HC_RESOURCE_SCHEME` (defaulting to `zendesk-hc`).
  * Help Center topology resources and generated instructions now use the configured scheme.
* **Documentation**
  * Documented the new configuration option, precedence rules (CLI over env), accepted bare RFC 3986 scheme formats, and examples.
* **Bug Fixes**
  * Improved CLI argument handling in the live MCP script to avoid misinterpreting additional flags.
* **Tests**
  * Expanded unit and integration coverage for defaults, overrides, env precedence, and invalid-scheme validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->