### PR TITLE
fix(typecheck): run native TS 7 under PRoot by un-hardlinking its inputs

### DIFF
--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -1,28 +1,54 @@
 #!/usr/bin/env node
 // Type-checks the project, picking a working `tsc` for the current environment.
 //
-// TypeScript 7 ships a native (Go) compiler, `tsgo`, that locates its bundled
-// lib.*.d.ts relative to itself via os.Executable() (/proc/self/exe). Under
-// PRoot / Termux, pnpm's hardlinked store binary is routed through the
-// link2symlink store (/.l2s), so that resolution breaks and tsgo is
-// non-functional (it panics, or silently loads no libs). Root cause and fix
-// belong upstream: https://github.com/microsoft/typescript-go
+// TypeScript 7 ships a native (Go) compiler, `tsgo`. Under PRoot's
+// link2symlink extension (Termux proot-distro on Android), pnpm's hardlinked
+// files are really symlinks into a hidden `/.l2s` store, and the kernel leaks
+// that store through `/proc` in two places tsgo relies on:
+//   1. `readlink(/proc/self/exe)` — the bundled lib.*.d.ts lookup next to the
+//      executable resolves to `/.l2s`, so tsgo panics at startup;
+//   2. `open(O_PATH)` + `readlink(/proc/self/fd/N)` — tsgo's realpath returns
+//      an extensionless `/.l2s/.l2s.<hash>` name for every resolved
+//      `.d.ts`/`.d.cts`/`package.json`, collapsing module resolution.
+// Node's own JS compilers are immune (glibc realpath walks with the syscalls
+// PRoot masks). Full analysis and minimal reproduction:
+// https://github.com/dlecan/tsgo-proot-l2s-repro — the durable fix belongs
+// upstream (https://github.com/microsoft/typescript-go).
 //
-// On such environments we fall back to the JS-based TypeScript 6, installed
-// under the `typescript-legacy` alias. Everywhere else — CI, x86, genuine
-// arm64 (Apple silicon, Graviton) — the fast native TS 7 is used. Because the
-// two are different compilers, CI (native TS 7) stays the source of truth; a
-// local TS 6 pass is a close pre-check, not a guarantee.
+// Workaround applied here: on such environments, break the pnpm hardlink of
+// every file the native compiler reads (copy-in-place; a standalone copy
+// realpaths normally), once per install, then run native TS 7 — ~8x faster
+// than the JS fallback on the affected hardware. A marker file under
+// node_modules skips the walk until the next `pnpm install` rewrites
+// `.modules.yaml`. The pass assumes pnpm's default project-local virtual
+// store; with an external `virtual-store-dir` nothing relevant lives under
+// node_modules, which the native-binary sentinel below detects, falling back
+// to TypeScript 6 (JS, under the `typescript-legacy` alias) — also the
+// automatic fallback for any other failure of the pass.
 //
-// Override the auto-detection with ZENDESK_MCP_TSC=native|legacy.
-// Retire this shim and the `typescript-legacy` alias once tsgo resolves the
-// upstream issue, restoring "typecheck": "tsc --noEmit".
+// Override the auto-detection with ZENDESK_MCP_TSC=native|legacy. `native` is
+// a pure compiler selection with zero filesystem side effects — under PRoot
+// it reproduces the raw upstream failure; the un-hardlink pass runs only on
+// auto-detection. Retire this shim and the `typescript-legacy` alias once
+// tsgo resolves the upstream issue, restoring "typecheck": "tsc --noEmit".
 
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
 import { constants } from 'node:os';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // Explicit override, normalized so casing/whitespace variants ("Native",
 // "legacy\n") are honored. An unrecognized value warns and falls through to
@@ -35,13 +61,129 @@ if (rawForced && forced !== 'native' && forced !== 'legacy') {
   );
 }
 
-// Detect PRoot's link2symlink layer — the one environment where tsgo mislocates
-// its libs. `PROOT_L2S_DIR` is PRoot's own signal that link2symlink is active
-// (set even when the store isn't at the default `/.l2s`); the path check is the
-// fallback. Keyed on these, never on arch (real arm64 runs native TS 7 fine).
+// Detect PRoot's link2symlink layer — the one environment where tsgo needs
+// the un-hardlink pass. `PROOT_L2S_DIR` is PRoot's own signal that
+// link2symlink is active (set even when the store isn't at the default
+// `/.l2s`); the path check is the fallback. Keyed on these, never on arch
+// (real arm64 runs native TS 7 fine as-is).
 const nativeBroken = () => Boolean(process.env.PROOT_L2S_DIR) || existsSync('/.l2s');
 
-const useLegacy = forced === 'legacy' || (forced !== 'native' && nativeBroken());
+// The pass mutates this package's own node_modules — resolve it from the
+// script's location, never from cwd, so a stray invocation from another
+// directory cannot rewrite an unrelated project.
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Files the native compiler reads during a type-check: its own executable
+// (`lib/tsc` inside the platform package), every declaration file and package
+// manifest, plus plain TS sources (a package may expose `.ts` files as its
+// types entry). Any of them still routed through the l2s store would leak its
+// `/.l2s` name through tsgo's realpath.
+const isTypecheckInput = (name, dir) =>
+  name.endsWith('.ts') ||
+  name.endsWith('.tsx') ||
+  name.endsWith('.cts') ||
+  name.endsWith('.mts') ||
+  name.endsWith('.json') ||
+  (name === 'tsc' && dir.endsWith('/lib'));
+
+// The tmp name is pid-unique so concurrent typecheck runs cannot clobber each
+// other's half-written copy; rename() then swaps in a complete file
+// atomically either way.
+const unshareFile = (path, stat) => {
+  const tmp = `${path}.unshare-tmp-${process.pid}`;
+  try {
+    copyFileSync(path, tmp);
+    chmodSync(tmp, stat.mode);
+    utimesSync(tmp, stat.atime, stat.mtime);
+    renameSync(tmp, path);
+  } catch (error) {
+    rmSync(tmp, { force: true });
+    throw error;
+  }
+};
+
+// Walk node_modules without following directory symlinks (pnpm's package
+// symlinks all point back into `node_modules/.pnpm`, which the walk covers).
+//
+// Detecting l2s routing: getdents is the one layer PRoot does NOT mask, so an
+// l2s-routed file surfaces as a symlink (d_type=DT_LNK) in the directory
+// listing even though lstat reports a regular file — regardless of its faked
+// hardlink count (an orphaned l2s pair reports nlink=1 and still leaks).
+// Genuine symlinks (pnpm package links, .bin shims) stay symlinks under lstat
+// and are left alone. A plain regular file with nlink > 1 is also copied — a
+// best-effort net for filesystems that report no d_type (where orphaned l2s
+// pairs are indistinguishable from regular files and can be missed).
+const unshareTree = (root) => {
+  let count = 0;
+  let sawNativeTsc = false;
+  const pending = [root];
+  while (pending.length > 0) {
+    const dir = pending.pop();
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(path);
+      } else if (entry.name.includes('.unshare-tmp-')) {
+        // Leftover from a crashed earlier pass.
+        rmSync(path, { force: true });
+      } else if (isTypecheckInput(entry.name, dir)) {
+        if (entry.name === 'tsc') {
+          sawNativeTsc = true;
+        }
+        const stat = lstatSync(path);
+        if (stat.isFile() && (!entry.isFile() || stat.nlink > 1)) {
+          unshareFile(path, stat);
+          count += 1;
+        }
+      }
+    }
+  }
+  return { count, sawNativeTsc };
+};
+
+// One-off per install: `pnpm install` rewrites `.modules.yaml`, which
+// invalidates the marker and re-triggers the walk (new files come back
+// hardlinked from the store). The marker is back-stamped to the walk's START
+// time and equality counts as stale, so an install racing the walk still
+// invalidates it.
+const ensureUnshared = () => {
+  const nodeModules = join(packageRoot, 'node_modules');
+  const marker = join(nodeModules, '.tsgo-unshared');
+  const modulesState = join(nodeModules, '.modules.yaml');
+  if (
+    existsSync(marker) &&
+    (!existsSync(modulesState) || statSync(modulesState).mtimeMs < statSync(marker).mtimeMs)
+  ) {
+    return;
+  }
+  console.error(
+    '[typecheck] PRoot link2symlink detected; un-hardlinking type-check inputs (one-off per install)',
+  );
+  const started = new Date();
+  const { count, sawNativeTsc } = unshareTree(nodeModules);
+  if (!sawNativeTsc) {
+    throw new Error(
+      `no native tsc binary under ${nodeModules} — unsupported layout (external pnpm virtual-store-dir?)`,
+    );
+  }
+  writeFileSync(marker, `${started.toISOString()}\n`);
+  utimesSync(marker, started, started);
+  console.error(
+    `[typecheck] un-hardlinked ${count} files in ${((Date.now() - started.getTime()) / 1000).toFixed(1)}s`,
+  );
+};
+
+let useLegacy = forced === 'legacy';
+if (!useLegacy && forced !== 'native' && nativeBroken()) {
+  try {
+    ensureUnshared();
+  } catch (error) {
+    console.error(
+      `[typecheck] un-hardlink pass failed (${error.message}); falling back to TypeScript 6`,
+    );
+    useLegacy = true;
+  }
+}
 const pkg = useLegacy ? 'typescript-legacy' : 'typescript';
 
 console.error(`[typecheck] ${useLegacy ? 'TypeScript 6 (JS fallback)' : 'TypeScript 7 (native)'}`);


### PR DESCRIPTION
## Summary

Make `pnpm typecheck` run the **native TypeScript 7 compiler** under PRoot
`link2symlink` (Termux proot-distro on Android) instead of the ~8× slower
JS-based TypeScript 6 fallback, by breaking the pnpm hardlink of every file
`tsgo` reads (copy-in-place) once per install before invoking it.

## Linked issue

None — dev-tooling improvement over the workaround shipped in #171, for an
**upstream** bug. Root-cause analysis and a standalone 4-stage repro live in
https://github.com/dlecan/tsgo-proot-l2s-repro (durable fix belongs to
https://github.com/microsoft/typescript-go; an upstream patch is being
prepared separately).

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [x] Tooling / CI

## Details

**Why the fallback existed.** PRoot's `link2symlink` extension emulates
hardlinks with symlinks into a hidden `/.l2s` store and masks
`lstat`/`readlink`, but cannot mask kernel-computed names surfaced through
`/proc`. `tsgo` consumes two of those: `/proc/self/exe` (bundled `lib.*.d.ts`
lookup → startup panic) and `open(O_PATH)` + `readlink(/proc/self/fd/N)` (its
Linux realpath → extensionless `/.l2s/...` names for every resolved
`.d.ts`/`.d.cts`/`package.json`, collapsing module resolution with
TS2307/TS2591/TS6054). #171 sidestepped this by running TypeScript 6 (JS) on
that environment.

**What this PR does.** A file whose copy-in-place makes it a genuine
standalone file (no l2s routing) realpaths correctly, so `typecheck.mjs` now:

1. detects the environment with the same signals as before (`PROOT_L2S_DIR`
   env var or `/.l2s`);
2. un-hardlinks the type-check inputs — the native `lib/tsc` binary plus all
   `*.ts` / `*.tsx` / `*.cts` / `*.mts` / `*.json` under the **package's own**
   `node_modules` (resolved from the script location, never from cwd).
   l2s-routed entries are detected as *getdents-says-symlink +
   lstat-says-regular-file* (getdents is the one layer PRoot does not mask),
   which also catches orphaned l2s pairs whose faked `nlink` is already 1;
   plain `nlink > 1` files are copied too as a d_type-less-filesystem
   fallback. Copies go through a pid-unique tmp name + atomic rename, so
   concurrent runs cannot clobber each other; stale tmp files from a crashed
   pass are swept by the next walk;
3. skips the walk while a marker (`node_modules/.tsgo-unshared`) is strictly
   newer than pnpm's `node_modules/.modules.yaml`. The marker is back-stamped
   to the walk's *start* time, so an install racing the walk still
   invalidates it — the cost stays one-off per install;
4. runs native TS 7. If the walk finds no native `tsc` at all (e.g. an
   external pnpm `virtual-store-dir`, whose files live outside the walked
   tree), the pass fails and the script falls back to TypeScript 6
   automatically, like for any other pass failure.

`ZENDESK_MCP_TSC=legacy` still forces TS 6. `ZENDESK_MCP_TSC=native` is now a
**pure compiler selection with zero filesystem side effects** — under PRoot it
reproduces the raw upstream failure (the repro path documented in the linked
repo); the un-hardlink pass runs only on auto-detection.

**Measured on the affected device** (Android, Termux proot-distro, slow
storage): fresh `pnpm install` → first `pnpm typecheck` un-hardlinks 4 729
files in ~144 s, then every run is ~2 s. The TS 6 fallback needs ~17 s per
run, so the walk pays for itself after ~10 runs — and local typechecking now
uses the **same compiler as CI**.

**Everywhere else** (CI, x86, genuine arm64): no PRoot signal → no walk, no
behavioral change.

`typescript-legacy` (TS 6 alias) is deliberately kept as the escape hatch and
automatic fallback; Renovate keeps it pinned to 6.x (#172). Retire both once
the upstream fix lands.

## Sanity checks (pure tooling — exempt from third-party validation)

Run locally on the author's PRoot environment:
- fresh install: `rm -rf node_modules && pnpm install` → `pnpm typecheck` →
  `[typecheck] un-hardlinked 4729 files in 144.1s` → `TypeScript 7 (native)`,
  exit 0 ✅ (declarations+json filter; the final extended filter picked up
  626 more `.ts`-source files on the next walk)
- second run: marker honored, no walk, ~2 s, exit 0 ✅
- orphaned l2s pair (nlink=1, still store-routed): detected and copied,
  resolution restored ✅ (this case is invisible to a pure `nlink` check)
- `ZENDESK_MCP_TSC=legacy pnpm typecheck` → TS 6, exit 0 ✅
- `ZENDESK_MCP_TSC=native pnpm typecheck` → native, no walk, no mutation ✅
- invoked from a foreign cwd (`node <repo>/scripts/typecheck.mjs -p <repo>`):
  repo's own node_modules used, no stray marker in the cwd ✅
- `pnpm check` clean ✅ ; `pnpm test` 546/546 ✅
- `/code-review` (xhigh, workflow-backed) run on the diff; all CONFIRMED
  findings addressed: marker start-stamping + strict comparison,
  cwd-independence, pure `native` override, pid-unique tmp + sweep,
  no-native-tsc sentinel, extended input filter ✅

## Notes for the reviewer (human or AI)

- Alternatives ruled out: `pnpm config package-import-method=copy` (install
  times unacceptable on the target device), `--preserveSymlinks` (breaks
  pnpm's transitive type deps, e.g. `@types/node` → `undici-types`).
- The walk classifies directories via `Dirent` only (Node lstats
  `DT_UNKNOWN` entries itself), and never follows directory symlinks —
  pnpm's package links all point back into `node_modules/.pnpm`, which the
  walk covers directly.
- The copy preserves mode and mtimes; pnpm re-hardlinks affected files on
  the next install, which also rewrites `.modules.yaml` and re-triggers the
  walk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript checking reliability in environments affected by filesystem link behavior.
  * Added automatic preparation of relevant dependency files before native type checking when needed.
  * Prevented unnecessary repeated filesystem processing by detecting when dependencies have changed.

* **Configuration**
  * Added an option to choose between native and legacy TypeScript checking.
  * Invalid compiler selection values now produce a warning and use the default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->