### PR TITLE
chore(lint): improve Biome check on Android/Proot plateform

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$CLAUDE_PROJECT_DIR\" && ./node_modules/.bin/biome check --write --no-errors-on-unmatched \"$CLAUDE_FILE_PATHS\" || true"
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && set -f && ./node_modules/.bin/biome check --write --no-errors-on-unmatched $CLAUDE_FILE_PATHS || true"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm exec biome check --write --no-errors-on-unmatched \"$CLAUDE_FILE_PATHS\" || true"
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && ./node_modules/.bin/biome check --write --no-errors-on-unmatched \"$CLAUDE_FILE_PATHS\" || true"
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,12 @@ test: if a running server behaves no differently for a client, it's tooling.
 ## Code style
 
 - TypeScript strict; Biome for lint/format (`pnpm check`).
+- Keep the `!!**/node_modules` force-ignore in `biome.json` `files.includes`: it
+  stops Biome 2's scanner from opening every dependency file for its module graph
+  (~40% of `pnpm check` wall time, worse on slow filesystems), and excludes them
+  from the *scan*, not the *lint* — diagnostics here are unchanged. Revisit if a
+  type-aware rule needs dependency types. `biome.json` rejects comments, hence
+  this note.
 - Functional: pure functions, immutable data, no classes (except `ZendeskApiError`).
 - Tool handlers are standalone functions in `ToolDefinition[]` arrays.
 - ASCII-only error messages on auth paths — `node:http` rejects non-ASCII bytes

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "includes": ["**", "!!**/node_modules"] },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,


### PR DESCRIPTION
## Problem

Biome 2's scanner walks the whole project to build a module graph, which means
opening every dependency file. Tracing a single-file `biome check` with the flags
from Biome's own [Investigate slowness](https://biomejs.dev/guides/investigate-slowness/)
guide (`--log-level=tracing --log-kind=json`) shows where the 6 s go:

| span | cumulative | calls |
|---|---|---|
| `open_file_internal` | 26 142 ms | **2 182** |
| `update_module_graph_internal` | 14 477 ms | 2 130 |
| `scan` | 5 580 ms | 1 |
| `scan_dependencies` | 3 100 ms | 1 |
| `pull_diagnostics` (the actual lint) | **78 ms** | 1 |
| `format_file` (the actual format) | **16 ms** | 1 |

2 182 files opened to check one. Useful work is under 100 ms; everything else is
project discovery. Cumulative totals exceed wall time because the scan is
multi-threaded.

This is a known Biome 2 issue — biomejs/biome#5545, #6478, #6815 — not something
specific to this repo. The force-ignore applied here is what Biome's own guide
recommends.

## Changes

1. **`biome.json`** — force-ignore `**/node_modules` in `files.includes`. This
   excludes dependencies from the *scan*, not the *lint*: still `Checked 79
   files`, and the full diagnostics output is byte-identical (diffed before/after
   on the whole `src/ tests/ scripts/` scope).
2. **`.claude/settings.json`** — the format hook ran `pnpm exec biome`, paying a
   pnpm startup (itself a Node process) in front of Biome's own Node wrapper.
   Call `./node_modules/.bin/biome` directly. I deliberately kept the `.bin`
   wrapper instead of the platform binary under
   `.pnpm/@biomejs+cli-linux-arm64@<version>/`: that path embeds the version and
   would silently break on every Biome bump. This leaves one Node startup
   (~650 ms) on the table in exchange for not breaking on upgrades.
3. **`AGENTS.md`** — a note so nobody deletes the `files.includes` line as dead
   config. `biome.json` rejects comments, so the rationale has nowhere else to
   live next to the code.

## Measurements

Biome 2.5.4, medians of **alternating A/B runs** (before/after interleaved, to
cancel filesystem cache drift). This machine runs a slow PRoot filesystem, so
absolute numbers are inflated and the gains are amplified — but the mechanism is
not environment-specific, and CI runs `pnpm check` too.

| | before | after | gain |
|---|---|---|---|
| format hook, end to end | 5 773 ms | 2 606 ms | −55 % |
| `pnpm check` (79 files) | 12 956 ms | 7 947 ms | −39 % |
| `pnpm check`, second series | 20 610 ms | 11 237 ms | −45 % |

Distributions are disjoint in both hook and second-series runs (worst "after" is
better than best "before"), so the gain is systematic rather than noise. The two
`pnpm check` series differ because `pnpm typecheck` un-hardlinks 5 376 files
mid-session (see #176), changing the filesystem state; the relative gain holds
across both.

## Alternatives rejected

- **Patching Biome** — unnecessary, config achieves it, and a local patch would
  need re-applying on every release.
- **Biome daemon** (`biome start` + `--use-server`) — measured, no gain on a
  single file (5,8-6,8 s vs 6,0-6,2 s, i.e. noise), and it adds a permanent
  filesystem watcher polling every 2 s.
- **oxlint** — genuinely much faster (425 ms for 79 files with extended rules,
  verified against a deliberately broken file so it isn't measuring nothing), but
  it is a linter only, with no formatter, so it cannot back this `--write` hook.
  Replacing Biome would be an architecture decision for the whole project, not a
  hook tweak.

## Validation

Tooling-only change (lint/format setup + a dev hook), so per `AGENTS.md`
"Planning" the standard gates *are* the validation — no functional validation
plan, nothing a client observes at runtime changes.

- `pnpm check` — green (79 files)
- `pnpm typecheck` — green (TS 7 native)
- `pnpm test` — green (546 tests, 31 files)
- `pnpm build` — green

Author-side review pass done on the diff. It surfaced a pre-existing bug in the
very line this PR touches, now fixed in the second commit:

- **`"$CLAUDE_FILE_PATHS"` was quoted as a single argument**, so a multi-path
  payload reached Biome as one bogus path and failed *silently*:
  `biome check "a.ts b.ts"` -> `Checked 0 files`, exit 0, plus a "derived from an
  internal Biome error" warning. Unquoting restores word splitting (`Checked 2
  files`); `set -f` disables globbing first so a wildcard in a path is not
  expanded by the shell. Single-path payloads unchanged (`Checked 1 file`).
  Nothing was broken in practice — the `Edit|Write` matcher only ever yields one
  path — but adding a MultiEdit-style tool would have silently skipped
  formatting. Paths containing spaces remain unsupported: that is inherent to
  `CLAUDE_FILE_PATHS` being a space-separated string.

One further pre-existing issue found and deliberately left out of this PR (scope
discipline), fixed separately:

- `tests/functional/bin/dump-tools-list.mjs:53` points to a "Functional testing"
  section of `AGENTS.md` that does not exist; the real documentation is
  `tests/functional/README.md` "Prerequisites (executor side)".

## Possible upstream report

`scan_dependencies` (3,1 s) still runs with `assist` fully disabled, and toggling
`organizeImports` changes nothing (5,0 s either way) — Biome appears to scan
dependencies even when the active config consumes no dependency types. Close to
#6815. I have the full trace JSON if it is worth filing.
