### PR TITLE
fix(logger): stop a circular field from crashing the caller

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -53,17 +53,13 @@ const REDACTED_KEYS = new Set([
 const isSensitive = (key: string): boolean =>
   REDACTED_KEYS.has(key.toLowerCase().replace(/[_-]/g, ''));
 
-// Recursively redact: a sensitive *key* anywhere in the tree (top-level or
-// nested in objects/arrays) has its value replaced, so `{ oauth: { token } }`
-// can't leak. Primitives are returned as-is.
-// `path` holds the objects on the current branch: a back-reference to an
-// ancestor becomes `[circular]` instead of recursing until the stack blows,
-// while the walk descends everywhere else so a cycle can't skip the redaction
-// of the keys inside it. A value shared between siblings is not a cycle.
+// Recursively redact: a sensitive *key* anywhere in the tree has its value
+// replaced, so `{ oauth: { token } }` can't leak. `path` is the current branch
+// only (add/delete around the descent), so a back-reference to an ancestor
+// becomes `[circular]` while a value shared between siblings is still walked.
+// Functions are dropped: an own enumerable `toJSON` copied into the output
+// would be invoked by `JSON.stringify` and hand back the unredacted original.
 const redactValue = (value: unknown, path: WeakSet<object> = new WeakSet()): unknown => {
-  // Functions never survive the walk: an own enumerable `toJSON` copied into
-  // the output would be invoked by `JSON.stringify` and hand back the original,
-  // unredacted object — a redaction bypass the caller controls.
   if (typeof value === 'function') return '[function]';
   if (!value || typeof value !== 'object') return value;
   if (path.has(value)) return '[circular]';
@@ -79,6 +75,18 @@ const redactValue = (value: unknown, path: WeakSet<object> = new WeakSet()): unk
       );
   path.delete(value);
   return out;
+};
+
+// Total over anything a caller can hand us: redaction reads objects that may
+// fight back (a throwing getter, an exotic proxy), and losing the fields beats
+// taking the caller down with them.
+const sanitise = (fields?: Fields): Fields => {
+  if (!fields) return {};
+  try {
+    return redactValue(fields) as Fields;
+  } catch {
+    return { fields: '[unredactable]' };
+  }
 };
 
 const renderValue = (value: unknown): string => {
@@ -115,21 +123,12 @@ export const createLogger = (level: LogLevel): Logger => {
   const emit = (lvl: LogLevel, event: string, fields?: Fields): void => {
     if (SEVERITY[lvl] < min) return;
 
-    // Redaction reads caller-supplied objects, which may fight back (a getter
-    // that throws, an exotic proxy). Losing the fields is acceptable; taking
-    // the caller down with them is not.
-    let safe: Fields;
-    try {
-      safe = fields ? (redactValue(fields) as Fields) : {};
-    } catch {
-      safe = { fields: '[unredactable]' };
-    }
+    const safe = sanitise(fields);
 
     try {
       console.error(formatLine(lvl, event, safe));
     } catch {
-      // Same contract as the MCP forward below: the stderr sink is
-      // best-effort and must never break the flow that emitted the log.
+      // Best-effort sink: a dead stderr must not break the caller.
     }
 
     if (server) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -56,14 +56,10 @@ const isSensitive = (key: string): boolean =>
 // Recursively redact: a sensitive *key* anywhere in the tree (top-level or
 // nested in objects/arrays) has its value replaced, so `{ oauth: { token } }`
 // can't leak. Primitives are returned as-is.
-//
-// `path` holds the objects on the current branch, so a back-reference to an
-// ancestor becomes `[circular]` instead of recursing until the stack blows
-// (Node errors, HTTP request/response pairs and socket handles all
-// self-reference). The walk still descends everywhere else — a cycle must
-// never become an escape hatch that skips redaction of the keys inside it —
-// and only true cycles are marked, not values merely shared between siblings.
-// The result is therefore always a finite tree that `JSON.stringify` accepts.
+// `path` holds the objects on the current branch: a back-reference to an
+// ancestor becomes `[circular]` instead of recursing until the stack blows,
+// while the walk descends everywhere else so a cycle can't skip the redaction
+// of the keys inside it. A value shared between siblings is not a cycle.
 const redactValue = (value: unknown, path: WeakSet<object> = new WeakSet()): unknown => {
   if (!value || typeof value !== 'object') return value;
   if (path.has(value)) return '[circular]';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -61,6 +61,10 @@ const isSensitive = (key: string): boolean =>
 // while the walk descends everywhere else so a cycle can't skip the redaction
 // of the keys inside it. A value shared between siblings is not a cycle.
 const redactValue = (value: unknown, path: WeakSet<object> = new WeakSet()): unknown => {
+  // Functions never survive the walk: an own enumerable `toJSON` copied into
+  // the output would be invoked by `JSON.stringify` and hand back the original,
+  // unredacted object — a redaction bypass the caller controls.
+  if (typeof value === 'function') return '[function]';
   if (!value || typeof value !== 'object') return value;
   if (path.has(value)) return '[circular]';
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -56,16 +56,29 @@ const isSensitive = (key: string): boolean =>
 // Recursively redact: a sensitive *key* anywhere in the tree (top-level or
 // nested in objects/arrays) has its value replaced, so `{ oauth: { token } }`
 // can't leak. Primitives are returned as-is.
-const redactValue = (value: unknown): unknown => {
-  if (Array.isArray(value)) return value.map(redactValue);
-  if (value && typeof value === 'object') {
-    const out: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      out[key] = isSensitive(key) ? '[REDACTED]' : redactValue(val);
-    }
-    return out;
-  }
-  return value;
+//
+// `path` holds the objects on the current branch, so a back-reference to an
+// ancestor becomes `[circular]` instead of recursing until the stack blows
+// (Node errors, HTTP request/response pairs and socket handles all
+// self-reference). The walk still descends everywhere else — a cycle must
+// never become an escape hatch that skips redaction of the keys inside it —
+// and only true cycles are marked, not values merely shared between siblings.
+// The result is therefore always a finite tree that `JSON.stringify` accepts.
+const redactValue = (value: unknown, path: WeakSet<object> = new WeakSet()): unknown => {
+  if (!value || typeof value !== 'object') return value;
+  if (path.has(value)) return '[circular]';
+
+  path.add(value);
+  const out = Array.isArray(value)
+    ? value.map((item) => redactValue(item, path))
+    : Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([key, val]) => [
+          key,
+          isSensitive(key) ? '[REDACTED]' : redactValue(val, path),
+        ]),
+      );
+  path.delete(value);
+  return out;
 };
 
 const renderValue = (value: unknown): string => {
@@ -102,8 +115,22 @@ export const createLogger = (level: LogLevel): Logger => {
   const emit = (lvl: LogLevel, event: string, fields?: Fields): void => {
     if (SEVERITY[lvl] < min) return;
 
-    const safe = fields ? (redactValue(fields) as Fields) : {};
-    console.error(formatLine(lvl, event, safe));
+    // Redaction reads caller-supplied objects, which may fight back (a getter
+    // that throws, an exotic proxy). Losing the fields is acceptable; taking
+    // the caller down with them is not.
+    let safe: Fields;
+    try {
+      safe = fields ? (redactValue(fields) as Fields) : {};
+    } catch {
+      safe = { fields: '[unredactable]' };
+    }
+
+    try {
+      console.error(formatLine(lvl, event, safe));
+    } catch {
+      // Same contract as the MCP forward below: the stderr sink is
+      // best-effort and must never break the flow that emitted the log.
+    }
 
     if (server) {
       try {

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -133,6 +133,29 @@ describe('createLogger', () => {
     expect(() => JSON.stringify(arg.data)).not.toThrow();
   });
 
+  it('neutralises a caller-supplied toJSON that would re-expose a redacted value', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const log = createLogger('debug');
+    log.attachServer({ sendLoggingMessage: send } as never);
+
+    // The walk redacts `token`, but an own enumerable `toJSON` copied into the
+    // sanitised tree would be invoked by JSON.stringify and hand back the
+    // original, unredacted object.
+    const hostile = {
+      token: 'tojson-secret',
+      toJSON: () => ({ token: 'tojson-secret' }),
+    };
+
+    log.error('hostile_tojson', { hostile });
+
+    const line = errSpy.mock.calls[0]?.[0] as string;
+    expect(line).not.toContain('tojson-secret');
+    expect(line).toContain('[REDACTED]');
+
+    const arg = send.mock.calls[0]?.[0] as { data: unknown };
+    expect(JSON.stringify(arg.data)).not.toContain('tojson-secret');
+  });
+
   it('does not throw when a field getter throws during redaction', () => {
     const log = createLogger('debug');
     const hostile = {

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -76,6 +76,85 @@ describe('createLogger', () => {
     expect(line).toContain('keep-me');
   });
 
+  it('collapses a circular reference instead of blowing the stack', () => {
+    const log = createLogger('debug');
+    const circular: Record<string, unknown> = { label: 'root' };
+    circular.self = circular;
+
+    expect(() => log.info('evt', { circular })).not.toThrow();
+
+    const line = errSpy.mock.calls[0]?.[0] as string;
+    expect(line).toContain('evt');
+    expect(line).toContain('[circular]');
+    expect(line).toContain('root');
+  });
+
+  it('still redacts sensitive keys inside a cycle', () => {
+    const log = createLogger('debug');
+    const node: Record<string, unknown> = { token: 'cyclic-secret' };
+    node.self = node;
+
+    log.error('cyclic', { node });
+
+    const line = errSpy.mock.calls[0]?.[0] as string;
+    expect(line).not.toContain('cyclic-secret');
+    expect(line).toContain('[REDACTED]');
+    expect(line).toContain('[circular]');
+  });
+
+  it('marks only true cycles, not values shared between siblings', () => {
+    const log = createLogger('debug');
+    const shared = { label: 'shared-value' };
+
+    log.info('dag', { a: shared, b: shared });
+
+    const line = errSpy.mock.calls[0]?.[0] as string;
+    expect(line).not.toContain('[circular]');
+    expect(line).toContain('a={"label":"shared-value"}');
+    expect(line).toContain('b={"label":"shared-value"}');
+  });
+
+  it('forwards the same sanitised payload to the MCP sink for a circular value', () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const log = createLogger('debug');
+    log.attachServer({ sendLoggingMessage: send } as never);
+
+    const node: Record<string, unknown> = { token: 'cyclic-secret' };
+    node.self = node;
+
+    expect(() => log.warn('cyclic', { node })).not.toThrow();
+
+    const arg = send.mock.calls[0]?.[0] as {
+      data: { node: { token: string; self: string } };
+    };
+    expect(arg.data.node.token).toBe('[REDACTED]');
+    expect(arg.data.node.self).toBe('[circular]');
+    // The payload must be a finite tree the transport can serialise.
+    expect(() => JSON.stringify(arg.data)).not.toThrow();
+  });
+
+  it('does not throw when a field getter throws during redaction', () => {
+    const log = createLogger('debug');
+    const hostile = {
+      get boom(): never {
+        throw new Error('getter exploded');
+      },
+    };
+
+    expect(() => log.info('hostile', { hostile })).not.toThrow();
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(errSpy.mock.calls[0]?.[0] as string).toContain('hostile');
+  });
+
+  it('does not throw when the stderr write itself fails', () => {
+    errSpy.mockImplementation(() => {
+      throw new Error('EPIPE');
+    });
+    const log = createLogger('debug');
+
+    expect(() => log.info('x', { a: 1 })).not.toThrow();
+  });
+
   it('keeps the canonical event name even if a field named "event" is passed', () => {
     const send = vi.fn().mockResolvedValue(undefined);
     const log = createLogger('debug');

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -138,9 +138,7 @@ describe('createLogger', () => {
     const log = createLogger('debug');
     log.attachServer({ sendLoggingMessage: send } as never);
 
-    // The walk redacts `token`, but an own enumerable `toJSON` copied into the
-    // sanitised tree would be invoked by JSON.stringify and hand back the
-    // original, unredacted object.
+    // See the `[function]` branch in redactValue.
     const hostile = {
       token: 'tojson-secret',
       toJSON: () => ({ token: 'tojson-secret' }),


### PR DESCRIPTION
## Summary

`redactValue` walked the field graph with no cycle tracking and ran *before* `renderValue`'s `[unserializable]` guard could ever see the value, so any `log.info('evt', { circular })` threw `RangeError: Maximum call stack size exceeded` out of the call that emitted the log. The walk now carries a `WeakSet` of the objects on the current branch and substitutes `[circular]` on a back-reference to an ancestor; `emit` additionally wraps redaction and the stderr write so no future defect in either can propagate to the caller.

Review turned up a second, related hole in the same walk — a caller-supplied `toJSON` survived redaction and re-exposed the secret at stringify time. Fixed here too; see *Scope addition* below.

## Linked issue

Closes #198

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally (600 tests, 32 files)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed — none needed: no tool, resource, prompt, flag or env var changes; the logger's redaction internals aren't documented outside the source comments, which are updated in the diff
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` — n/a
- [ ] If the change has **MCP-runtime-observable** behaviour … — see below

### On the functional validation plan

**No plan, deliberately — and here is the reasoning rather than a silent omission.** The fix is internal hardening on a path no client can currently reach. Every `logger.*` call site in `src/` passes primitives or pre-extracted strings (`status`, `port`, `errorCode`, `error: message`, `count`, `mode`, …); none forwards a raw error, request/response pair or socket handle, so no sequence of MCP tool calls can construct a field graph with a cycle or a hostile `toJSON`. A validator driving the running server through `mcp__*` tools would therefore exercise exactly the same observable behaviour before and after this diff.

What the fix protects against is the *next* call site that logs a self-referencing or caller-controlled object. That contract is pinned by unit tests, which is where it belongs.

## Changes

`src/utils/logger.ts`

- `redactValue(value, path = new WeakSet())` — tracks the objects on the **current branch** (add on entry, delete on exit) rather than every object ever visited. Consequences, all intentional:
  - a back-reference to an ancestor renders as `[circular]` instead of recursing until the stack blows;
  - the walk keeps descending everywhere else, so a cycle can't become an escape hatch that skips redaction of the keys inside it;
  - a value merely **shared between siblings** (a DAG, not a cycle) is still rendered in full — matching `JSON.stringify`, which also only rejects true cycles;
  - the returned value is always a finite tree, so `renderValue`'s `JSON.stringify` succeeds and both sinks receive the same serialisable payload.
- Function values are replaced with `[function]` — see *Scope addition*.
- `emit` — redaction and the stderr write are each wrapped. Redaction reads caller-supplied objects that may fight back (a getter that throws, an exotic proxy); losing the fields to `fields=[unredactable]` is acceptable, taking the caller down with them is not. This is the same best-effort contract the MCP forward already carried, now applied to the stderr path — which answers the "worth deciding alongside" question in the issue.

`tests/unit/utils/logger.test.ts` — seven regression tests, each written failing first: cycle doesn't throw and names the cycle; sensitive keys inside a cycle are still `[REDACTED]`; sibling-shared values are *not* falsely marked circular; the MCP sink gets the same sanitised, `JSON.stringify`-able payload; a hostile `toJSON` can't re-expose a redacted value on either sink; a throwing getter doesn't propagate; a failing stderr write doesn't propagate.

## Scope addition — `toJSON` redaction bypass

Raised in review, confirmed by reproduction before any code changed:

```
entries:      [ 'token', 'toJSON' ]
stringified:  {"hostile":{"token":"tojson-secret"}}
```

The walk copies own enumerable properties into the sanitised tree, functions included. A caller-supplied `toJSON` therefore survived redaction and was invoked later by `JSON.stringify` — in `renderValue` and again in the MCP transport — handing back the original, unredacted object. `token` was replaced, and the secret still reached both sinks.

Fixed by substituting `[function]` for any function value at the top of `redactValue`, rather than special-casing the `toJSON` key: it closes the class instead of one spelling of it (a key guard leaves `items: [fn]` reachable through the array branch), and loses nothing, since `JSON.stringify` already rendered a function as `undefined`.

**This predates the PR** — the previous `redactValue` copied functions through the same way. Landing it here rather than in a separate PR is a deliberate exception to scope discipline: it's a redaction bypass in the exact function this PR rewrites, under the same hostile-caller threat model as the throwing getter already handled. Happy to split it out if you'd rather keep the diff to the cycle fix.

## Notes for the reviewer (human or AI)

- **Branch tracking vs. visited-set.** The issue suggests "a `WeakSet` of visited objects". A plain visited-set would also collapse sibling-shared subtrees to `[circular]`, silently dropping diagnostics that are perfectly loggable. Branch tracking costs one `delete` per node and keeps the output faithful; the DAG test pins the difference.
- **`[unredactable]` loses all fields, not just the hostile one.** Deliberate: a partial walk that resumed after a throwing getter would risk emitting values the interrupted redaction never got to inspect. Dropping the whole field set is the conservative choice for a redaction path.
- **Marker vocabulary.** `[function]` rather than reusing `[unserializable]`, which is `renderValue`'s word for values that *failed* to serialise — two different outcomes shouldn't share a marker.
- **Not touched:** `renderValue`'s `[unserializable]` guard, which still covers the genuinely unserializable cases (`BigInt`, a throwing `toJSON`). The test that reaches it lands with #197.
- Exponential blowup on a heavily shared DAG is theoretically possible with branch tracking (each shared subtree re-walked per path). Not guarded: log fields here are shallow diagnostic records, and the alternative loses correctness on the common case.