### PR TITLE
fix(config): fail loudly on flags and env vars with a missing or empty value

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,24 @@ Options:
 
 `--namespace` and `--read-only` are applied before the proxies are registered, so they narrow the surface in every mode — in the default `namespace` mode, `--namespace help_center` registers a single proxy (`zendesk_help_center`) instead of the full set of namespace proxies.
 
+### A malformed invocation fails at startup
+
+The server refuses to boot rather than run with config it cannot honour. Four
+shapes are rejected, each naming the flag at fault:
+
+| Invocation | Why it is rejected |
+| --- | --- |
+| `--mode` (nothing after it) | the value was forgotten |
+| `--mode ""` or `--mode=` | an empty value, typically `--mode "$VAR"` with `VAR` unset |
+| `--host --read-only` | the value is another flag, so `--host` would swallow it |
+| `--read-only=false` | a standalone flag takes no value |
+| `--moed all` | unknown flag — a typo is not silently ignored |
+
+Values are never echoed back in these messages, so a mistyped
+`--token=<secret>` reports only the flag name. Both `--flag value` and
+`--flag=value` are accepted. Only the first positional argument is read as the
+subdomain.
+
 **Examples:**
 
 ```bash
@@ -102,6 +120,20 @@ Scope and limits, by design:
   sources to reload. It is meant for `tsx`-from-source development.
 
 ## Environment variables
+
+An **empty** variable is a misconfiguration, not "unset": `PORT=` in a compose
+file, and `PORT="$VAR"` with `VAR` unset, both arrive as an empty string, and
+applying the default there would boot a server whose config silently disagrees
+with the deployment. Every single-value variable below therefore fails at
+startup when set but empty, naming the variable — unset it to get the default.
+
+Two deliberate exceptions:
+
+- `CORS_ORIGIN` is a *list*, where an empty value legitimately means "no extra
+  origins" on top of the built-in allowlist.
+- A variable that a CLI flag overrides is never consulted, so `--port 8080`
+  alongside a stray `PORT=` still boots. Validation applies to the value the
+  server actually uses.
 
 ### `ZENDESK_SUBDOMAIN`
 **Required:** yes (or the CLI `<subdomain>` argument) · **Default:** —

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,7 @@ shapes are rejected, each naming the knob at fault:
 | `--mode ""` or `--mode=` | an empty value, typically `--mode "$VAR"` with `VAR` unset |
 | `--host --read-only` | the value is another flag, so `--host` would swallow it |
 | `--read-only=false` | a standalone flag takes no value |
-| `--moed all` | unknown flag — a typo is not silently ignored |
+| `--moed all` | an unknown flag. A typo is not silently ignored |
 | `mycompany extra` | a second positional argument, so one of them would be dropped |
 
 Values are never echoed back in these messages, so a mistyped
@@ -67,10 +67,10 @@ Values are never echoed back in these messages, so a mistyped
 `--flag=value` are accepted.
 
 Exactly one positional argument is read, as the subdomain. A repeatable flag
-(`--namespace`, `--tool`, `--cors-origin`) has to be repeated —
-`--namespace tickets --namespace help_center`, never
-`--namespace tickets help_center`, which would leave `help_center` sitting where
-the subdomain belongs.
+(`--namespace`, `--tool`, `--cors-origin`) has to be repeated:
+`--namespace tickets --namespace help_center`. Writing
+`--namespace tickets help_center` instead leaves `help_center` sitting where the
+subdomain belongs.
 
 **Examples:**
 
@@ -131,7 +131,7 @@ An **empty** variable is a misconfiguration, not "unset": `PORT=` in a compose
 file, and `PORT="$VAR"` with `VAR` unset, both arrive as an empty string, and
 applying the default there would boot a server whose config silently disagrees
 with the deployment. Every single-value variable below therefore fails at
-startup when set but empty, naming the variable — unset it to get the default.
+startup when set but empty, naming the variable. Unset it to get the default.
 
 Two deliberate exceptions:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,8 +50,8 @@ Options:
 
 ### A malformed invocation fails at startup
 
-The server refuses to boot rather than run with config it cannot honour. Four
-shapes are rejected, each naming the flag at fault:
+The server refuses to boot rather than run with config it cannot honour. These
+shapes are rejected, each naming the knob at fault:
 
 | Invocation | Why it is rejected |
 | --- | --- |
@@ -60,11 +60,17 @@ shapes are rejected, each naming the flag at fault:
 | `--host --read-only` | the value is another flag, so `--host` would swallow it |
 | `--read-only=false` | a standalone flag takes no value |
 | `--moed all` | unknown flag — a typo is not silently ignored |
+| `mycompany extra` | a second positional argument, so one of them would be dropped |
 
 Values are never echoed back in these messages, so a mistyped
 `--token=<secret>` reports only the flag name. Both `--flag value` and
-`--flag=value` are accepted. Only the first positional argument is read as the
-subdomain.
+`--flag=value` are accepted.
+
+Exactly one positional argument is read, as the subdomain. A repeatable flag
+(`--namespace`, `--tool`, `--cors-origin`) has to be repeated —
+`--namespace tickets --namespace help_center`, never
+`--namespace tickets help_center`, which would leave `help_center` sitting where
+the subdomain belongs.
 
 **Examples:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,9 +62,10 @@ shapes are rejected, each naming the knob at fault:
 | `--moed all` | an unknown flag. A typo is not silently ignored |
 | `mycompany extra` | a second positional argument, so one of them would be dropped |
 
-Values are never echoed back in these messages, so a mistyped
-`--token=<secret>` reports only the flag name. Both `--flag value` and
-`--flag=value` are accepted.
+Values are never echoed back in these messages, so an unsupported flag written
+as `--anything=<secret>` is reported by name alone, with the value withheld. For
+the flags that take a value, both `--flag value` and `--flag=value` work;
+standalone flags such as `--read-only` accept no value in either form.
 
 Exactly one positional argument is read, as the subdomain. A repeatable flag
 (`--namespace`, `--tool`, `--cors-origin`) has to be repeated:
@@ -137,9 +138,10 @@ Two deliberate exceptions:
 
 - `CORS_ORIGIN` is a *list*, where an empty value legitimately means "no extra
   origins" on top of the built-in allowlist.
-- A variable that a CLI flag overrides is never consulted, so `--port 8080`
-  alongside a stray `PORT=` still boots. Validation applies to the value the
-  server actually uses.
+- A variable that the command line overrides is never consulted, so `--port
+  8080` alongside a stray `PORT=` still boots, and so does the positional
+  `<subdomain>` alongside an empty `ZENDESK_SUBDOMAIN`. Validation applies to
+  the value the server actually uses.
 
 ### `ZENDESK_SUBDOMAIN`
 **Required:** yes (or the CLI `<subdomain>` argument) · **Default:** none

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,29 +8,29 @@ variables referenced below.
 
 The server would rather not boot than run with config it cannot honour, so a
 malformed invocation fails immediately. The message names the knob at fault, and
-never repeats the value you passed — a mistyped `--token=<secret>` reports only
+never repeats the value you passed: a mistyped `--token=<secret>` reports only
 the flag name.
 
 | What you get | What to look for |
 | --- | --- |
 | `option '--mode <value>' argument missing` | the flag is the last thing on the command line; its value was forgotten |
-| `Empty value for --mode.` | the value is an empty string — usually `--mode "$VAR"` with `VAR` unset in the shell or compose file |
+| `Empty value for --mode.` | the value is an empty string, usually `--mode "$VAR"` with `VAR` unset in the shell or compose file |
 | `Option '--host' argument is ambiguous` | the next token is another flag, so `--host` would have swallowed it. To pass a value that really does start with a dash, use `--host=-value` |
 | `Unknown option '--moed'` | a typo, or a flag from a different version. Check it against the [CLI reference](configuration.md#cli-reference) |
 | `Option '--read-only' does not take an argument` | a standalone flag was given a value |
-| `Expected one positional argument (the subdomain), got 2.` | a stray argument. Most often a repeatable flag given a space-separated list — write `--namespace tickets --namespace help_center` |
+| `Expected one positional argument (the subdomain), got 2.` | a stray argument. Most often a repeatable flag given a space-separated list, where `--namespace tickets --namespace help_center` is the right form |
 | `Empty PORT. Set it to a value, or unset it entirely.` | the variable is set but empty. Remove it entirely to fall back to the default |
 
 The rows starting `option` / `Option` / `Unknown option` come from Node's own
-argument parser, so treat that wording as indicative rather than exact — it can
-change between Node releases. The `Empty …` and `Expected one positional …`
+argument parser, so treat that wording as indicative rather than exact. It can
+change between Node releases. The `Empty ...` and `Expected one positional ...`
 messages are ours and stable.
 
 Two things that are *not* errors: `CORS_ORIGIN=` is a valid way to say "no extra
 origins", and a variable that a CLI flag overrides is never read, so `--port
 8080` alongside a stray `PORT=` starts normally.
 
-If a deployment that used to work now fails here, that is the point — it was
+If a deployment that used to work now fails here, that is the point. It was
 running with config that had been silently dropped. The most common case is an
 empty `HC_RESOURCE_SCHEME`, which used to fall back to `zendesk-hc` while
 runbooks expected a branded scheme.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,11 +18,13 @@ the flag name.
 | `Option '--host' argument is ambiguous` | the next token is another flag, so `--host` would have swallowed it. To pass a value that really does start with a dash, use `--host=-value` |
 | `Unknown option '--moed'` | a typo, or a flag from a different version. Check it against the [CLI reference](configuration.md#cli-reference) |
 | `Option '--read-only' does not take an argument` | a standalone flag was given a value |
+| `Expected one positional argument (the subdomain), got 2.` | a stray argument. Most often a repeatable flag given a space-separated list — write `--namespace tickets --namespace help_center` |
 | `Empty PORT. Set it to a value, or unset it entirely.` | the variable is set but empty. Remove it entirely to fall back to the default |
 
-The wording of the first, third, fourth and fifth comes from Node's own argument
-parser, so treat the examples above as indicative rather than exact — they can be
-reworded between Node releases. The `Empty …` messages are ours and stable.
+The rows starting `option` / `Option` / `Unknown option` come from Node's own
+argument parser, so treat that wording as indicative rather than exact — it can
+change between Node releases. The `Empty …` and `Expected one positional …`
+messages are ours and stable.
 
 Two things that are *not* errors: `CORS_ORIGIN=` is a valid way to say "no extra
 origins", and a variable that a CLI flag overrides is never read, so `--port

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,35 @@ Common issues running the [Zendesk MCP Server](../README.md) and how to diagnose
 them. See also [Configuration](configuration.md) for the flags and environment
 variables referenced below.
 
+## The server refuses to start and names a flag or a variable
+
+The server would rather not boot than run with config it cannot honour, so a
+malformed invocation fails immediately. The message names the knob at fault, and
+never repeats the value you passed — a mistyped `--token=<secret>` reports only
+the flag name.
+
+| What you get | What to look for |
+| --- | --- |
+| `option '--mode <value>' argument missing` | the flag is the last thing on the command line; its value was forgotten |
+| `Empty value for --mode.` | the value is an empty string — usually `--mode "$VAR"` with `VAR` unset in the shell or compose file |
+| `Option '--host' argument is ambiguous` | the next token is another flag, so `--host` would have swallowed it. To pass a value that really does start with a dash, use `--host=-value` |
+| `Unknown option '--moed'` | a typo, or a flag from a different version. Check it against the [CLI reference](configuration.md#cli-reference) |
+| `Option '--read-only' does not take an argument` | a standalone flag was given a value |
+| `Empty PORT. Set it to a value, or unset it entirely.` | the variable is set but empty. Remove it entirely to fall back to the default |
+
+The wording of the first, third, fourth and fifth comes from Node's own argument
+parser, so treat the examples above as indicative rather than exact — they can be
+reworded between Node releases. The `Empty …` messages are ours and stable.
+
+Two things that are *not* errors: `CORS_ORIGIN=` is a valid way to say "no extra
+origins", and a variable that a CLI flag overrides is never read, so `--port
+8080` alongside a stray `PORT=` starts normally.
+
+If a deployment that used to work now fails here, that is the point — it was
+running with config that had been silently dropped. The most common case is an
+empty `HC_RESOURCE_SCHEME`, which used to fall back to `zendesk-hc` while
+runbooks expected a branded scheme.
+
 ## The browser doesn't open during OAuth login
 
 The OAuth flow opens your default browser on the first tool call. The first call

--- a/scripts/mcp-live.ts
+++ b/scripts/mcp-live.ts
@@ -26,7 +26,7 @@
  */
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { loadConfig } from '../src/config';
+import { loadConfig, VALUE_FLAG_NAMES } from '../src/config';
 import { createMcpServer } from '../src/server';
 
 const argv = process.argv.slice(2);
@@ -46,25 +46,12 @@ const fail = (message: string): never => {
 // arg), fall back to a placeholder. This keeps credential-free inspection
 // working; a real `call` still needs a real subdomain + token.
 // Skip values that follow a value-taking flag (e.g. `all` in `--mode all`),
-// otherwise the placeholder is wrongly skipped. Keep in sync with the
-// value-taking flags in `src/config.ts` `parseCliArgs`.
-const VALUE_FLAGS = new Set([
-  '--mode',
-  '--namespace',
-  '--tool',
-  '--log-level',
-  '--hc-resource-scheme',
-  '--transport',
-  '--host',
-  '--port',
-  '--public-url',
-  '--cors-origin',
-  '--callback-port',
-]);
+// otherwise the placeholder is wrongly skipped. The flag list comes from
+// `src/config.ts`, so it cannot drift from the parser's own view of it.
 const hasPositionalSubdomain = configArgs.some((arg, i) => {
   if (arg.startsWith('-')) return false;
   const prev = configArgs[i - 1];
-  return !(prev && VALUE_FLAGS.has(prev));
+  return !(prev && VALUE_FLAG_NAMES.has(prev));
 });
 if (!process.env['ZENDESK_SUBDOMAIN'] && !hasPositionalSubdomain) {
   process.env['ZENDESK_SUBDOMAIN'] = 'mcp-live-placeholder';

--- a/src/config.ts
+++ b/src/config.ts
@@ -266,6 +266,10 @@ const parseCliArgs = (args: string[]): CliResult => {
     );
   }
 
+  // Built up locally and returned once: `parseCliArgs` stays a pure function of
+  // its argv, and the accumulator never escapes. A `reduce` spreading `acc` per
+  // flag would read as more immutable but is what `noAccumulatingSpread`
+  // (enabled in biome.json) rejects, for its O(n^2) copying.
   const result: CliResult = { subdomain: positionals[0] };
 
   // parseArgs only reports flags that were actually passed, so iterating its

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,7 +120,10 @@ export const ConfigSchema = z.object({
 export type Config = z.infer<typeof ConfigSchema>;
 
 interface CliResult {
-  subdomain?: string;
+  // Explicitly `| undefined` so the parser can assign the first positional
+  // unconditionally: `exactOptionalPropertyTypes` would otherwise force a guard
+  // that reads as behaviour but only ever satisfies the type checker.
+  subdomain?: string | undefined;
   mode?: string;
   readOnly?: boolean;
   namespaces?: string[];
@@ -178,7 +181,6 @@ const parsePortEnv = (raw: string | undefined, label: string): number | undefine
 // over (`--port 8080` next to a stray `PORT=` in a compose file is normal).
 const requireNonEmptyEnv = (name: string): string | undefined => {
   const raw = process.env[name];
-  if (raw === undefined) return undefined;
   if (raw === '') {
     throw new Error(`Empty ${name}. Set it to a value, or unset it entirely.`);
   }
@@ -252,9 +254,7 @@ const parseCliArgs = (args: string[]): CliResult => {
   });
 
   // Only the first positional is taken as the subdomain; extras stay ignored.
-  const result: CliResult = {};
-  const subdomain = positionals[0];
-  if (subdomain !== undefined) result.subdomain = subdomain;
+  const result: CliResult = { subdomain: positionals[0] };
 
   // parseArgs only reports flags that were actually passed, so iterating its
   // output visits exactly the operator's invocation.
@@ -322,8 +322,10 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
   const cli = parseCliArgs(argv);
 
   const subdomain = cli.subdomain ?? requireNonEmptyEnv('ZENDESK_SUBDOMAIN') ?? '';
-  const oauthClientId =
-    requireNonEmptyEnv('ZENDESK_OAUTH_CLIENT_ID') ?? (subdomain ? `${subdomain}_zendesk` : '');
+  // No empty-subdomain special case: a missing subdomain already fails the
+  // schema on its own, and derived-but-unused `_zendesk` here keeps that report
+  // down to the one issue the operator can act on.
+  const oauthClientId = requireNonEmptyEnv('ZENDESK_OAUTH_CLIENT_ID') ?? `${subdomain}_zendesk`;
 
   const mode = cli.tools?.length ? 'all' : (cli.mode ?? 'namespace');
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -192,7 +192,7 @@ const requireNonEmptyEnv = (name: string): string | undefined => {
 // of a flag whose value is another dash-leading token, and of a value handed to a
 // standalone flag — so those guarantees cannot drift per-flag the way the
 // previous branch-per-flag chain could. Adding a flag is one entry here.
-export const CLI_OPTIONS = {
+const CLI_OPTIONS = {
   mode: { type: 'string' },
   namespace: { type: 'string', multiple: true },
   tool: { type: 'string', multiple: true },

--- a/src/config.ts
+++ b/src/config.ts
@@ -253,7 +253,19 @@ const parseCliArgs = (args: string[]): CliResult => {
     allowPositionals: true,
   });
 
-  // Only the first positional is taken as the subdomain; extras stay ignored.
+  // A second positional is always a mistake, and dropping it silently is the
+  // exact failure this module refuses to commit elsewhere: `--namespace tickets
+  // help_center mycompany` would take `help_center` as the subdomain and discard
+  // `mycompany`, reaching the wrong Zendesk tenant with a narrowed tool surface
+  // and no diagnostic at all. Counted, never echoed (same policy as parsePort).
+  if (positionals.length > 1) {
+    throw new Error(
+      `Expected one positional argument (the subdomain), got ${positionals.length}. ` +
+        'A repeatable flag has to be repeated (--namespace tickets --namespace ' +
+        'help_center); it does not take a space-separated list.',
+    );
+  }
+
   const result: CliResult = { subdomain: positionals[0] };
 
   // parseArgs only reports flags that were actually passed, so iterating its

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { type ParseArgsConfig, parseArgs } from 'node:util';
 import * as z from 'zod/v4';
 
 export const ToolMode = z.enum(['single', 'namespace', 'all']);
@@ -158,133 +159,128 @@ const parsePort = (raw: string, label: string): number => {
 };
 
 const parsePortEnv = (raw: string | undefined, label: string): number | undefined =>
-  raw === undefined || raw === '' ? undefined : parsePort(raw, label);
+  raw === undefined ? undefined : parsePort(raw, label);
 
-// Append to a repeatable list flag, creating it on first use.
-const appendTo =
-  (key: 'namespaces' | 'tools' | 'corsOrigins') =>
-  (result: CliResult, value: string): void => {
-    const list = result[key] ?? [];
-    list.push(value);
-    result[key] = list;
-  };
+// An empty environment variable is a misconfiguration, not "unset": `FOO=` in a
+// compose file, and `FOO="$BAR"` with BAR unset, both reach us as ''. Applying
+// the default there boots a server whose config silently disagrees with the
+// deployment's intent, so fail naming the variable instead (issue #174). The
+// value is not echoed, same policy as parsePort above.
+//
+// Deliberately not applied to CORS_ORIGIN: that one is a comma-separated *list*,
+// where `CORS_ORIGIN=` legitimately means "no extra origins" on top of the
+// built-in allowlist. Empty single-value variable is an error; empty list
+// variable is an empty list.
+//
+// Reached through `??`, so it only fires for a variable that is actually
+// consulted: a CLI flag wins over the env by contract, and the variable it
+// shadows is dead config rather than a misconfiguration worth refusing to boot
+// over (`--port 8080` next to a stray `PORT=` in a compose file is normal).
+const requireNonEmptyEnv = (name: string): string | undefined => {
+  const raw = process.env[name];
+  if (raw === undefined) return undefined;
+  if (raw === '') {
+    throw new Error(`Empty ${name}. Set it to a value, or unset it entirely.`);
+  }
+  return raw;
+};
 
-// Maps, not object literals: these are indexed by raw argv, and a plain object
-// would resolve inherited keys — a bare `toString` argument would hit
-// Object.prototype and be swallowed instead of taken as the subdomain.
+// The whole CLI surface as one declarative table. `parseArgs` derives from it the
+// rejection of an unknown flag, of a value-taking flag left at the end of argv,
+// of a flag whose value is another dash-leading token, and of a value handed to a
+// standalone flag — so those guarantees cannot drift per-flag the way the
+// previous branch-per-flag chain could. Adding a flag is one entry here.
+export const CLI_OPTIONS = {
+  mode: { type: 'string' },
+  namespace: { type: 'string', multiple: true },
+  tool: { type: 'string', multiple: true },
+  'log-level': { type: 'string' },
+  'hc-resource-scheme': { type: 'string' },
+  transport: { type: 'string' },
+  host: { type: 'string' },
+  port: { type: 'string' },
+  'public-url': { type: 'string' },
+  'cors-origin': { type: 'string', multiple: true },
+  'callback-port': { type: 'string' },
+  'read-only': { type: 'boolean' },
+  'no-topology': { type: 'boolean' },
+  'no-promoted-articles': { type: 'boolean' },
+  dev: { type: 'boolean' },
+} as const satisfies ParseArgsConfig['options'];
 
-// Flags that stand alone. Adding one is a line here, not a branch below.
-const STANDALONE_FLAGS = new Map<string, (result: CliResult) => void>([
-  [
-    '--read-only',
-    (result) => {
-      result.readOnly = true;
-    },
-  ],
-  [
-    '--no-topology',
-    (result) => {
-      result.topology = false;
-    },
-  ],
-  [
-    '--no-promoted-articles',
-    (result) => {
-      result.promotedArticles = false;
-    },
-  ],
-  [
-    '--dev',
-    (result) => {
-      result.dev = true;
-    },
-  ],
+// The value-taking subset, spelled as they appear on the command line. Exported
+// so scripts/mcp-live.ts can tell `all` in `--mode all` from a positional
+// subdomain without maintaining its own copy of the list.
+export const VALUE_FLAG_NAMES: ReadonlySet<string> = new Set(
+  Object.entries(CLI_OPTIONS)
+    .filter(([, spec]) => spec.type === 'string')
+    .map(([name]) => `--${name}`),
+);
+
+// Which CliResult field each flag feeds, for the ones whose value passes through
+// untouched. `--port` / `--callback-port` are handled separately because they go
+// through parsePort, and the standalone flags below carry no value at all.
+const FIELD_BY_FLAG = new Map<string, keyof CliResult>([
+  ['mode', 'mode'],
+  ['namespace', 'namespaces'],
+  ['tool', 'tools'],
+  ['log-level', 'logLevel'],
+  ['hc-resource-scheme', 'hcResourceScheme'],
+  ['transport', 'transport'],
+  ['host', 'host'],
+  ['public-url', 'publicUrl'],
+  ['cors-origin', 'corsOrigins'],
 ]);
 
-// Flags that consume the following argument. Repeatable ones append; the rest
-// last-wins, both matching the previous if/else chain.
-const VALUED_FLAGS = new Map<string, (result: CliResult, value: string) => void>([
-  [
-    '--mode',
-    (result, value) => {
-      result.mode = value;
-    },
-  ],
-  [
-    '--hc-resource-scheme',
-    (result, value) => {
-      result.hcResourceScheme = value;
-    },
-  ],
-  [
-    '--log-level',
-    (result, value) => {
-      result.logLevel = value;
-    },
-  ],
-  [
-    '--transport',
-    (result, value) => {
-      result.transport = value;
-    },
-  ],
-  [
-    '--host',
-    (result, value) => {
-      result.host = value;
-    },
-  ],
-  [
-    '--public-url',
-    (result, value) => {
-      result.publicUrl = value;
-    },
-  ],
-  [
-    '--port',
-    (result, value) => {
-      result.port = parsePort(value, '--port');
-    },
-  ],
-  [
-    '--callback-port',
-    (result, value) => {
-      result.callbackPort = parsePort(value, '--callback-port');
-    },
-  ],
-  ['--namespace', appendTo('namespaces')],
-  ['--tool', appendTo('tools')],
-  ['--cors-origin', appendTo('corsOrigins')],
+// Standalone flags set a fixed value, which is why they cannot go through
+// FIELD_BY_FLAG: `--no-topology` being present means `topology: false`.
+const STANDALONE_EFFECTS = new Map<string, Partial<CliResult>>([
+  ['read-only', { readOnly: true }],
+  ['no-topology', { topology: false }],
+  ['no-promoted-articles', { promotedArticles: false }],
+  ['dev', { dev: true }],
 ]);
 
 const parseCliArgs = (args: string[]): CliResult => {
+  // `strict` (the default) is what makes a malformed invocation fail at startup.
+  // Node's messages already name the offending flag and never echo the value
+  // after an `=`, so they are surfaced as-is rather than re-wrapped.
+  const { values, positionals } = parseArgs({
+    args,
+    options: CLI_OPTIONS,
+    allowPositionals: true,
+  });
+
+  // Only the first positional is taken as the subdomain; extras stay ignored.
   const result: CliResult = {};
+  const subdomain = positionals[0];
+  if (subdomain !== undefined) result.subdomain = subdomain;
 
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === undefined) continue;
+  // parseArgs only reports flags that were actually passed, so iterating its
+  // output visits exactly the operator's invocation.
+  for (const [flag, value] of Object.entries(values)) {
+    // The one shape parseArgs accepts: an empty value, from `--mode ""` or
+    // `--mode=`. That is exactly what a shell hands over for an unset variable,
+    // and it used to be dropped and then consumed as the positional subdomain,
+    // so startup failed with a misleading `ZENDESK_SUBDOMAIN is required`.
+    if (Array.isArray(value) ? value.includes('') : value === '') {
+      throw new Error(`Empty value for --${flag}. Provide a value, or omit the flag.`);
+    }
 
-    const standalone = STANDALONE_FLAGS.get(arg);
-    if (standalone) {
-      standalone(result);
+    const effect = STANDALONE_EFFECTS.get(flag);
+    if (effect) {
+      Object.assign(result, effect);
       continue;
     }
 
-    // Truthiness, not `!== undefined`: a valued flag with an empty or missing
-    // value is ignored rather than recorded, as it was before.
-    const valued = VALUED_FLAGS.get(arg);
-    const next = args[i + 1];
-    if (valued && next) {
-      valued(result, next);
-      i++;
-      continue;
-    }
+    const field = FIELD_BY_FLAG.get(flag);
+    if (field) Object.assign(result, { [field]: value });
+  }
 
-    // Only the first non-flag argument is taken; `subdomain` being unset is
-    // exactly the "no positional seen yet" state.
-    if (!arg.startsWith('-') && result.subdomain === undefined) {
-      result.subdomain = arg;
-    }
+  // Ports last, so an empty value is rejected above before parsePort sees it.
+  if (values.port !== undefined) result.port = parsePort(values.port, '--port');
+  if (values['callback-port'] !== undefined) {
+    result.callbackPort = parsePort(values['callback-port'], '--callback-port');
   }
 
   return result;
@@ -306,16 +302,18 @@ const resolveTransportSettings = (cli: CliResult): TransportSettings => {
   // CORS allowlist extension: CLI flags first, then comma-separated env var.
   // The defaults (major web MCP clients + localhost-any-port) are baked into
   // the HTTP transport — this list ADDS to them, never replaces them.
+  // Read directly, not through requireNonEmptyEnv: as a list variable, an empty
+  // CORS_ORIGIN means "no extra origins" rather than a misconfiguration.
   const corsFromEnv = (process.env['CORS_ORIGIN'] ?? '')
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 
   return {
-    transport: cli.transport ?? process.env['TRANSPORT'] ?? 'stdio',
-    host: cli.host ?? process.env['HOST'] ?? '0.0.0.0',
-    port: cli.port ?? parsePortEnv(process.env['PORT'], 'PORT') ?? 3000,
-    publicUrl: cli.publicUrl ?? process.env['PUBLIC_URL'],
+    transport: cli.transport ?? requireNonEmptyEnv('TRANSPORT') ?? 'stdio',
+    host: cli.host ?? requireNonEmptyEnv('HOST') ?? '0.0.0.0',
+    port: cli.port ?? parsePortEnv(requireNonEmptyEnv('PORT'), 'PORT') ?? 3000,
+    publicUrl: cli.publicUrl ?? requireNonEmptyEnv('PUBLIC_URL'),
     corsOrigins: [...(cli.corsOrigins ?? []), ...corsFromEnv],
   };
 };
@@ -323,24 +321,24 @@ const resolveTransportSettings = (cli: CliResult): TransportSettings => {
 export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
   const cli = parseCliArgs(argv);
 
-  const subdomain = cli.subdomain ?? process.env['ZENDESK_SUBDOMAIN'] ?? '';
+  const subdomain = cli.subdomain ?? requireNonEmptyEnv('ZENDESK_SUBDOMAIN') ?? '';
   const oauthClientId =
-    process.env['ZENDESK_OAUTH_CLIENT_ID'] ?? (subdomain ? `${subdomain}_zendesk` : '');
+    requireNonEmptyEnv('ZENDESK_OAUTH_CLIENT_ID') ?? (subdomain ? `${subdomain}_zendesk` : '');
 
   const mode = cli.tools?.length ? 'all' : (cli.mode ?? 'namespace');
 
   const callbackPort =
     cli.callbackPort ??
-    parsePortEnv(process.env['ZENDESK_OAUTH_CALLBACK_PORT'], 'ZENDESK_OAUTH_CALLBACK_PORT');
+    parsePortEnv(requireNonEmptyEnv('ZENDESK_OAUTH_CALLBACK_PORT'), 'ZENDESK_OAUTH_CALLBACK_PORT');
 
-  // `|| undefined`: an empty env means unset (same convention as parsePortEnv),
-  // letting the schema default (`zendesk-hc`) apply; format is schema-validated.
-  const hcResourceScheme = cli.hcResourceScheme ?? (process.env['HC_RESOURCE_SCHEME'] || undefined);
+  // Unset leaves this undefined so the schema default (`zendesk-hc`) applies;
+  // empty is rejected by requireNonEmptyEnv. Format is schema-validated.
+  const hcResourceScheme = cli.hcResourceScheme ?? requireNonEmptyEnv('HC_RESOURCE_SCHEME');
 
   return ConfigSchema.parse({
     subdomain,
     oauthClientId,
-    logLevel: cli.logLevel ?? process.env['LOG_LEVEL'] ?? 'info',
+    logLevel: cli.logLevel ?? requireNonEmptyEnv('LOG_LEVEL') ?? 'info',
     mode,
     readOnly: cli.readOnly ?? false,
     namespaces: cli.namespaces,

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -416,6 +416,44 @@ describe('loadConfig', () => {
       expect(() => loadConfig(['mycompany', '--read-only=false'])).toThrow();
     });
 
+    it('rejects a second positional instead of silently dropping it', () => {
+      expect(() => loadConfig(['mycompany', 'othercompany'])).toThrow(
+        /Expected one positional argument \(the subdomain\), got 2\./,
+      );
+    });
+
+    it('counts the positionals it actually got', () => {
+      // Pins the count to the real number rather than a fixed string, so the
+      // operator can tell two stray arguments from one.
+      expect(() => loadConfig(['mycompany', 'second', 'third'])).toThrow(/got 3\./);
+    });
+
+    it('rejects a space-separated list handed to a repeatable flag', () => {
+      // The natural wrong guess for a `multiple: true` flag. Used to boot against
+      // subdomain `help_center` with only the `tickets` namespace registered and
+      // `mycompany` dropped: the wrong tenant AND a narrowed tool surface, with
+      // no diagnostic — the same class of silent misconfiguration as issue #174.
+      expect(() => loadConfig(['--namespace', 'tickets', 'help_center', 'mycompany'])).toThrow(
+        /Expected one positional argument \(the subdomain\), got 2\./,
+      );
+      expect(() => loadConfig(['mycompany', '--tool', 'get_ticket', 'list_tickets'])).toThrow(
+        /Expected one positional argument/,
+      );
+    });
+
+    it('points at the repeated-flag form rather than just refusing', () => {
+      expect(() => loadConfig(['mycompany', 'extra'])).toThrow(
+        /--namespace tickets --namespace help_center/,
+      );
+    });
+
+    it('does not echo the extra positional values', () => {
+      // Same no-echo policy as parsePort: a stray argument can be a tenant name.
+      expect(() => loadConfig(['mycompany', 's3cr3t-tenant'])).toThrow(
+        expect.objectContaining({ message: expect.not.stringContaining('s3cr3t-tenant') }),
+      );
+    });
+
     it('still accepts every flag with a proper value', () => {
       const config = loadConfig([
         'mycompany',

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -555,6 +555,14 @@ describe('loadConfig', () => {
       expect(config.hcResourceScheme).toBe('wiki');
     });
 
+    it('ignores an empty ZENDESK_SUBDOMAIN that the positional argument overrides', () => {
+      // The positional subdomain is not a flag, but it shadows the variable the
+      // same way, so the same rule applies: the variable is never consulted and
+      // its emptiness is dead config rather than a reason to refuse to boot.
+      process.env['ZENDESK_SUBDOMAIN'] = '';
+      expect(loadConfig(['mycompany']).subdomain).toBe('mycompany');
+    });
+
     it('keeps CORS_ORIGIN tolerant of an empty value', () => {
       // A list variable: `CORS_ORIGIN=` means "no extra origins", which is a
       // normal way to write it in a compose file. The built-in allowlist (major

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -102,8 +102,12 @@ describe('loadConfig', () => {
     expect(config.subdomain).toBe('envcompany');
   });
 
-  it('throws on missing subdomain', () => {
-    expect(() => loadConfig([])).toThrow();
+  it('throws on missing subdomain, reporting only that', () => {
+    // oauthClientId is derived from the subdomain, so an empty subdomain used to
+    // fail twice — once for itself and once for a `''` client id the operator
+    // never set. Only the actionable issue is reported now.
+    expect(() => loadConfig([])).toThrow(/ZENDESK_SUBDOMAIN is required/);
+    expect(() => loadConfig([])).not.toThrow(/oauthClientId/);
   });
 
   it('parses --log-level flag', () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { loadConfig } from '../../src/config';
+import { loadConfig, VALUE_FLAG_NAMES } from '../../src/config';
 
 describe('loadConfig', () => {
   beforeEach(() => {
@@ -285,10 +285,14 @@ describe('loadConfig', () => {
       }
     });
 
-    it('treats an empty HC_RESOURCE_SCHEME env as unset (same as PORT-style envs)', () => {
+    // Deliberate spec change (issue #174): this used to assert that an empty
+    // HC_RESOURCE_SCHEME meant "unset", matching the PORT-style envs. That
+    // convention hid a broken deployment — `--hc-resource-scheme "$SCHEME"` with
+    // SCHEME unset booted on the default scheme while runbooks expected the
+    // branded one. Empty now fails at startup, naming the variable.
+    it('rejects an empty HC_RESOURCE_SCHEME env', () => {
       process.env['HC_RESOURCE_SCHEME'] = '';
-      const config = loadConfig(['mycompany']);
-      expect(config.hcResourceScheme).toBe('zendesk-hc');
+      expect(() => loadConfig(['mycompany'])).toThrow(/Empty HC_RESOURCE_SCHEME\./);
     });
 
     it('rejects an invalid HC_RESOURCE_SCHEME env value', () => {
@@ -334,6 +338,196 @@ describe('loadConfig', () => {
     it('rejects ZENDESK_OAUTH_CALLBACK_PORT env values that are not strictly numeric', () => {
       process.env['ZENDESK_OAUTH_CALLBACK_PORT'] = '52000abc';
       expect(() => loadConfig(['mycompany'])).toThrow(/Invalid ZENDESK_OAUTH_CALLBACK_PORT value/);
+    });
+  });
+
+  // A value-taking flag whose value is missing or empty used to be dropped
+  // silently, so the server booted with defaults and nothing in the logs pointed
+  // at the cause (issue #174). Every shape below must now fail at startup.
+  describe('strict CLI parsing', () => {
+    // Driven by the exported flag list, not a hand-picked sample: a new flag is
+    // covered the moment it is added to CLI_OPTIONS, so the guarantee cannot
+    // drift per-flag the way the old one-branch-per-flag chain did.
+    const valueFlags = [...VALUE_FLAG_NAMES];
+
+    it('covers every value-taking flag declared in CLI_OPTIONS', () => {
+      // Guards the parametrised cases below against silently shrinking to zero.
+      expect(valueFlags).toHaveLength(11);
+    });
+
+    it.each(valueFlags)('rejects %s as the last argument (value forgotten)', (flag) => {
+      expect(() => loadConfig(['mycompany', flag])).toThrow();
+    });
+
+    it.each(valueFlags)('rejects %s followed by an empty value', (flag) => {
+      expect(() => loadConfig(['mycompany', flag, ''])).toThrow(
+        new RegExp(`Empty value for \\${flag}\\.`),
+      );
+    });
+
+    it.each(valueFlags)('rejects %s in the --flag= form with nothing after it', (flag) => {
+      expect(() => loadConfig(['mycompany', `${flag}=`])).toThrow(
+        new RegExp(`Empty value for \\${flag}\\.`),
+      );
+    });
+
+    it('rejects a value-taking flag that would swallow the next flag', () => {
+      // Used to yield host === '--read-only' with readOnly silently false: on
+      // stdio `host` is ignored entirely, so a server meant to be read-only
+      // exposed its write tools with no diagnostic at all.
+      expect(() => loadConfig(['mycompany', '--host', '--read-only'])).toThrow();
+    });
+
+    it('rejects an unknown flag instead of silently ignoring it', () => {
+      expect(() => loadConfig(['mycompany', '--hc-ressource-scheme', 'wiki'])).toThrow();
+    });
+
+    it('does not let a typo-d flag turn its value into the subdomain', () => {
+      // `--hc-ressource-scheme wiki mycompany` used to boot against subdomain
+      // `wiki`, dropping `mycompany` — the wrong Zendesk tenant, silently.
+      expect(() => loadConfig(['--hc-ressource-scheme', 'wiki', 'mycompany'])).toThrow();
+    });
+
+    it('does not echo the value of an unknown --flag=value argument', () => {
+      // Same no-echo policy as parsePort: an Error.message here bubbles up to
+      // the `console.error('Fatal error:', error)` in src/index.ts.
+      expect(() => loadConfig(['mycompany', '--oauth-token=s3cr3t'])).toThrow(
+        expect.objectContaining({ message: expect.not.stringContaining('s3cr3t') }),
+      );
+    });
+
+    it('reports the empty flag rather than a misleading missing-subdomain error', () => {
+      // The empty value used to fall through to the positional-subdomain branch,
+      // consuming it so `mycompany` was dropped and startup failed with
+      // `ZENDESK_SUBDOMAIN is required` — naming the wrong knob entirely.
+      expect(() => loadConfig(['--hc-resource-scheme', '', 'mycompany'])).toThrow(
+        /Empty value for --hc-resource-scheme\./,
+      );
+      expect(() => loadConfig(['--hc-resource-scheme', '', 'mycompany'])).not.toThrow(
+        /ZENDESK_SUBDOMAIN is required/,
+      );
+    });
+
+    it('rejects a value handed to a standalone flag', () => {
+      expect(() => loadConfig(['mycompany', '--read-only=false'])).toThrow();
+    });
+
+    it('still accepts every flag with a proper value', () => {
+      const config = loadConfig([
+        'mycompany',
+        '--mode',
+        'all',
+        '--read-only',
+        '--namespace',
+        'tickets',
+        '--hc-resource-scheme',
+        'wiki',
+        '--log-level',
+        'debug',
+        '--transport',
+        'http',
+        '--host',
+        '127.0.0.1',
+        '--port',
+        '8080',
+        '--public-url',
+        'https://mcp.example.com',
+        '--cors-origin',
+        'https://app.example.com',
+        '--callback-port',
+        '51000',
+        '--dev',
+      ]);
+      expect(config.subdomain).toBe('mycompany');
+      expect(config.readOnly).toBe(true);
+      expect(config.hcResourceScheme).toBe('wiki');
+      expect(config.port).toBe(8080);
+      expect(config.callbackPort).toBe(51000);
+      expect(config.corsOrigins).toEqual(['https://app.example.com']);
+      expect(config.dev).toBe(true);
+    });
+
+    it('accepts the --flag=value form', () => {
+      const config = loadConfig(['mycompany', '--mode=all', '--hc-resource-scheme=wiki']);
+      expect(config.mode).toBe('all');
+      expect(config.hcResourceScheme).toBe('wiki');
+    });
+
+    it('takes a bare argument that collides with an Object.prototype key as the subdomain', () => {
+      // The old parser indexed argv against Maps precisely to avoid inherited
+      // keys being resolved; parseArgs collects positionals into an array, so
+      // they are never lookup keys at all.
+      const config = loadConfig(['toString']);
+      expect(config.subdomain).toBe('toString');
+    });
+  });
+
+  // An empty environment variable is an operator error, not "unset": `FOO=` in a
+  // compose file, or `FOO="$BAR"` with BAR unset, both arrive as ''. Applying the
+  // default there hides a broken deployment (issue #174).
+  describe('empty environment variables', () => {
+    beforeEach(() => {
+      delete process.env['PUBLIC_URL'];
+      delete process.env['CORS_ORIGIN'];
+    });
+
+    it.each([
+      'ZENDESK_OAUTH_CLIENT_ID',
+      'LOG_LEVEL',
+      'TRANSPORT',
+      'HOST',
+      'PORT',
+      'PUBLIC_URL',
+      'ZENDESK_OAUTH_CALLBACK_PORT',
+      'HC_RESOURCE_SCHEME',
+    ])('rejects an empty %s', (name) => {
+      process.env[name] = '';
+      expect(() => loadConfig(['mycompany'])).toThrow(new RegExp(`Empty ${name}\\.`));
+    });
+
+    it('rejects an empty ZENDESK_SUBDOMAIN', () => {
+      // No positional here: the subdomain is the one knob a CLI argument would
+      // override, and an overridden variable is never consulted (see below).
+      process.env['ZENDESK_SUBDOMAIN'] = '';
+      expect(() => loadConfig([])).toThrow(/Empty ZENDESK_SUBDOMAIN\./);
+    });
+
+    it('ignores an empty variable that a CLI flag overrides', () => {
+      // Deliberate: validation applies to the value that is actually consulted.
+      // CLI > env is the documented precedence, so an empty variable the flag
+      // shadows is dead config, not a misconfiguration worth refusing to boot
+      // over — `--port 8080` alongside a stray `PORT=` in a compose file is a
+      // normal deployment, not a broken one.
+      process.env['PORT'] = '';
+      process.env['HC_RESOURCE_SCHEME'] = '';
+      const config = loadConfig([
+        'mycompany',
+        '--port',
+        '8080',
+        '--hc-resource-scheme',
+        'wiki',
+        '--transport',
+        'http',
+      ]);
+      expect(config.port).toBe(8080);
+      expect(config.hcResourceScheme).toBe('wiki');
+    });
+
+    it('keeps CORS_ORIGIN tolerant of an empty value', () => {
+      // A list variable: `CORS_ORIGIN=` means "no extra origins", which is a
+      // normal way to write it in a compose file. The built-in allowlist (major
+      // web MCP clients + localhost) applies regardless.
+      process.env['CORS_ORIGIN'] = '';
+      const config = loadConfig(['mycompany']);
+      expect(config.corsOrigins).toEqual([]);
+    });
+
+    it('still applies defaults when the variables are unset rather than empty', () => {
+      const config = loadConfig(['mycompany']);
+      expect(config.hcResourceScheme).toBe('zendesk-hc');
+      expect(config.port).toBe(3000);
+      expect(config.callbackPort).toBeUndefined();
+      expect(config.logLevel).toBe('info');
     });
   });
 });


### PR DESCRIPTION
## Summary

A value-taking flag with a missing or empty value was dropped silently, so the server booted with defaults and nothing pointed at the cause. Detection now goes through `node:util` `parseArgs` driven by one declarative flag table, which also rejects unknown flags, a flag whose value is another flag, and a stray second positional; empty single-value environment variables fail the same way. A correctly configured server is unaffected — a misconfigured one refuses to boot instead of running with silently-wrong config.

## Linked issue

Closes #174

## Scope — wider than the issue, and approved

Issue #174 asks for one thing: a value-taking **CLI flag** whose value is missing or empty must fail instead of being dropped. This PR does that, and three more things:

| Beyond the issue | Status in #174 | Why it is here |
| --- | --- | --- |
| Rejecting **unknown flags** (`--moed`) | listed under *Alternatives considered*, explicitly left "to be decided in this issue" | `parseArgs` in `strict` mode gives this for free; opting out would mean deliberately re-allowing typos. Same failure shape as the issue's own case 2 — `--hc-ressource-scheme wiki mycompany` boots against tenant `wiki` |
| Rejecting **empty environment variables** | **not mentioned at all** | The issue's case 2 is a shell handing over `''` for an unset variable. The identical mistake in a compose file (`HC_RESOURCE_SCHEME=`) produced the identical silent misconfiguration, so fixing only the CLI half would have left the more common deployment path broken |
| Rejecting **extra positionals** | not mentioned | Found by review of this PR: `--namespace tickets help_center mycompany` booted against subdomain `help_center` with only `tickets` registered. The last silently-dropped argv shape, and the same wrong-tenant outcome the issue objects to |
| Rejecting a value given to a **standalone flag** (`--read-only=false`) | not mentioned | Also free from `strict` mode |

The maintainer has confirmed the environment-variable rule is wanted, and with it the rest of the widened scope. Issue #174 now records that decision in its own body, so the four rows above are the agreed shape of this change and nothing is being split out.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [x] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` — n/a, no tool added
- [x] If the change has **MCP-runtime-observable** behaviour: this PR carries a `## Functional validation plan` — see the scope note in it, the negative shapes are not reachable from the validator's environment

## What was wrong

Every value-taking branch was guarded by a truthiness check on the next argument, so a missing or empty value made the guard falsy and the flag was discarded. Verified against `loadConfig` before the fix:

| argv | before |
| --- | --- |
| `["mycompany","--hc-resource-scheme"]` | boots on the default scheme, zero diagnostic |
| `["--hc-resource-scheme","","mycompany"]` | `''` becomes the positional subdomain, `mycompany` is dropped, startup fails with `ZENDESK_SUBDOMAIN is required` — naming the wrong knob |

Three further shapes surfaced while fixing it, none of them in the issue:

- `["mycompany","--host","--read-only"]` yielded `host === '--read-only'` with `readOnly: false`. On stdio `host` is ignored entirely, so the **only** effect was a server meant to be read-only exposing its write tools, silently.
- `["--hc-ressource-scheme","wiki","mycompany"]` booted against subdomain `wiki`: the typo'd flag was skipped, `wiki` taken as the positional, `mycompany` dropped. A wrong Zendesk tenant, not a wrong flag.
- `["--namespace","tickets","help_center","mycompany"]` booted against subdomain `help_center` with only the `tickets` namespace registered and `mycompany` dropped — the wrong tenant *and* a narrowed tool surface at once. A space-separated list is the natural wrong guess for a `multiple: true` flag, and extra positionals were the last silently-dropped argv shape left standing.

## What changed

`parseArgs` in `strict` mode rejects the unknown-flag, missing-value, flag-as-value and value-to-a-standalone-flag shapes. Two rules are ours, because they are the two `parseArgs` accepts: an empty value, and more than one positional. Node's messages already name the offending flag and never echo the value after an `=`, so they pass through rather than being re-wrapped; the `Empty ...` and `Expected one positional ...` messages are ours and stable. Neither of ours echoes a value — the positional one reports a count.

Empty single-value environment variables now fail naming the variable, across the nine `loadConfig` reads. Two deliberate exceptions, both documented in `docs/configuration.md`:

- `CORS_ORIGIN` stays tolerant — as a list, an empty value legitimately means "no extra origins".
- A variable the command line overrides is never consulted, so `--port 8080` next to a stray `PORT=` still boots, and so does the positional `<subdomain>` next to an empty `ZENDESK_SUBDOMAIN`. Validation applies to the value the server actually uses.

The value-flag list is now derived once and consumed by `scripts/mcp-live.ts`, replacing a hand-maintained copy under a "Keep in sync" comment. One correction to the premise, since #174 cites it: the issue notes that copy "was found out of sync by six flags in #173", which was true then but is no longer — on `1b669c4` its 11 entries match the parser's 11 value-taking flags exactly, verified by diffing the two lists. Deriving it removes the standing invitation to drift; it is not repairing a live defect.

## Notes for the reviewer

**One deliberate spec change, and it rewrites an existing test.** `tests/unit/config.test.ts` used to assert that an empty `HC_RESOURCE_SCHEME` meant "unset" and applied the default, matching the PORT-style convention. That convention is what hid the broken deployment in the issue, so the test now asserts rejection. It is not a test weakened to go green; it is a test inverted because the spec it encoded is the bug. This follows from the same decision that keeps the environment-variable rule in scope, but it is the single most reversible thing here if you want the old convention back.

**A third-party parser was evaluated and rejected, empirically.** commander 15 and convict 6 were both installed and exercised against the real shapes. Both **accept an empty CLI value and an empty env var** — they reproduce this exact defect rather than fixing it — and commander additionally accepts `--host --read-only`, which the built-in rejects. convict also echoes offending values into its messages (`value was "nope"`), contradicting the no-echo policy documented in `src/config.ts`, and brings its own schema language alongside `ConfigSchema`, which that file designates as the single authority. `node:util` `parseArgs` is a built-in, stable since Node 20.0.0, matching `engines: node>=20` and the `smoke-node20` job. `allowNegative` is deliberately not used (Node 22.4+); `--no-topology` and `--no-promoted-articles` stay declared as their own booleans.

**The `Map`-not-object-literal comment was removed with the maps it explained.** That guard existed because the old parser indexed raw argv against a lookup. `parseArgs` rejects `--toString` / `--__proto__` / `--constructor` as unknown options, returns a null-prototype `values` object, and collects positionals into an array that is never a lookup key — a bare `toString` argument correctly becomes the subdomain, and there is a test for it.

**`parseCliArgs` builds its result with a local mutable accumulator, and two attempts to remove that were backed out.** Both collide with lint rules this repo has enabled, so the "cleaner" versions cannot land:

- Explicit per-flag assignments (which would also restore the compile-time checking that `Object.assign(result, { [field]: value })` loses to a computed key): 15 straight-line `if`s put the function at cognitive complexity 22 against the ceiling of 15 in `noExcessiveCognitiveComplexity`.
- A `reduce` spreading the accumulator, as CodeRabbit suggested: two `noAccumulatingSpread` errors, and `pnpm check` runs `--error-on-warnings`.

The function is pure either way — same argv in, same `CliResult` out, and the accumulator never escapes — so what is left is a style preference the lint config has already settled. A comment at the accumulator records this. The computed-key gap is covered behaviourally instead: every `FIELD_BY_FLAG` entry is asserted by a test, and the mutation gate kills all string-literal mutants on those lines.

**Mutation gate drove three simplifications.** The first run left three survivors. None was a missing assertion — each marked a branch that could not affect the outcome, so they were removed rather than annotated with `Stryker disable`: a redundant `undefined` guard, a guard that only satisfied `exactOptionalPropertyTypes`, and an `oauthClientId` fallback the schema made unreachable. That last one cuts the failure report for a missing subdomain from two issues to the one the operator can act on.

## Functional validation plan

### Scope note — read first

This change is a **startup/config** concern: every rejection happens in `loadConfig`, before any transport is connected. That collides with the validator profile this repo's `run-validation-plan` skill assumes — a session already on the branch **with the server running and authenticated**, forbidden from building or starting it. A server that refuses to boot cannot be observed from a session whose server is already up.

So the negative shapes below are marked **not validator-reachable**, honestly rather than dressed up as tool calls. They are covered by the unit tests in `tests/unit/config.test.ts` (parametrised over all 11 value-taking flags), a 100% mutation score on every changed line, and direct probes of the built binary recorded under "Implementer evidence". What the validator *can* and should confirm is the claim that actually touches a running server: **nothing changed for a correctly configured one.**

### Context

The running server in the validator's environment was started with valid config, so it exercises exactly the regression-risk path: the rewritten parser produced the config it is running on. `--mode all` means the full tool surface is registered, which is the most sensitive observable — a mis-mapped flag would show up as a wrong surface or a missing resource.

Not exercised, and not worth testing: per-tool behaviour, Zendesk API shapes, auth flows. This PR touches none of them.

### Setup & prerequisites

None beyond the ready environment. No state to seed, no probe script, no credentials beyond what is already wired in. Capture `git rev-parse HEAD` and report the SHA so the verdict is anchored to a commit.

### Scenarios

| id | Validates | Action | Expected observable |
| --- | --- | --- | --- |
| V1 | The rewritten parser produced a correct config for the running server | `tools/list` | The full `--mode all` surface. On this branch that is 52 tools: `help_center` 29, `tickets` 18, `users` 5. Compare against `createAllTools` on the commit you actually test rather than against that total, which moves whenever tools are added — what matters is that no namespace is missing and the count is not short |
| V2 | `--hc-resource-scheme` default survives the rewrite | `resources/list` | The topology resource is exposed as `zendesk-hc://topology` — the default scheme, not an empty or mangled one |
| V3 | The topology resource still reads | Read `zendesk-hc://topology` | Returns the locales / category-section tree normally. Confirms the scheme round-trips through the SDK's registry lookup, the thing an empty scheme would have broken |
| V4 | A real read path is unaffected | `get_current_user` (or any cheap read) | Succeeds as before. Any failure here is unrelated to this PR but worth reporting |

V1 through V3 are the priority and take one call each. V4 is a sanity check.

### Not validator-reachable — for the record

These are the PR's actual subject. They need a server launched with deliberately broken config, which the validator profile excludes. Listed so a human reviewer can run them by hand from a checkout if they want independent confirmation:

| Invocation | Expected |
| --- | --- |
| `node dist/index.js mycompany --hc-resource-scheme` | `option '--hc-resource-scheme <value>' argument missing` |
| `node dist/index.js --hc-resource-scheme "" mycompany` | `Empty value for --hc-resource-scheme.` — and **not** `ZENDESK_SUBDOMAIN is required` |
| `node dist/index.js mycompany --host --read-only` | `Option '--host' argument is ambiguous` |
| `node dist/index.js --hc-ressource-scheme wiki mycompany` | `Unknown option '--hc-ressource-scheme'` |
| `node dist/index.js mycompany --read-only=false` | `Option '--read-only' does not take an argument` |
| `node dist/index.js --namespace tickets help_center mycompany` | `Expected one positional argument (the subdomain), got 2.` — and the offending values are **not** in the message |
| `HC_RESOURCE_SCHEME= node dist/index.js mycompany` | `Empty HC_RESOURCE_SCHEME. Set it to a value, or unset it entirely.` |
| `ZENDESK_SUBDOMAIN= node dist/index.js mycompany` | boots — the positional overrides the variable, so the empty value is never consulted |
| `node dist/index.js mycompany --oauth-token=s3cr3t` | `Unknown option '--oauth-token'` — the value is **not** in the message |
| `node dist/index.js mycompany --mode all --read-only --hc-resource-scheme wiki` | boots normally |

### Long-running behaviours

None. Nothing in this change is time-based, so there is no timer to simulate.

### Implementer evidence

All rows above were run against the built binary on this branch and produced the expected output, including the two no-echo cases. Gates on the current head, with `main` merged in: `pnpm typecheck` and `pnpm check` clean, `pnpm test` 768 passing, `pnpm test:coverage` at the thresholds with `config.ts` at 100% branch coverage, `pnpm test:mutation:diff origin/main HEAD` 124/124 mutants killed on the changed lines. `pnpm tsx scripts/mcp-live.ts list -- --mode namespace` was run to exercise the shared `VALUE_FLAG_NAMES` import on its drift-sensitive path. CI is green.

The test and mutant totals rose from 725 and 100 as `main` was merged in: the branch now carries the Help Center translation tools from #224 and the release-tooling tests, none of which this PR touches.

### Reporting instructions

Post one PR comment in English: per-id verdict (`OK` / `FAIL` / `BLOCKED`) with the observed evidence — the tool count and namespace breakdown for V1, the exact resource URI for V2, a snippet of the payload for V3 — the HEAD SHA you tested, and an overall green/failing summary. If a scenario's evidence is ambiguous, say so rather than guessing a verdict.

### One environment note

The functional harness forwards `env: process.env` to the server it spawns (`tests/functional/bin/dump-tools-list.mjs`). An empty exported `PORT` or `HC_RESOURCE_SCHEME` in a shell will now fail those scenarios. That is the intended behaviour of this change, not a harness bug.

## Summary by CodeRabbit

- **New Features**
  - Added stricter startup validation for command-line arguments and environment variables.
  - Supports documented flag formats, repeatable options, positional subdomains, and CLI-over-environment precedence.
  - Provides clear, secret-safe errors for unknown, missing, empty, or extra arguments.

- **Bug Fixes**
  - Invalid configuration now fails consistently at startup instead of silently using unintended values.
  - Empty single-value environment variables are rejected, while empty `CORS_ORIGIN` remains valid.
  - Preserved fallback behavior for resource-scheme configuration.

- **Documentation**
  - Added configuration and troubleshooting guidance for validation errors, accepted syntax, and corrective actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter startup validation for command-line arguments and environment variables.
  * Added support for repeatable options and multiple accepted flag formats.
  * Improved handling of empty values, positional arguments, and configuration precedence.
  * Protected secrets from appearing in startup error messages.

* **Bug Fixes**
  * Empty configuration values now fail clearly when invalid, while valid empty CORS settings remain supported.

* **Documentation**
  * Added configuration and troubleshooting guidance for startup validation errors, accepted syntax, and corrective actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->