### PR TITLE
docs: fix a stale harness pointer and drop AGENTS.md's directory tour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,10 @@ Open a *new* issue for the delta. Fuller checklist in `CONTRIBUTING.md`.
 
 ## Architecture
 
-Standard MCP server under `src/` (entry `index.ts` → `server.ts`). Auth in
-`auth/`, HTTP client in `client/`, tool definitions in `tools/`, tool filtering
-in `routing/registry.ts`. Transports in `transports/`: stdio (SDK
-`StdioServerTransport`) plus a thin `node:http` HTTP transport that wraps
-`StreamableHTTPServerTransport` and serves the RFC 9728 / RFC 8414 OAuth
-discovery endpoints; HTTP builds a per-session `McpServer` so the request's
-bearer is captured in the tools' closure — no shared state.
+Transports: stdio (SDK `StdioServerTransport`) plus a thin `node:http` HTTP
+transport that wraps `StreamableHTTPServerTransport` and serves the RFC 9728 /
+RFC 8414 OAuth discovery endpoints; HTTP builds a per-session `McpServer` so the
+request's bearer is captured in the tools' closure — no shared state.
 
 **Tool modes** (chosen at startup by `--mode`): `all` (every tool individually),
 `namespace` (default — one proxy per namespace), `single` (one `zendesk` proxy).

--- a/tests/functional/bin/dump-tools-list.mjs
+++ b/tests/functional/bin/dump-tools-list.mjs
@@ -50,8 +50,9 @@ const die = (msg, code = 1) => {
 const subdomain = process.env.ZENDESK_SUBDOMAIN;
 if (!subdomain) {
   die(
-    'ZENDESK_SUBDOMAIN is not set. See the "Functional testing" section in AGENTS.md ' +
-      'for how to configure the reference Zendesk instance (fruggr) locally.',
+    'ZENDESK_SUBDOMAIN is not set. See "Prerequisites (executor side)" in ' +
+      'tests/functional/README.md for how to configure the reference Zendesk ' +
+      'instance (fruggr) locally.',
   );
 }
 if (!existsSync(serverEntry)) {


### PR DESCRIPTION
Two independent documentation fixes, neither related to the lint-performance
work in #183.

## 1. A stale pointer in the functional harness

`tests/functional/bin/dump-tools-list.mjs` failed with:

> ZENDESK_SUBDOMAIN is not set. See the "Functional testing" section in AGENTS.md for how to configure the reference Zendesk instance (fruggr) locally.

There is no "Functional testing" section in `AGENTS.md`. The file mentions the
harness only in passing under `## Testing`, and deliberately delegates the detail
("Details in `tests/functional/README.md`") per its own
no-duplicated-setup-steps rule. So whoever hit this error went looking in the
wrong file.

The real instructions — including `export ZENDESK_SUBDOMAIN=fruggr` — are in
`tests/functional/README.md` under "Prerequisites (executor side)". Now pointed
there. Verified by triggering the failure path for real:

```
$ unset ZENDESK_SUBDOMAIN; node tests/functional/bin/dump-tools-list.mjs
ZENDESK_SUBDOMAIN is not set. See "Prerequisites (executor side)" in tests/functional/README.md for how to configure the reference Zendesk instance (fruggr) locally.
```

Target heading confirmed present (`tests/functional/README.md:36`), and a grep
shows this was the only stale pointer of its kind.

## 2. `AGENTS.md` no longer documents its own directory layout

`AGENTS.md` opens by forbidding exactly this:

> **Don't document what the code already shows.** File-by-file trees, command
> listings, env-var tables, setup steps — the agent reads those from the source,
> `package.json` or the docs faster than it trusts a prose copy here, and
> duplicating them only burns context and goes stale.

The Architecture section then opened with a file-by-file tour (`src/`, `auth/`,
`client/`, `tools/`, `routing/registry.ts`, `transports/`) that any session
reconstructs with one `ls` plus `package.json`. Dropped, along with the
now-redundant "in `transports/`" locator in the following sentence.

Everything a session cannot derive from the code stays: the transport wrapping
and the per-session `McpServer` rationale, tool modes and proxy scoping, the
OAuth-only decision, and the pointers to `README.md` / `docs/`.

Worth ~45 est. tokens per session that loads the file — small on its own. The
real point is that the file keeps to its own rule, so the tour doesn't grow back.
`CONTRIBUTING.md:146` ("See `AGENTS.md` for the full architecture") still
resolves: the section is intact, minus the tree.

## Validation

Docs-and-tooling only (one error string in a dev script, one prose section), so
per `AGENTS.md` "Planning" the standard gates are the validation — nothing a
client observes at runtime changes.

- `pnpm check` — green (79 files)
- `pnpm typecheck` — green (TS 7 native)
- `pnpm test` — green (546 tests, 31 files)
- `pnpm build` — green

Both commits were split out of #183's author-side review for scope discipline.
This branch and #183 both touch `AGENTS.md`, in sections ~70 lines apart, so
they merge in either order without conflict.
