### PR TITLE
chore(deps): update conventional-changelog-conventionalcommits to v10 with a writer 9 override

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,13 +17,13 @@
             { "type": "fix", "section": "Bug Fixes" },
             { "type": "perf", "section": "Performance Improvements" },
             { "type": "revert", "section": "Reverts" },
-            { "type": "docs", "section": "Documentation", "hidden": false },
-            { "type": "style", "section": "Styles", "hidden": false },
-            { "type": "chore", "section": "Chores", "hidden": false },
-            { "type": "refactor", "section": "Code Refactoring", "hidden": false },
-            { "type": "test", "section": "Tests", "hidden": false },
-            { "type": "build", "section": "Build System", "hidden": false },
-            { "type": "ci", "section": "Continuous Integration", "hidden": false }
+            { "type": "docs", "section": "Documentation" },
+            { "type": "style", "section": "Styles" },
+            { "type": "chore", "section": "Chores" },
+            { "type": "refactor", "section": "Code Refactoring" },
+            { "type": "test", "section": "Tests" },
+            { "type": "build", "section": "Build System" },
+            { "type": "ci", "section": "Continuous Integration" }
           ]
         },
         "collapsedSections": [

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -125,6 +125,11 @@ version depending on `conventional-changelog-writer@^9`. The canary assertions i
 `tests/unit/release-notes-preset-render.test.ts` are what detects a broken pairing,
 in either direction.
 
+Until then the entry is kept current like any other override: Renovate tracks it
+and auto-merges its patch / minor bumps (the `pnpm.overrides` row in the auto-merge
+policy below), a major would land in the Dependency Dashboard for approval, and
+either way the canary gates the merge.
+
 ## Auto-merge policy
 
 | Update kind                                       | Vulnerability (security) | Non-vulnerability        |

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -78,9 +78,12 @@ each new version automatically.
 
 semantic-release generates the notes from **every** commit between the previous
 tag and the release commit — including the non-triggering ones (`chore`, `ci`,
-`build`, `test`, `refactor`, `docs`, `style`). By default the `conventionalcommits`
-preset hides those types, so they never surfaced in any changelog even though they
-belong to a release range.
+`build`, `test`, `refactor`, `docs`, `style`). The `conventionalcommits` preset
+hides those types in its default type list (`effect: 'hidden'`), so they never
+surfaced in any changelog even though they belong to a release range. The
+`presetConfig.types` array in `.releaserc.json` replaces that list wholesale, and
+an entry without an `effect` defaults to visible — which is why the types are
+listed there with a `section` and nothing else.
 
 To keep them visible without drowning the consumer-facing notes (especially the
 Renovate `chore(deps)` churn), the `release-notes-generator` step is replaced by a
@@ -92,11 +95,35 @@ It calls the official generator, then post-processes the markdown:
 - **Internal sections** — the non-triggering types above — are grouped into a single
   collapsed `<details>` block placed underneath.
 
-No Handlebars template is reimplemented, so the wrapper survives preset version
-bumps. The collapsed section titles and the `<summary>` label are configurable via
-the `collapsedSections` / `collapsedSummary` plugin options in `.releaserc.json`.
-The wrapper requires `@semantic-release/release-notes-generator` as an explicit
-devDependency (kept on the same major as the one `semantic-release` bundles).
+No Handlebars template is reimplemented — the wrapper only reorganizes rendered
+markdown, so it is insensitive to *how* the preset renders. It does not, however,
+shield the pipeline from the preset ↔ writer coupling below. The collapsed section
+titles and the `<summary>` label are configurable via the `collapsedSections` /
+`collapsedSummary` plugin options in `.releaserc.json`. The wrapper requires
+`@semantic-release/release-notes-generator` as an explicit devDependency (kept on
+the same major as the one `semantic-release` bundles).
+
+### Preset / writer version coupling
+
+`conventional-changelog-conventionalcommits` v10 replaced Handlebars template
+strings with render functions. Only `conventional-changelog-writer@9` understands
+that shape, while `@semantic-release/release-notes-generator@14` (latest) still
+declares `conventional-changelog-writer@^8`. Paired as published, writer 8 finds no
+`mainTemplate` and renders **only the version header** — a release would still be
+cut, with an empty CHANGELOG and GitHub Release. Upstream issue:
+[semantic-release/release-notes-generator#992](https://github.com/semantic-release/release-notes-generator/issues/992).
+
+`pnpm-workspace.yaml` therefore overrides the writer to `^9.2.0`. The override is
+unscoped because `@semantic-release/commit-analyzer` declares the writer but never
+imports it (it reads only the preset's `parserOpts`; release levels come from its
+own default release rules), so forcing the writer cannot affect version detection —
+only rendering. Verified on real repository history: the generated notes are
+byte-identical to the pre-upgrade output.
+
+**Removal condition:** drop the override once `release-notes-generator` publishes a
+version depending on `conventional-changelog-writer@^9`. The canary assertions in
+`tests/unit/release-notes-preset-render.test.ts` are what detects a broken pairing,
+in either direction.
 
 ## Auto-merge policy
 
@@ -127,15 +154,6 @@ Concrete examples:
 - Non-vuln patch update of `hono` (prod) → PR `chore(deps): update hono to X` → manual review → no release on merge.
 - GitHub Action digest bump → PR `chore(deps): update actions/X` → manual review → no release.
 - Weekly Friday lockfile maintenance (before 8am, Europe/Paris) → PR `chore(deps): lock file maintenance` → auto-merge → no release. Picks up transitive updates whose parent ranges already allow the new version (e.g. a `^3.0.1`-ranged transitive moving from 3.1.0 to 3.1.2).
-
-## Transitive vulnerabilities
-
-`vulnerabilityAlerts` only acts on dependencies that appear in `package.json`. For vulnerabilities deep in the tree (visible in `pnpm-lock.yaml` only), two mechanisms cover the gap:
-
-1. **`lockFileMaintenance`** (weekly, Friday morning) regenerates `pnpm-lock.yaml`. Any transitive whose parent range already accepts the patched version moves up — no manifest change needed. This covers the common case.
-2. **`pnpm.overrides`** in `package.json` is required when the parent pins the vulnerable transitive at an exact version (or a range that excludes the patched one). The first time, a maintainer opens a `fix(security):` PR adding the override; from then on, Renovate auto-bumps the override entry via the dedicated `matchDepTypes: ["pnpm.overrides"]` rule (patch / minor only).
-
-**Caveat — semver hygiene in the npm ecosystem.** Bumping a transitive via lockfile-only regen relies on the parent's declared semver range being accurate. Some maintainers ship breaking changes in patch/minor versions. The auto-merged `lockFileMaintenance` PR is therefore guarded by CI (typecheck + tests); a regression should fail the build and block the merge. Skim the diff when reviewing CI failures on these PRs.
 
 ## Admin prerequisites (out-of-PR settings)
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@types/hast": "^3.0.4",
     "@types/node": "^22.15.0",
     "@vitest/coverage-v8": "^4.1.0",
-    "conventional-changelog-conventionalcommits": "^9.3.1",
+    "conventional-changelog-conventionalcommits": "^10.2.1",
     "msw": "^2.12.13",
     "semantic-release": "^25.0.3",
     "shx": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   ip-address: ^10.2.0
+  conventional-changelog-writer: ^9.2.0
 
 importers:
 
@@ -94,8 +95,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.10(vitest@4.1.10)
       conventional-changelog-conventionalcommits:
-        specifier: ^9.3.1
-        version: 9.3.1
+        specifier: ^10.2.1
+        version: 10.2.1
       msw:
         specifier: ^2.12.13
         version: 2.15.0(@types/node@22.20.1)(typescript@7.0.2)
@@ -220,6 +221,10 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@conventional-changelog/template@1.2.1':
+    resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
+    engines: {node: '>=22'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -806,6 +811,10 @@ packages:
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
 
+  '@simple-libs/stream-utils@2.0.0':
+    resolution: {integrity: sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==}
+    engines: {node: '>=22'}
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -1209,6 +1218,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  argue-cli@3.1.0:
+    resolution: {integrity: sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==}
+    engines: {node: '>=22'}
+
   argv-formatter@1.0.0:
     resolution: {integrity: sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==}
 
@@ -1375,18 +1388,22 @@ packages:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
     engines: {node: '>=18'}
 
-  conventional-changelog-conventionalcommits@9.3.1:
-    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
-    engines: {node: '>=18'}
+  conventional-changelog-conventionalcommits@10.2.1:
+    resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
+    engines: {node: '>=22'}
 
-  conventional-changelog-writer@8.4.0:
-    resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
-    engines: {node: '>=18'}
+  conventional-changelog-writer@9.2.0:
+    resolution: {integrity: sha512-eACD5BaAQCYjeI3RExkCZopNaaIuXzCP4kaAb2lEFXcGa/KOuxJfj8v/SnjhvF6377pYn0A2Gji+6GhwUK8rEA==}
+    engines: {node: '>=22'}
     hasBin: true
 
   conventional-commits-filter@5.0.0:
     resolution: {integrity: sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==}
     engines: {node: '>=18'}
+
+  conventional-commits-filter@6.0.1:
+    resolution: {integrity: sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==}
+    engines: {node: '>=22'}
 
   conventional-commits-parser@6.4.0:
     resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
@@ -1805,11 +1822,6 @@ packages:
   graphql@16.14.2:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-
-  handlebars@4.7.9:
-    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
 
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -2462,9 +2474,6 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neo-async@2.6.2:
-    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
   nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
 
@@ -3038,10 +3047,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -3298,11 +3303,6 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
-  uglify-js@3.19.3:
-    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
@@ -3508,9 +3508,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wordwrap@1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -3658,6 +3655,8 @@ snapshots:
 
   '@colors/colors@1.5.0':
     optional: true
+
+  '@conventional-changelog/template@1.2.1': {}
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -4065,7 +4064,7 @@ snapshots:
   '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.7(typescript@7.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.1
-      conventional-changelog-writer: 8.4.0
+      conventional-changelog-writer: 9.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.4.0
       debug: 4.4.3
@@ -4152,7 +4151,7 @@ snapshots:
   '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.7(typescript@7.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.1
-      conventional-changelog-writer: 8.4.0
+      conventional-changelog-writer: 9.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.4.0
       debug: 4.4.3
@@ -4164,6 +4163,8 @@ snapshots:
       - supports-color
 
   '@simple-libs/stream-utils@1.2.0': {}
+
+  '@simple-libs/stream-utils@2.0.0': {}
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -4455,6 +4456,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  argue-cli@3.1.0: {}
+
   argv-formatter@1.0.0: {}
 
   array-ify@1.0.0: {}
@@ -4636,19 +4639,21 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@9.3.1:
+  conventional-changelog-conventionalcommits@10.2.1:
     dependencies:
-      compare-func: 2.0.0
+      '@conventional-changelog/template': 1.2.1
 
-  conventional-changelog-writer@8.4.0:
+  conventional-changelog-writer@9.2.0:
     dependencies:
-      '@simple-libs/stream-utils': 1.2.0
-      conventional-commits-filter: 5.0.0
-      handlebars: 4.7.9
-      meow: 13.2.0
+      '@conventional-changelog/template': 1.2.1
+      '@simple-libs/stream-utils': 2.0.0
+      argue-cli: 3.1.0
+      conventional-commits-filter: 6.0.1
       semver: 7.8.5
 
   conventional-commits-filter@5.0.0: {}
+
+  conventional-commits-filter@6.0.1: {}
 
   conventional-commits-parser@6.4.0:
     dependencies:
@@ -5111,15 +5116,6 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphql@16.14.2: {}
-
-  handlebars@4.7.9:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
 
   has-flag@3.0.0: {}
 
@@ -5960,8 +5956,6 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neo-async@2.6.2: {}
-
   nerf-dart@1.0.0: {}
 
   nice-try@1.0.5: {}
@@ -6556,8 +6550,6 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.6.1: {}
-
   space-separated-tokens@2.0.2: {}
 
   spawn-error-forwarder@1.0.0: {}
@@ -6798,9 +6790,6 @@ snapshots:
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
 
-  uglify-js@3.19.3:
-    optional: true
-
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
@@ -6959,8 +6948,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wordwrap@1.0.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ minimumReleaseAge: 10080
 
 overrides:
   ip-address: ^10.2.0
+  conventional-changelog-writer: ^9.2.0

--- a/tests/unit/release-notes-preset-render.test.ts
+++ b/tests/unit/release-notes-preset-render.test.ts
@@ -12,19 +12,13 @@ import { generateNotes } from '../../scripts/release-notes-collapsed.js';
  * `@semantic-release/release-notes-generator` with the exact `presetConfig` that
  * ships in `.releaserc.json`, then through our collapsing wrapper.
  *
- * It is a deliberate compatibility canary: the conventionalcommits preset must
- * stay on a generation whose `writerOpts` the resolved
- * `conventional-changelog-writer` can render. Preset v10 replaced Handlebars
- * template strings with render functions, which only writer 9 understands, while
- * `@semantic-release/release-notes-generator` still declares
- * `conventional-changelog-writer@^8` — writer 8 finds no `mainTemplate` and emits
- * *only* the version header. The pairing therefore holds solely because
- * `pnpm-workspace.yaml` overrides the writer to `^9`.
- *
- * These assertions are the tripwire if that pairing breaks again: a lockfile regen
- * that drops the override, or an upstream major moving the writer past 9. They fail
- * loudly instead of shipping empty changelogs. See `docs/release-automation.md`
- * ("Preset / writer version coupling") for the removal condition.
+ * It is a deliberate compatibility canary: the preset renders only under a
+ * `conventional-changelog-writer` major that understands its `writerOpts`, and that
+ * pairing currently holds only because `pnpm-workspace.yaml` overrides the writer
+ * to `^9`. Drop the override, or outgrow it, and generation degrades silently to
+ * just the version header — these assertions fail loudly instead of shipping an
+ * empty changelog. Full mechanism and removal condition:
+ * `docs/release-automation.md` ("Preset / writer version coupling").
  */
 
 // The collapsing plugin is the 2nd `.releaserc.json` plugin entry: [path, options].

--- a/tests/unit/release-notes-preset-render.test.ts
+++ b/tests/unit/release-notes-preset-render.test.ts
@@ -13,12 +13,18 @@ import { generateNotes } from '../../scripts/release-notes-collapsed.js';
  * ships in `.releaserc.json`, then through our collapsing wrapper.
  *
  * It is a deliberate compatibility canary: the conventionalcommits preset must
- * stay on a generation whose `writerOpts` the pinned `release-notes-generator`
- * (and its `conventional-changelog-writer`) can render. A preset major that
- * switches the rendering API — e.g. v10's Handlebars → render-functions change,
- * which needs `conventional-changelog-writer@9` while the plugin still depends on
- * `@^8` — silently produces notes containing only the version header. These
- * assertions fail loudly in that case instead of shipping empty changelogs.
+ * stay on a generation whose `writerOpts` the resolved
+ * `conventional-changelog-writer` can render. Preset v10 replaced Handlebars
+ * template strings with render functions, which only writer 9 understands, while
+ * `@semantic-release/release-notes-generator` still declares
+ * `conventional-changelog-writer@^8` — writer 8 finds no `mainTemplate` and emits
+ * *only* the version header. The pairing therefore holds solely because
+ * `pnpm-workspace.yaml` overrides the writer to `^9`.
+ *
+ * These assertions are the tripwire if that pairing breaks again: a lockfile regen
+ * that drops the override, or an upstream major moving the writer past 9. They fail
+ * loudly instead of shipping empty changelogs. See `docs/release-automation.md`
+ * ("Preset / writer version coupling") for the removal condition.
  */
 
 // The collapsing plugin is the 2nd `.releaserc.json` plugin entry: [path, options].


### PR DESCRIPTION
## Summary
Unblocks the `conventional-changelog-conventionalcommits` v9 → v10 upgrade that has been red on #103 since June, by forcing `conventional-changelog-writer@^9.2.0` through a pnpm override. Also drops the `"hidden": false` keys that v10 turns into dead config, and documents the preset ↔ writer coupling with its removal condition.

## Linked issue
None (no tracking issue — the update lives on the Renovate dashboard, #21). Supersedes #103. Upstream: [semantic-release/release-notes-generator#992](https://github.com/semantic-release/release-notes-generator/issues/992).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [x] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main` — n/a, no issue; `Supersedes #103` cross-references the Renovate PR, which Renovate closes once `main` satisfies `^10`
- [x] `pnpm test` passes locally (546 tests)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings — authored and self-reviewed in a Claude Code session; the empirical controls below stand in for a second pass
- [x] Documentation is updated where needed (`docs/release-automation.md`)
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` — n/a, no tool change
- [x] If the change has **MCP-runtime-observable** behaviour: this PR carries a `## Functional validation plan` — n/a, see scope note below

## Notes for the reviewer (human or AI)

### Root cause

Preset v10 replaced Handlebars template strings with **render functions** (`template`/`headerPartial`… go from `string` to `function`), a shape only `conventional-changelog-writer@9` understands. `@semantic-release/release-notes-generator@14.1.1` (latest) still declares `conventional-changelog-writer@^8`; writer 8 finds no `mainTemplate` and falls back to its own default template, emitting **only the version header**. `commit-analyzer` is unaffected, so a release would still be cut — with an empty CHANGELOG and GitHub Release. Rendered with the same commit set:

| preset | writer | result |
|---|---|---|
| 9.3.1 | 8.4.0 | full notes ✅ |
| **10.2.1** | **8.4.0** | **header only** ❌ |
| 10.2.1 | 9.2.0 | full notes ✅ |

The canary added in #104 was doing exactly its job — this is a real silent regression, not a brittle test.

### Why the override is safe

`@semantic-release/commit-analyzer` declares `conventional-changelog-writer@^8` but **never imports it** (no occurrence in its source): it consumes only the preset's `parserOpts`, and release levels come from its own `lib/default-release-rules.js`, not the preset's `whatBump`. Forcing the writer therefore cannot affect version detection — only rendering. Hence an unscoped override rather than `'@semantic-release/release-notes-generator>conventional-changelog-writer'`; both were tested and pass, the unscoped one is more readable and is covered by the existing Renovate `matchDepTypes: ["pnpm.overrides"]` rule. Precedent in this repo: `ip-address`.

### Empirical verification

1. **Changelog output is unchanged.** Notes generated through `scripts/release-notes-collapsed.js` with the shipping `presetConfig`, over the **last 60 real commits** of this repo: **byte-identical** before/after (same md5). The only deltas appear on a synthetic edge-case set and are upstream v10 bug fixes — non-closing references rendered separately (`closes #9, references #7 #8`, upstream #1482) and breaking-change note ordering (upstream #1487).
2. **Negative control.** Removing the override line and reinstalling makes both canary assertions fail again with "header only" — the tripwire still guards. Restored and re-verified green.
3. **`pnpm why conventional-changelog-writer`** → single version, `9.2.0`.
4. **Cleaned config.** After dropping `"hidden": false`, all seven internal sections (`Documentation`, `Styles`, `Chores`, `Code Refactoring`, `Tests`, `Build System`, `Continuous Integration`) still render and still sit inside the `<details>` block, public sections above.

### `hidden` → `effect`

v10's other breaking change replaces the `hidden` commit-type property with `effect`. `isTypeEffect()` defaults a type entry to `'bump'`, so an entry with no `effect` is **visible** — our `presetConfig` keeps working and the `"hidden": false` keys become dead weight, hence the cleanup. I deliberately did *not* write `"effect": "bump"` instead: it would be accurate but misleading, since it reads as "a `chore` triggers a release" and semantic-release never consults `whatBump`. The reasoning is captured in `docs/release-automation.md`. Note these keys are load-bearing under v9, so the cleanup only travels with the bump.

### Node engines

The preset now requires Node ≥ 22. It is a devDependency: the release job runs Node 24 (`.nvmrc`) and `smoke-node20` installs only the packed tarball, so nothing runtime-facing changes.

### Boy-scout

`docs/release-automation.md` loses its "Transitive vulnerabilities" section — self-evident content, and it described overrides as living in `package.json`, which stopped being true when they moved to `pnpm-workspace.yaml`. Verified no inbound anchors from `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `AGENTS.md`, `docs/`, `.github/` or `renovate.json`; the auto-merge policy table still documents the `pnpm.overrides` rule.

### Scope

Pure release/dev tooling: a running server behaves identically for any MCP client (no tool surface, transport, auth, resource, prompt, persistence or timing change), so the standard gates are the validation and no third-party functional pass is required. No test was added on top of the canary — a "writer must resolve to 9" assertion would duplicate what the canary already proves behaviourally.

### Follow-up

Drop the override once `release-notes-generator` ships a version depending on `conventional-changelog-writer@^9`. Removal condition and rationale are documented in `docs/release-automation.md` ("Preset / writer version coupling") and referenced from the canary's doc comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEFrLy2BcmohQQPnYghu47)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Notes**
  * Updated release-note generation so non-release commit categories are handled according to the conventional commits preset defaults, reducing noise in published notes.
  * Preserved section mappings for supported commit categories.

* **Documentation**
  * Clarified how commit visibility and preset configuration affect generated release notes.
  * Expanded guidance on release-tool compatibility and workspace configuration.
  * Removed outdated vulnerability information.

* **Tests**
  * Improved compatibility-canary documentation for release-note rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->