### PR TITLE
feat(help-center): section & category translation tools (#224)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,6 +196,13 @@ Hard cap on the number of article pages scanned to find promoted ("featured") ar
 
 **Cost note.** Each scanned page is one Zendesk API request, and Zendesk rate-limits every plan, so on a large Help Center a single listing or tool call can fan out to several requests. The resource-listing scan is cached per session for a few minutes (`ARTICLE_RESOURCES_TTL_MS`) so repeated `resources/list` calls coalesce; the `list_promoted_articles` tool performs a fresh, uncached scan on every call. The scan runs only when a resource-capable client calls `resources/list` or the LLM calls `list_promoted_articles`, never at connect. The worst case is a large catalog with few or no promoted articles: a full-cap scan for little result. If that matters for your tenant's quota, lower this cap or disable the pre-listing with **`--no-promoted-articles`**, which turns off the resource `list` scan **and** the `list_promoted_articles` tool, so the server makes **zero** preloading requests. It does **not** disable reading a known article by id (`<scheme>://article/{id}` stays registered): that is a cheap, on-demand single fetch, not a preload.
 
+### `ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES`
+**Required:** no · **Default:** `60`
+
+Hard cap on the number of categories and sections probed by `find_translation_gaps`. Categories are scanned first, then sections with whatever budget is left; the report names exactly what it left unscanned when the cap bites. Raise it to audit a larger tree in one call.
+
+**Cost note.** Unlike articles, sections and categories have no "missing translations" endpoint, and a locale-filtered listing (`list_sections` with a `locale`) cannot tell an absent translation from an unpublished draft — it omits both. Answering the question therefore costs **one Zendesk request per node scanned**, on top of the two listings and the locale fetch. The scan runs only when the LLM calls the tool, never at connect, and it is not cached. Pass `category_id` to audit a single branch instead of the whole tree when quota matters.
+
 ---
 
 ← Back to the [README](../README.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,7 +201,7 @@ Hard cap on the number of article pages scanned to find promoted ("featured") ar
 
 Hard cap on the number of categories and sections probed by `find_translation_gaps`. Categories are scanned first, then sections with whatever budget is left; the report names exactly what it left unscanned when the cap bites. Raise it to audit a larger tree in one call.
 
-**Cost note.** Unlike articles, sections and categories have no "missing translations" endpoint, and a locale-filtered listing (`list_sections` with a `locale`) cannot tell an absent translation from an unpublished draft — it omits both. Answering the question therefore costs **one Zendesk request per node scanned**, on top of the two listings and the locale fetch. The scan runs only when the LLM calls the tool, never at connect, and it is not cached. Pass `category_id` to audit a single branch instead of the whole tree when quota matters.
+**Cost note.** Unlike articles, sections and categories have no "missing translations" endpoint, and a locale-filtered listing (`list_sections` with a `locale`) cannot answer the question either: a node with no translation in that locale is simply absent from it, without saying why, and a node whose translation is an unpublished **draft** is still returned — observed on a live tenant with an admin token — rendered under the draft's own name. Absence is therefore ambiguous and presence does not mean published, so the audit reads the draft flag on each node. That costs **one Zendesk request per node scanned**, on top of the two listings and the locale fetch. The scan runs only when the LLM calls the tool, never at connect, and it is not cached. Pass `category_id` to audit a single branch instead of the whole tree when quota matters.
 
 ---
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -48,6 +48,9 @@ out every `write` tool before the proxies are built.
 | `list_articles` | List articles with sorting and translation info | read |
 | `list_promoted_articles` | List the promoted ("featured") articles (scans + filters client-side, page-capped) | read |
 | `list_article_translations` | List available translations for an article | read |
+| `list_section_translations` | List a section's translations with their draft state, telling an untranslated section apart from an unpublished one | read |
+| `list_category_translations` | List a category's translations with their draft state, telling an untranslated category apart from an unpublished one | read |
+| `find_translation_gaps` | Audit the category → section tree for a locale and report every node with no translation or an unpublished draft (one request per node scanned, capped) | read |
 | `list_article_attachments` | List attachments on an article | read |
 | `list_permission_groups` | List Guide permission groups (needed to create articles; requires Guide-admin / Help Center manager rights) | read |
 | `list_content_tags` | List Guide content tags (end-user visible), cursor-paginated with name-prefix filter and sort | read |
@@ -60,6 +63,8 @@ out every `write` tool before the proxies are built.
 | `archive_article` | Archive (soft-delete) an article; recoverable only via the Guide admin UI | write |
 | `create_article_translation` | Create a translation for an article | write |
 | `update_article_translation` | Update an article's translation (full body) | write |
+| `set_section_translation` | Create or publish a section's translation in one locale (creates when absent, updates otherwise; only the fields passed are written) | write |
+| `set_category_translation` | Create or publish a category's translation in one locale (creates when absent, updates otherwise; only the fields passed are written) | write |
 | `update_article_section` | Replace a single section of an article | write |
 | `create_content_tag` | Create a new Guide content tag | write |
 | `create_article_attachment` | Upload a file to a Help Center article (returns the created attachment) | write |

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -50,7 +50,7 @@ out every `write` tool before the proxies are built.
 | `list_article_translations` | List available translations for an article | read |
 | `list_section_translations` | List a section's translations with their draft state, telling an untranslated section apart from an unpublished one | read |
 | `list_category_translations` | List a category's translations with their draft state, telling an untranslated category apart from an unpublished one | read |
-| `find_translation_gaps` | Audit the category → section tree for a locale and report every node with no translation or an unpublished draft (one request per node scanned, capped) | read |
+| `find_translation_gaps` | Audit a locale across every category **and** every section, reporting each one that has no translation or only an unpublished draft; scope it to one category with `category_id` (one request per node scanned, capped) | read |
 | `list_article_attachments` | List attachments on an article | read |
 | `list_permission_groups` | List Guide permission groups (needed to create articles; requires Guide-admin / Help Center manager rights) | read |
 | `list_content_tags` | List Guide content tags (end-user visible), cursor-paginated with name-prefix filter and sort | read |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,8 +47,9 @@ export const ARTICLE_RESOURCES_SCAN_MAX_PAGES = positiveIntEnv(
 
 // Max category + section nodes probed by find_translation_gaps. Unlike articles,
 // sections and categories have no "missing translations" endpoint, and the
-// locale-filtered listing cannot tell an absent translation from a draft one, so
-// the only honest answer costs one translations request per node. This bounds
+// locale-filtered listing cannot answer the question either — it omits a node with
+// no translation without saying why, and still returns one whose translation is a
+// draft — so the only honest answer costs one translations request per node. This bounds
 // that fan-out on a large Help Center; nodes beyond the cap are left unscanned
 // and the tool says so. Override via ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES.
 export const TRANSLATION_GAP_SCAN_MAX_NODES = positiveIntEnv(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,17 @@ export const ARTICLE_RESOURCES_SCAN_MAX_PAGES = positiveIntEnv(
   20,
 );
 
+// Max category + section nodes probed by find_translation_gaps. Unlike articles,
+// sections and categories have no "missing translations" endpoint, and the
+// locale-filtered listing cannot tell an absent translation from a draft one, so
+// the only honest answer costs one translations request per node. This bounds
+// that fan-out on a large Help Center; nodes beyond the cap are left unscanned
+// and the tool says so. Override via ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES.
+export const TRANSLATION_GAP_SCAN_MAX_NODES = positiveIntEnv(
+  'ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES',
+  60,
+);
+
 // Local port the OAuth PKCE flow listens on for the browser callback. Must match
 // the redirect URL registered in the Zendesk OAuth client. Deliberately picked
 // outside the usual dev range (3000/5000/8080…) and below the OS ephemeral

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,22 +45,12 @@ export const ARTICLE_RESOURCES_SCAN_MAX_PAGES = positiveIntEnv(
   20,
 );
 
-// Max category + section nodes probed by find_translation_gaps. Unlike articles,
-// sections and categories have no "missing translations" endpoint, and the
-// locale-filtered listing cannot answer the question either — it omits a node with
-// no translation without saying why, and still returns one whose translation is a
-// draft — so the only honest answer costs one translations request per node. This bounds
-// that fan-out on a large Help Center; nodes beyond the cap are left unscanned
-// and the tool says so. Override via ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES.
-//
-// A cheaper route may exist and is deliberately not taken yet: the sections and
-// categories LIST endpoints document a `translations` sideload
-// (`?include=translations`), which would collapse the whole fan-out — and this cap
-// with it — into the two listings already fetched. What the docs do not say is
-// whether a sideloaded translation carries `draft`, and `draft` is the entire
-// point here, so adopting it has to be measured against a live tenant first.
-// Tracked separately; until then this stays on the endpoint that is known to
-// return the flag.
+// Max category + section nodes probed by find_translation_gaps. Sections and
+// categories have no "missing translations" endpoint and the locale-filtered
+// listing cannot substitute for one, so the answer costs one request per node;
+// this bounds the fan-out and the tool reports what it left unscanned. A
+// `translations` sideload could remove it — untaken, see #226. Override via
+// ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES.
 export const TRANSLATION_GAP_SCAN_MAX_NODES = positiveIntEnv(
   'ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES',
   60,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,6 +52,15 @@ export const ARTICLE_RESOURCES_SCAN_MAX_PAGES = positiveIntEnv(
 // draft — so the only honest answer costs one translations request per node. This bounds
 // that fan-out on a large Help Center; nodes beyond the cap are left unscanned
 // and the tool says so. Override via ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES.
+//
+// A cheaper route may exist and is deliberately not taken yet: the sections and
+// categories LIST endpoints document a `translations` sideload
+// (`?include=translations`), which would collapse the whole fan-out — and this cap
+// with it — into the two listings already fetched. What the docs do not say is
+// whether a sideloaded translation carries `draft`, and `draft` is the entire
+// point here, so adopting it has to be measured against a live tenant first.
+// Tracked separately; until then this stays on the endpoint that is known to
+// return the flag.
 export const TRANSLATION_GAP_SCAN_MAX_NODES = positiveIntEnv(
   'ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES',
   60,

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -105,6 +105,13 @@ const listTranslations = (
 // localized *name* and `body` the localized *description*. The tools speak
 // name/description — the vocabulary list_sections and list_categories already
 // return — and do the mapping here, so a caller never has to know about it.
+//
+// The two levels are treated as ISO: same endpoints, same object, same
+// behaviour, parameterised by kind rather than implemented twice. Anything done
+// to one level must be done to the other — schema, description, error message,
+// report line, test. The unit tests enforce that by running every case over both
+// levels from one table (see NODE_LEVELS in the tests), which is also what
+// stands in for the category write path's missing live validation (#225, S12).
 type TreeNodeKind = 'sections' | 'categories';
 
 const NODE_LABEL: Record<TreeNodeKind, string> = {

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -221,9 +221,13 @@ const nodeTranslationWriteText = (
 // --- find_translation_gaps.
 //
 // A node is a gap when the target locale has no translation at all, or has one
-// that is still a draft. Those need different fixes (write a translation vs flip
-// `draft`), which is exactly what `list_sections?locale=…` cannot tell you: it
-// omits both cases alike.
+// that is still a draft. Those need different fixes — write a translation vs flip
+// `draft` — and `list_sections?locale=…` answers neither question. Measured on a
+// live tenant with an admin token (#225 validation): a node with no translation is
+// absent from that listing, but a node whose translation is a DRAFT is still
+// returned, rendered with the draft's own name. So absence there is ambiguous and
+// presence does not mean published, which is why this audit probes the
+// translations endpoint per node instead of diffing the two listings.
 type GapReason = 'missing' | 'draft';
 
 interface TranslationGap {
@@ -1132,7 +1136,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'List Section Translations',
       description:
-        'List the translations of a Help Center section: for each locale, the localized name, whether a description is set, and whether the translation is published or still a draft. Reach for this when a section looks untranslated in a locale — list_sections with a locale omits a section that has no translation AND one whose translation is an unpublished draft, and only this tool tells the two apart. Fix either case with set_section_translation; to sweep every category and section at once, use find_translation_gaps.',
+        'List the translations of a Help Center section: for each locale, the localized name, whether a description is set, and whether the translation is published or still a draft. Reach for this when a section looks wrong in a locale, because list_sections with that locale cannot settle it: a section with no translation is omitted from it, while a section whose translation is an unpublished draft may still be listed there under the draft name — so appearing in that listing does not mean published, and the draft flag here is what decides. Fix either case with set_section_translation; to sweep every category and section at once, use find_translation_gaps.',
       inputSchema: z.object({
         section_id: z
           .number()
@@ -1162,7 +1166,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'List Category Translations',
       description:
-        'List the translations of a Help Center category: for each locale, the localized name, whether a description is set, and whether the translation is published or still a draft. Reach for this when a category looks untranslated in a locale — list_categories with a locale omits a category that has no translation AND one whose translation is an unpublished draft, and only this tool tells the two apart. Fix either case with set_category_translation; to sweep every category and section at once, use find_translation_gaps.',
+        'List the translations of a Help Center category: for each locale, the localized name, whether a description is set, and whether the translation is published or still a draft. Reach for this when a category looks wrong in a locale, because list_categories with that locale cannot settle it: a category with no translation is omitted from it, while a category whose translation is an unpublished draft may still be listed there under the draft name — so appearing in that listing does not mean published, and the draft flag here is what decides. Fix either case with set_category_translation; to sweep every category and section at once, use find_translation_gaps.',
       inputSchema: z.object({
         category_id: z
           .number()
@@ -1197,7 +1201,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Find Help Center Translation Gaps',
       description:
-        'Audit the Help Center tree for a target locale and report every category and section that has no translation, or one that is still an unpublished draft. Use it before or after translating articles: an article published in a second locale is unreachable while its parent section only exists in the source locale, and that gap is invisible to list_sections. Costs one extra request per node scanned, capped (the report says so when the cap bites) — pass category_id to narrow it. Fix what it reports with set_section_translation / set_category_translation.',
+        'Audit the Help Center tree for a target locale and report every category and section that has no translation, or one that is still an unpublished draft. Use it before or after translating articles: an article published in a second locale is unreachable while its parent section only exists in the source locale. Listing sections in that locale cannot answer this — a node with no translation is simply absent, without saying why, and a node whose translation is an unpublished draft may still be listed under its draft name — so this audit reads the draft flag on each node instead of trusting that listing. Costs one extra request per node scanned, capped (the report says so when the cap bites) — pass category_id to narrow it. Fix what it reports with set_section_translation / set_category_translation.',
       inputSchema: z.object({
         locale: z
           .string()

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -99,19 +99,12 @@ const listTranslations = (
 
 // --- Section / category translations.
 //
-// Sections and categories live on the same Translations endpoint family as
-// articles (`/{sections|categories}/{id}/translations`) and return the same
-// translation object, with two fields carrying different meanings: `title` is the
+// Same endpoint family as articles, same translation object, but `title` is the
 // localized *name* and `body` the localized *description*. The tools speak
-// name/description — the vocabulary list_sections and list_categories already
-// return — and do the mapping here, so a caller never has to know about it.
+// name/description (what list_sections/list_categories return) and map here.
 //
-// The two levels are treated as ISO: same endpoints, same object, same
-// behaviour, parameterised by kind rather than implemented twice. Anything done
-// to one level must be done to the other — schema, description, error message,
-// report line, test. The unit tests enforce that by running every case over both
-// levels from one table (see NODE_LEVELS in the tests), which is also what
-// stands in for the category write path's missing live validation (#225, S12).
+// The two levels are ISO: anything done to one must be done to the other. Tests
+// enforce it over both from one table (NODE_LEVELS).
 type TreeNodeKind = 'sections' | 'categories';
 
 const NODE_LABEL: Record<TreeNodeKind, string> = {
@@ -119,14 +112,10 @@ const NODE_LABEL: Record<TreeNodeKind, string> = {
   categories: 'category',
 };
 
-// `locales` narrows the response when the caller only cares about one language.
-// The result is filtered locally anyway (see findTranslation), so the tools stay
-// correct even where the server-side filter is not applied. The value is
-// lower-cased so the server-side filter cannot disagree with that local,
-// case-insensitive comparison: Zendesk stores locales lower-cased, and whether it
-// matches the filter case-sensitively is not documented — if it does, a caller's
-// "FR" would come back empty and every node would read as "no translation".
-// Normalizing costs nothing if the filter is case-insensitive after all.
+// `locales` only narrows the response; the result is filtered locally anyway, so
+// an unapplied server-side filter stays correct. Lower-cased because whether that
+// filter is case-sensitive is undocumented: if it is, a caller's "FR" comes back
+// empty and every node reads as untranslated.
 const listNodeTranslations = (
   subdomain: string,
   token: string,
@@ -141,8 +130,7 @@ const listNodeTranslations = (
     locale ? { locales: locale.toLowerCase() } : undefined,
   ).then((res) => res.translations ?? []);
 
-// Locales are matched case-insensitively: Zendesk normalizes its own to lower
-// case, but a caller (or a copy-paste from Guide) may well pass "fr-FR".
+// Case-insensitive: a caller may well pass "FR" or a copy-paste from Guide.
 const findTranslation = (
   translations: ZendeskTranslation[],
   locale: string,
@@ -152,14 +140,10 @@ const findTranslation = (
 };
 
 /**
- * Create-or-update a section/category translation in one call.
- *
- * The probe that decides POST vs PUT is the very call `list_*_translations`
- * makes, so the caller pays one request instead of being forced to list first —
- * or to recover from the 400 the API returns when a POST targets a locale that
- * already has a translation. Only the fields actually passed are sent on update,
- * so omitting `description` never blanks an existing one and omitting `draft`
- * never republishes (or unpublishes) by accident.
+ * Create-or-update a section/category translation in one call. The POST-vs-PUT
+ * probe spares the caller a listing round-trip, or the 400 a duplicate POST
+ * returns. Only the fields passed are sent on update, so omitting `description`
+ * never blanks it and omitting `draft` never (un)publishes by accident.
  */
 const upsertNodeTranslation = async (
   subdomain: string,
@@ -193,15 +177,13 @@ const upsertNodeTranslation = async (
   if (name !== undefined) updates['title'] = name;
   if (description !== undefined) updates['body'] = description;
   if (draft !== undefined) updates['draft'] = draft;
-  // An empty payload would round-trip to Zendesk and come back reported as an
-  // update, which is a lie. Say what is missing instead.
+  // An empty payload would round-trip and be reported as an update: a lie.
   if (Object.keys(updates).length === 0) {
     throw new Error(
       `Nothing to write: ${NODE_LABEL[kind]} #${nodeId} already has a "${existing.locale}" translation, so pass at least one of "name", "description" or "draft" to change it (draft: false publishes it).`,
     );
   }
-  // Zendesk's own spelling of the locale, not the caller's: the PUT path has to
-  // match the existing translation even when the input was cased differently.
+  // Zendesk's spelling, not the caller's, so the PUT path matches.
   const { translation } = await helpCenterPut<{ translation: ZendeskTranslation }>(
     subdomain,
     token,
@@ -227,14 +209,11 @@ const nodeTranslationWriteText = (
 
 // --- find_translation_gaps.
 //
-// A node is a gap when the target locale has no translation at all, or has one
-// that is still a draft. Those need different fixes — write a translation vs flip
-// `draft` — and `list_sections?locale=…` answers neither question. Measured on a
-// live tenant with an admin token (#225 validation): a node with no translation is
-// absent from that listing, but a node whose translation is a DRAFT is still
-// returned, rendered with the draft's own name. So absence there is ambiguous and
-// presence does not mean published, which is why this audit probes the
-// translations endpoint per node instead of diffing the two listings.
+// A gap is no translation at all, or a draft one — different fixes, and
+// `list_sections?locale=…` shows neither. Measured with an admin token (#225): a
+// missing translation is absent there, a DRAFT one is still listed under its
+// draft name. So absence is ambiguous and presence is not "published", hence the
+// per-node probe rather than a listing diff.
 type GapReason = 'missing' | 'draft';
 
 interface TranslationGap {
@@ -282,10 +261,8 @@ const renderGapLines = (
       ...gaps.map((gap) => `- **${gap.name}** (${gap.id}) — ${GAP_REASON_TEXT[gap.reason]}`),
     ];
   }
-  // "every one scanned has a translation" would be a wrong reading of an empty
-  // scan (a category with no sections, a scope that matched nothing) — and
-  // "nothing to scan" would be a wrong reading of a level the node cap never
-  // reached, which is the opposite of an all-clear.
+  // Three distinct states, and conflating any two reads as a false all-clear:
+  // nothing at this level, nothing left after the cap, nothing missing.
   if (scanned === 0) {
     return [
       header,
@@ -297,10 +274,8 @@ const renderGapLines = (
   return [header, '_(none — every one scanned has a published translation)_'];
 };
 
-// Nodes probed at a time. Zendesk enforces a per-account *concurrent* request
-// limit well below the node cap, and a single 429 rejects the whole audit, so the
-// scan goes in small waves instead of firing every node at once. Same requests,
-// same report — just a bounded burst.
+// Nodes probed at a time. Zendesk caps concurrent requests per account and one
+// 429 would sink the whole audit, so the burst stays bounded.
 const GAP_SCAN_WAVE_SIZE = 5;
 
 const probeInWaves = async <T>(
@@ -317,11 +292,9 @@ const probeInWaves = async <T>(
   return gaps;
 };
 
-// The categories to audit. Scoping to one fetches that category on its own
-// rather than filtering the paginated listing: the listing is capped at one page,
-// so filtering it would silently report "0 categories scanned" for a category
-// that merely sits further down — and a wrong id would look like an empty tree
-// instead of the 404 it is.
+// Scoping fetches the one category rather than filtering the one-page listing,
+// which would report "0 scanned" for a category further down, and an empty tree
+// instead of a 404 for a wrong id.
 const fetchGapCategories = async (
   subdomain: string,
   token: string,

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -114,7 +114,12 @@ const NODE_LABEL: Record<TreeNodeKind, string> = {
 
 // `locales` narrows the response when the caller only cares about one language.
 // The result is filtered locally anyway (see findTranslation), so the tools stay
-// correct even where the server-side filter is not applied.
+// correct even where the server-side filter is not applied. The value is
+// lower-cased so the server-side filter cannot disagree with that local,
+// case-insensitive comparison: Zendesk stores locales lower-cased, and whether it
+// matches the filter case-sensitively is not documented — if it does, a caller's
+// "FR" would come back empty and every node would read as "no translation".
+// Normalizing costs nothing if the filter is case-insensitive after all.
 const listNodeTranslations = (
   subdomain: string,
   token: string,
@@ -126,7 +131,7 @@ const listNodeTranslations = (
     subdomain,
     token,
     `/${kind}/${nodeId}/translations`,
-    locale ? { locales: locale } : undefined,
+    locale ? { locales: locale.toLowerCase() } : undefined,
   ).then((res) => res.translations ?? []);
 
 // Locales are matched case-insensitively: Zendesk normalizes its own to lower
@@ -253,21 +258,52 @@ interface GapReport {
   listingIncomplete: boolean;
 }
 
-const renderGapLines = (heading: string, gaps: TranslationGap[], scanned: number): string[] => {
+const renderGapLines = (
+  heading: string,
+  gaps: TranslationGap[],
+  scanned: number,
+  found: number,
+): string[] => {
+  const header = `## ${heading} (${scanned} scanned)`;
   if (gaps.length > 0) {
     return [
-      `## ${heading} (${scanned} scanned)`,
+      header,
       ...gaps.map((gap) => `- **${gap.name}** (${gap.id}) — ${GAP_REASON_TEXT[gap.reason]}`),
     ];
   }
   // "every one scanned has a translation" would be a wrong reading of an empty
-  // scan (a category with no sections, a scope that matched nothing).
-  return [
-    `## ${heading} (${scanned} scanned)`,
-    scanned === 0
-      ? '_(none to scan at this level)_'
-      : '_(none — every one scanned has a published translation)_',
-  ];
+  // scan (a category with no sections, a scope that matched nothing) — and
+  // "nothing to scan" would be a wrong reading of a level the node cap never
+  // reached, which is the opposite of an all-clear.
+  if (scanned === 0) {
+    return [
+      header,
+      found === 0
+        ? '_(none to scan at this level)_'
+        : `_(none scanned — the ${TRANSLATION_GAP_SCAN_MAX_NODES}-node cap was spent before this level; ${found} left unchecked, see the note below)_`,
+    ];
+  }
+  return [header, '_(none — every one scanned has a published translation)_'];
+};
+
+// Nodes probed at a time. Zendesk enforces a per-account *concurrent* request
+// limit well below the node cap, and a single 429 rejects the whole audit, so the
+// scan goes in small waves instead of firing every node at once. Same requests,
+// same report — just a bounded burst.
+const GAP_SCAN_WAVE_SIZE = 5;
+
+const probeInWaves = async <T>(
+  nodes: T[],
+  probe: (node: T) => Promise<TranslationGap | null>,
+): Promise<TranslationGap[]> => {
+  const gaps: TranslationGap[] = [];
+  for (let i = 0; i < nodes.length; i += GAP_SCAN_WAVE_SIZE) {
+    const wave = await Promise.all(nodes.slice(i, i + GAP_SCAN_WAVE_SIZE).map(probe));
+    for (const gap of wave) {
+      if (gap !== null) gaps.push(gap);
+    }
+  }
+  return gaps;
 };
 
 // The categories to audit. Scoping to one fetches that category on its own
@@ -314,9 +350,9 @@ const renderGapReport = (report: GapReport): string => {
             )}), so everything below reads as untranslated. Check the spelling, or activate the language in Guide first.`,
             '',
           ]),
-      ...renderGapLines('Categories', categoryGaps, scanned.categories),
+      ...renderGapLines('Categories', categoryGaps, scanned.categories, found.categories),
       '',
-      ...renderGapLines('Sections', sectionGaps, scanned.sections),
+      ...renderGapLines('Sections', sectionGaps, scanned.sections, found.sections),
       '',
       gapCount === 0
         ? `No gaps: all ${scanned.categories} category/ies and ${scanned.sections} section(s) scanned have a published "${locale}" translation.`
@@ -1208,26 +1244,20 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           Math.max(0, TRANSLATION_GAP_SCAN_MAX_NODES - categories.length),
         );
 
-        const [categoryGaps, sectionGaps] = await Promise.all([
-          Promise.all(
-            categories.map(async (category) =>
-              classifyGap(
-                category,
-                await listNodeTranslations(subdomain, token, 'categories', category.id, locale),
-                locale,
-              ),
-            ),
+        const categoryGaps = await probeInWaves(categories, async (category) =>
+          classifyGap(
+            category,
+            await listNodeTranslations(subdomain, token, 'categories', category.id, locale),
+            locale,
           ),
-          Promise.all(
-            sections.map(async (section) =>
-              classifyGap(
-                section,
-                await listNodeTranslations(subdomain, token, 'sections', section.id, locale),
-                locale,
-              ),
-            ),
+        );
+        const sectionGaps = await probeInWaves(sections, async (section) =>
+          classifyGap(
+            section,
+            await listNodeTranslations(subdomain, token, 'sections', section.id, locale),
+            locale,
           ),
-        ]);
+        );
 
         return {
           content: [
@@ -1236,8 +1266,8 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
               text: renderGapReport({
                 locale,
                 activeLocales: locales.locales ?? [],
-                categoryGaps: categoryGaps.filter((gap): gap is TranslationGap => gap !== null),
-                sectionGaps: sectionGaps.filter((gap): gap is TranslationGap => gap !== null),
+                categoryGaps,
+                sectionGaps,
                 scanned: { categories: categories.length, sections: sections.length },
                 found: { categories: allCategories.length, sections: allSections.length },
                 listingIncomplete:

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -17,6 +17,7 @@ import {
   LARGE_ARTICLE_SECTION_COUNT,
   MAX_PAGE_SIZE,
   REORDER_CONFIRM_THRESHOLD,
+  TRANSLATION_GAP_SCAN_MAX_NODES,
 } from '../constants';
 import { fetchPromotedArticles, LIST_PROMOTED_ARTICLES_TOOL } from '../guidance/article-resources';
 import type {
@@ -26,6 +27,7 @@ import type {
   ZendeskContentTag,
   ZendeskLabel,
   ZendeskListResponse,
+  ZendeskLocalesResponse,
   ZendeskPermissionGroup,
   ZendeskSection,
   ZendeskTranslation,
@@ -55,6 +57,7 @@ import {
   formatContentTag,
   formatLabel,
   formatList,
+  formatNodeTranslationSummary,
   formatPermissionGroup,
   formatSection,
   formatTranslation,
@@ -93,6 +96,207 @@ const listTranslations = (
     token,
     `/articles/${articleId}/translations`,
   ).then((res) => res.translations);
+
+// --- Section / category translations.
+//
+// Sections and categories live on the same Translations endpoint family as
+// articles (`/{sections|categories}/{id}/translations`) and return the same
+// translation object, with two fields carrying different meanings: `title` is the
+// localized *name* and `body` the localized *description*. The tools speak
+// name/description — the vocabulary list_sections and list_categories already
+// return — and do the mapping here, so a caller never has to know about it.
+type TreeNodeKind = 'sections' | 'categories';
+
+const NODE_LABEL: Record<TreeNodeKind, string> = {
+  sections: 'section',
+  categories: 'category',
+};
+
+const SECTION_ID_DESC =
+  'Section ID — the numeric id of the Help Center section. Obtain it from list_sections or the zendesk-hc://topology resource.';
+
+const CATEGORY_ID_DESC =
+  'Category ID — the numeric id of the Help Center category. Obtain it from list_categories or the zendesk-hc://topology resource.';
+
+// `locales` narrows the response when the caller only cares about one language.
+// The result is filtered locally anyway (see findTranslation), so the tools stay
+// correct even where the server-side filter is not applied.
+const listNodeTranslations = (
+  subdomain: string,
+  token: string,
+  kind: TreeNodeKind,
+  nodeId: number,
+  locale?: string,
+): Promise<ZendeskTranslation[]> =>
+  helpCenterGet<{ translations: ZendeskTranslation[] }>(
+    subdomain,
+    token,
+    `/${kind}/${nodeId}/translations`,
+    locale ? { locales: locale } : undefined,
+  ).then((res) => res.translations ?? []);
+
+// Locales are matched case-insensitively: Zendesk normalizes its own to lower
+// case, but a caller (or a copy-paste from Guide) may well pass "fr-FR".
+const findTranslation = (
+  translations: ZendeskTranslation[],
+  locale: string,
+): ZendeskTranslation | undefined => {
+  const wanted = locale.toLowerCase();
+  return translations.find((t) => t.locale.toLowerCase() === wanted);
+};
+
+/**
+ * Create-or-update a section/category translation in one call.
+ *
+ * The probe that decides POST vs PUT is the very call `list_*_translations`
+ * makes, so the caller pays one request instead of being forced to list first —
+ * or to recover from the 400 the API returns when a POST targets a locale that
+ * already has a translation. Only the fields actually passed are sent on update,
+ * so omitting `description` never blanks an existing one and omitting `draft`
+ * never republishes (or unpublishes) by accident.
+ */
+const upsertNodeTranslation = async (
+  subdomain: string,
+  token: string,
+  kind: TreeNodeKind,
+  nodeId: number,
+  input: { locale: string; name?: string; description?: string; draft?: boolean },
+): Promise<{ translation: ZendeskTranslation; created: boolean }> => {
+  const { locale, name, description, draft } = input;
+  const existing = findTranslation(
+    await listNodeTranslations(subdomain, token, kind, nodeId, locale),
+    locale,
+  );
+
+  if (!existing) {
+    if (name === undefined) {
+      throw new Error(
+        `${NODE_LABEL[kind]} #${nodeId} has no "${locale}" translation yet, so one has to be created and "name" is required. Pass the localized name, or call list_${NODE_LABEL[kind]}_translations to see which locales already exist.`,
+      );
+    }
+    const { translation } = await helpCenterPost<{ translation: ZendeskTranslation }>(
+      subdomain,
+      token,
+      `/${kind}/${nodeId}/translations`,
+      { translation: { locale, title: name, body: description ?? '', draft: draft ?? false } },
+    );
+    return { translation, created: true };
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (name !== undefined) updates['title'] = name;
+  if (description !== undefined) updates['body'] = description;
+  if (draft !== undefined) updates['draft'] = draft;
+  // Zendesk's own spelling of the locale, not the caller's: the PUT path has to
+  // match the existing translation even when the input was cased differently.
+  const { translation } = await helpCenterPut<{ translation: ZendeskTranslation }>(
+    subdomain,
+    token,
+    `/${kind}/${nodeId}/translations/${existing.locale}`,
+    { translation: updates },
+  );
+  return { translation, created: false };
+};
+
+const nodeTranslationWriteText = (
+  kind: TreeNodeKind,
+  nodeId: number,
+  translation: ZendeskTranslation,
+  created: boolean,
+): string =>
+  [
+    `Translation ${created ? 'created' : 'updated'} for ${NODE_LABEL[kind]} #${nodeId} in "${
+      translation.locale
+    }" (${translation.draft ? 'draft, not visible to end users' : 'published'}).`,
+    '',
+    formatNodeTranslationSummary(translation),
+  ].join('\n');
+
+// --- find_translation_gaps.
+//
+// A node is a gap when the target locale has no translation at all, or has one
+// that is still a draft. Those need different fixes (write a translation vs flip
+// `draft`), which is exactly what `list_sections?locale=…` cannot tell you: it
+// omits both cases alike.
+type GapReason = 'missing' | 'draft';
+
+interface TranslationGap {
+  id: number;
+  name: string;
+  reason: GapReason;
+}
+
+const GAP_REASON_TEXT: Record<GapReason, string> = {
+  missing: 'no translation',
+  draft: 'draft translation (not published)',
+};
+
+const classifyGap = (
+  node: { id: number; name: string },
+  translations: ZendeskTranslation[],
+  locale: string,
+): TranslationGap | null => {
+  const translation = findTranslation(translations, locale);
+  if (!translation) return { id: node.id, name: node.name, reason: 'missing' };
+  return translation.draft ? { id: node.id, name: node.name, reason: 'draft' } : null;
+};
+
+interface GapReport {
+  locale: string;
+  activeLocales: string[];
+  categoryGaps: TranslationGap[];
+  sectionGaps: TranslationGap[];
+  scanned: { categories: number; sections: number };
+  found: { categories: number; sections: number };
+  /** True when the category or section listing itself spilled past one page. */
+  listingIncomplete: boolean;
+}
+
+const renderGapLines = (heading: string, gaps: TranslationGap[], scanned: number): string[] => [
+  `## ${heading} (${scanned} scanned)`,
+  ...(gaps.length > 0
+    ? gaps.map((gap) => `- **${gap.name}** (${gap.id}) — ${GAP_REASON_TEXT[gap.reason]}`)
+    : ['_(none — every one scanned has a published translation)_']),
+];
+
+const renderGapReport = (report: GapReport): string => {
+  const { locale, categoryGaps, sectionGaps, scanned, found } = report;
+  const gapCount = categoryGaps.length + sectionGaps.length;
+  const capped = scanned.categories < found.categories || scanned.sections < found.sections;
+  return truncateIfNeeded(
+    [
+      `# Translation gaps — "${locale}"`,
+      '',
+      ...(report.activeLocales.some((l) => l.toLowerCase() === locale.toLowerCase())
+        ? []
+        : [
+            `> ⚠ "${locale}" is not an active locale of this Help Center (active: ${report.activeLocales.join(
+              ', ',
+            )}), so everything below reads as untranslated. Check the spelling, or activate the language in Guide first.`,
+            '',
+          ]),
+      ...renderGapLines('Categories', categoryGaps, scanned.categories),
+      '',
+      ...renderGapLines('Sections', sectionGaps, scanned.sections),
+      '',
+      gapCount === 0
+        ? `No gaps: all ${scanned.categories} category/ies and ${scanned.sections} section(s) scanned have a published "${locale}" translation.`
+        : `${gapCount} node(s) need a published "${locale}" translation. Fix a category with set_category_translation and a section with set_section_translation, passing draft: false to publish.`,
+      ...(capped
+        ? [
+            '',
+            `_Note: the scan stopped at its ${TRANSLATION_GAP_SCAN_MAX_NODES}-node cap, covering ${scanned.categories}/${found.categories} categories and ${scanned.sections}/${found.sections} sections. The rest were not checked — narrow the scan with category_id, or raise ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES._`,
+          ]
+        : []),
+      ...(report.listingIncomplete
+        ? [
+            '',
+            `_Note: this Help Center has more than ${MAX_PAGE_SIZE} categories or sections, so only the first page of each was considered. Narrow the scan with category_id to audit the rest._`,
+          ]
+        : []),
+    ].join('\n'),
+  );
+};
 
 const largeArticleHint = (body: string, sectionCount: number): string | null => {
   if (body.length < LARGE_ARTICLE_BODY_CHARS && sectionCount < LARGE_ARTICLE_SECTION_COUNT) {
@@ -842,6 +1046,307 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
             {
               type: 'text',
               text: `Translation updated for article #${article_id} in "${locale}".\n\n${formatTranslation(translation)}`,
+            },
+          ],
+        };
+      },
+    },
+    {
+      name: 'list_section_translations',
+      namespace: 'help_center',
+      readOnly: true,
+      title: 'List Section Translations',
+      description:
+        'List the translations of a Help Center section: for each locale, the localized name, whether a description is set, and whether the translation is published or still a draft. Reach for this when a section looks untranslated in a locale — list_sections with a locale omits a section that has no translation AND one whose translation is an unpublished draft, and only this tool tells the two apart. Fix either case with set_section_translation; to sweep every category and section at once, use find_translation_gaps.',
+      inputSchema: z.object({
+        section_id: z.number().int().describe(SECTION_ID_DESC),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { section_id } = params as { section_id: number };
+        const token = await getToken();
+        const translations = await listNodeTranslations(subdomain, token, 'sections', section_id);
+        return {
+          content: [{ type: 'text', text: formatList(translations, formatNodeTranslationSummary) }],
+        };
+      },
+    },
+    {
+      name: 'list_category_translations',
+      namespace: 'help_center',
+      readOnly: true,
+      title: 'List Category Translations',
+      description:
+        'List the translations of a Help Center category: for each locale, the localized name, whether a description is set, and whether the translation is published or still a draft. Reach for this when a category looks untranslated in a locale — list_categories with a locale omits a category that has no translation AND one whose translation is an unpublished draft, and only this tool tells the two apart. Fix either case with set_category_translation; to sweep every category and section at once, use find_translation_gaps.',
+      inputSchema: z.object({
+        category_id: z.number().int().describe(CATEGORY_ID_DESC),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { category_id } = params as { category_id: number };
+        const token = await getToken();
+        const translations = await listNodeTranslations(
+          subdomain,
+          token,
+          'categories',
+          category_id,
+        );
+        return {
+          content: [{ type: 'text', text: formatList(translations, formatNodeTranslationSummary) }],
+        };
+      },
+    },
+    {
+      name: 'find_translation_gaps',
+      namespace: 'help_center',
+      readOnly: true,
+      title: 'Find Help Center Translation Gaps',
+      description:
+        'Audit the Help Center tree for a target locale and report every category and section that has no translation, or one that is still an unpublished draft. Use it before or after translating articles: an article published in a second locale is unreachable while its parent section only exists in the source locale, and that gap is invisible to list_sections. Costs one extra request per node scanned, capped (the report says so when the cap bites) — pass category_id to narrow it. Fix what it reports with set_section_translation / set_category_translation.',
+      inputSchema: z.object({
+        locale: z
+          .string()
+          .describe(
+            'Locale to audit, e.g. "fr" or "de" — usually a non-default active locale of the Help Center (zendesk-hc://topology lists them). A locale that is not active is reported as a warning, since every node would then look untranslated.',
+          ),
+        category_id: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            'Restrict the audit to this category and the sections it contains (id from list_categories). Omit to sweep the whole tree, which costs one request per category and per section.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { locale, category_id } = params as { locale: string; category_id?: number };
+        const token = await getToken();
+        const pageParams = buildCursorParams(MAX_PAGE_SIZE, undefined);
+        const [locales, categoriesRes, sectionsRes] = await Promise.all([
+          helpCenterGet<ZendeskLocalesResponse>(subdomain, token, '/locales'),
+          helpCenterGet<ZendeskListResponse<ZendeskCategory>>(
+            subdomain,
+            token,
+            '/categories',
+            pageParams,
+          ),
+          helpCenterGet<ZendeskListResponse<ZendeskSection>>(
+            subdomain,
+            token,
+            sectionListPath(category_id, undefined),
+            pageParams,
+          ),
+        ]);
+
+        // Scoping to one category filters the same listing rather than fetching
+        // the category on its own: the request is already paid for.
+        const allCategories = (categoriesRes.categories ?? []).filter(
+          (category) => category_id === undefined || category.id === category_id,
+        );
+        const allSections = sectionsRes.sections ?? [];
+
+        // Categories first, sections with whatever budget is left: a caller
+        // auditing a bilingual tree cares most about the top of it, and the note
+        // in the report names exactly what went unscanned.
+        const categories = allCategories.slice(0, TRANSLATION_GAP_SCAN_MAX_NODES);
+        const sections = allSections.slice(
+          0,
+          Math.max(0, TRANSLATION_GAP_SCAN_MAX_NODES - categories.length),
+        );
+
+        const [categoryGaps, sectionGaps] = await Promise.all([
+          Promise.all(
+            categories.map(async (category) =>
+              classifyGap(
+                category,
+                await listNodeTranslations(subdomain, token, 'categories', category.id, locale),
+                locale,
+              ),
+            ),
+          ),
+          Promise.all(
+            sections.map(async (section) =>
+              classifyGap(
+                section,
+                await listNodeTranslations(subdomain, token, 'sections', section.id, locale),
+                locale,
+              ),
+            ),
+          ),
+        ]);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: renderGapReport({
+                locale,
+                activeLocales: locales.locales ?? [],
+                categoryGaps: categoryGaps.filter((gap): gap is TranslationGap => gap !== null),
+                sectionGaps: sectionGaps.filter((gap): gap is TranslationGap => gap !== null),
+                scanned: { categories: categories.length, sections: sections.length },
+                found: { categories: allCategories.length, sections: allSections.length },
+                listingIncomplete:
+                  extractPaginationMeta(categoriesRes, allCategories.length).has_more ||
+                  extractPaginationMeta(sectionsRes, allSections.length).has_more,
+              }),
+            },
+          ],
+        };
+      },
+    },
+    {
+      name: 'set_section_translation',
+      namespace: 'help_center',
+      readOnly: false,
+      title: 'Create or Update a Section Translation',
+      description:
+        'Create or update the translation of a Help Center section in one locale, and return the resulting translation (locale, localized name, draft state). Creates the translation when the locale has none and updates it otherwise, so no listing call is needed first; only the fields you pass are written, which makes "publish this draft" a single draft: false. Use it to make a section reachable in a locale where its articles are already translated — a gap find_translation_gaps reports and list_sections cannot explain.',
+      inputSchema: z.object({
+        section_id: z
+          .number()
+          .int()
+          .describe(
+            'Section ID — the numeric id of the section whose translation to write. Obtain it from list_sections, find_translation_gaps or the zendesk-hc://topology resource.',
+          ),
+        locale: z
+          .string()
+          .describe(
+            'Locale to write, e.g. "fr" or "de". Must be an active locale of the Help Center (zendesk-hc://topology lists them); list_section_translations shows which ones the section already has.',
+          ),
+        name: z
+          .string()
+          .min(1)
+          .optional()
+          .describe(
+            "Localized section name for this locale (sent as the API's translation `title`). Required when the locale has no translation yet; omit on an existing one to leave its name untouched, for instance when only publishing a draft.",
+          ),
+        description: z
+          .string()
+          .optional()
+          .describe(
+            "Localized section description for this locale (sent as the API's translation `body`). Omit to leave an existing description untouched; pass an empty string to clear it.",
+          ),
+        draft: z
+          .boolean()
+          .optional()
+          .describe(
+            'Publication state: false publishes the translation, making the section visible to end users in this locale; true keeps (or puts) it back as a draft. Defaults to false when creating; omit on an existing translation to leave its state unchanged.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { section_id, ...input } = params as {
+          section_id: number;
+          locale: string;
+          name?: string;
+          description?: string;
+          draft?: boolean;
+        };
+        const token = await getToken();
+        const { translation, created } = await upsertNodeTranslation(
+          subdomain,
+          token,
+          'sections',
+          section_id,
+          input,
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: nodeTranslationWriteText('sections', section_id, translation, created),
+            },
+          ],
+        };
+      },
+    },
+    {
+      name: 'set_category_translation',
+      namespace: 'help_center',
+      readOnly: false,
+      title: 'Create or Update a Category Translation',
+      description:
+        'Create or update the translation of a Help Center category in one locale, and return the resulting translation (locale, localized name, draft state). Creates the translation when the locale has none and updates it otherwise, so no listing call is needed first; only the fields you pass are written, which makes "publish this draft" a single draft: false. Use it to make a category reachable in a locale where its sections or articles are already translated — a gap find_translation_gaps reports and list_categories cannot explain.',
+      inputSchema: z.object({
+        category_id: z
+          .number()
+          .int()
+          .describe(
+            'Category ID — the numeric id of the category whose translation to write. Obtain it from list_categories, find_translation_gaps or the zendesk-hc://topology resource.',
+          ),
+        locale: z
+          .string()
+          .describe(
+            'Locale to write, e.g. "fr" or "de". Must be an active locale of the Help Center (zendesk-hc://topology lists them); list_category_translations shows which ones the category already has.',
+          ),
+        name: z
+          .string()
+          .min(1)
+          .optional()
+          .describe(
+            "Localized category name for this locale (sent as the API's translation `title`). Required when the locale has no translation yet; omit on an existing one to leave its name untouched, for instance when only publishing a draft.",
+          ),
+        description: z
+          .string()
+          .optional()
+          .describe(
+            "Localized category description for this locale (sent as the API's translation `body`). Omit to leave an existing description untouched; pass an empty string to clear it.",
+          ),
+        draft: z
+          .boolean()
+          .optional()
+          .describe(
+            'Publication state: false publishes the translation, making the category visible to end users in this locale; true keeps (or puts) it back as a draft. Defaults to false when creating; omit on an existing translation to leave its state unchanged.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { category_id, ...input } = params as {
+          category_id: number;
+          locale: string;
+          name?: string;
+          description?: string;
+          draft?: boolean;
+        };
+        const token = await getToken();
+        const { translation, created } = await upsertNodeTranslation(
+          subdomain,
+          token,
+          'categories',
+          category_id,
+          input,
+        );
+        return {
+          content: [
+            {
+              type: 'text',
+              text: nodeTranslationWriteText('categories', category_id, translation, created),
             },
           ],
         };

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -112,12 +112,6 @@ const NODE_LABEL: Record<TreeNodeKind, string> = {
   categories: 'category',
 };
 
-const SECTION_ID_DESC =
-  'Section ID — the numeric id of the Help Center section. Obtain it from list_sections or the zendesk-hc://topology resource.';
-
-const CATEGORY_ID_DESC =
-  'Category ID — the numeric id of the Help Center category. Obtain it from list_categories or the zendesk-hc://topology resource.';
-
 // `locales` narrows the response when the caller only cares about one language.
 // The result is filtered locally anyway (see findTranslation), so the tools stay
 // correct even where the server-side filter is not applied.
@@ -187,6 +181,13 @@ const upsertNodeTranslation = async (
   if (name !== undefined) updates['title'] = name;
   if (description !== undefined) updates['body'] = description;
   if (draft !== undefined) updates['draft'] = draft;
+  // An empty payload would round-trip to Zendesk and come back reported as an
+  // update, which is a lie. Say what is missing instead.
+  if (Object.keys(updates).length === 0) {
+    throw new Error(
+      `Nothing to write: ${NODE_LABEL[kind]} #${nodeId} already has a "${existing.locale}" translation, so pass at least one of "name", "description" or "draft" to change it (draft: false publishes it).`,
+    );
+  }
   // Zendesk's own spelling of the locale, not the caller's: the PUT path has to
   // match the existing translation even when the input was cased differently.
   const { translation } = await helpCenterPut<{ translation: ZendeskTranslation }>(
@@ -252,12 +253,50 @@ interface GapReport {
   listingIncomplete: boolean;
 }
 
-const renderGapLines = (heading: string, gaps: TranslationGap[], scanned: number): string[] => [
-  `## ${heading} (${scanned} scanned)`,
-  ...(gaps.length > 0
-    ? gaps.map((gap) => `- **${gap.name}** (${gap.id}) — ${GAP_REASON_TEXT[gap.reason]}`)
-    : ['_(none — every one scanned has a published translation)_']),
-];
+const renderGapLines = (heading: string, gaps: TranslationGap[], scanned: number): string[] => {
+  if (gaps.length > 0) {
+    return [
+      `## ${heading} (${scanned} scanned)`,
+      ...gaps.map((gap) => `- **${gap.name}** (${gap.id}) — ${GAP_REASON_TEXT[gap.reason]}`),
+    ];
+  }
+  // "every one scanned has a translation" would be a wrong reading of an empty
+  // scan (a category with no sections, a scope that matched nothing).
+  return [
+    `## ${heading} (${scanned} scanned)`,
+    scanned === 0
+      ? '_(none to scan at this level)_'
+      : '_(none — every one scanned has a published translation)_',
+  ];
+};
+
+// The categories to audit. Scoping to one fetches that category on its own
+// rather than filtering the paginated listing: the listing is capped at one page,
+// so filtering it would silently report "0 categories scanned" for a category
+// that merely sits further down — and a wrong id would look like an empty tree
+// instead of the 404 it is.
+const fetchGapCategories = async (
+  subdomain: string,
+  token: string,
+  categoryId: number | undefined,
+): Promise<{ categories: ZendeskCategory[]; hasMore: boolean }> => {
+  if (categoryId !== undefined) {
+    const { category } = await helpCenterGet<{ category: ZendeskCategory }>(
+      subdomain,
+      token,
+      `/categories/${categoryId}`,
+    );
+    return { categories: [category], hasMore: false };
+  }
+  const response = await helpCenterGet<ZendeskListResponse<ZendeskCategory>>(
+    subdomain,
+    token,
+    '/categories',
+    buildCursorParams(MAX_PAGE_SIZE, undefined),
+  );
+  const categories = response.categories ?? [];
+  return { categories, hasMore: extractPaginationMeta(response, categories.length).has_more };
+};
 
 const renderGapReport = (report: GapReport): string => {
   const { locale, categoryGaps, sectionGaps, scanned, found } = report;
@@ -1059,7 +1098,12 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       description:
         'List the translations of a Help Center section: for each locale, the localized name, whether a description is set, and whether the translation is published or still a draft. Reach for this when a section looks untranslated in a locale — list_sections with a locale omits a section that has no translation AND one whose translation is an unpublished draft, and only this tool tells the two apart. Fix either case with set_section_translation; to sweep every category and section at once, use find_translation_gaps.',
       inputSchema: z.object({
-        section_id: z.number().int().describe(SECTION_ID_DESC),
+        section_id: z
+          .number()
+          .int()
+          .describe(
+            'Section ID — the numeric id of the Help Center section. Obtain it from list_sections or the zendesk-hc://topology resource.',
+          ),
       }),
       annotations: {
         readOnlyHint: true,
@@ -1084,7 +1128,12 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       description:
         'List the translations of a Help Center category: for each locale, the localized name, whether a description is set, and whether the translation is published or still a draft. Reach for this when a category looks untranslated in a locale — list_categories with a locale omits a category that has no translation AND one whose translation is an unpublished draft, and only this tool tells the two apart. Fix either case with set_category_translation; to sweep every category and section at once, use find_translation_gaps.',
       inputSchema: z.object({
-        category_id: z.number().int().describe(CATEGORY_ID_DESC),
+        category_id: z
+          .number()
+          .int()
+          .describe(
+            'Category ID — the numeric id of the Help Center category. Obtain it from list_categories or the zendesk-hc://topology resource.',
+          ),
       }),
       annotations: {
         readOnlyHint: true,
@@ -1136,28 +1185,18 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
       handler: async (params) => {
         const { locale, category_id } = params as { locale: string; category_id?: number };
         const token = await getToken();
-        const pageParams = buildCursorParams(MAX_PAGE_SIZE, undefined);
-        const [locales, categoriesRes, sectionsRes] = await Promise.all([
+        const [locales, categoryScope, sectionsRes] = await Promise.all([
           helpCenterGet<ZendeskLocalesResponse>(subdomain, token, '/locales'),
-          helpCenterGet<ZendeskListResponse<ZendeskCategory>>(
-            subdomain,
-            token,
-            '/categories',
-            pageParams,
-          ),
+          fetchGapCategories(subdomain, token, category_id),
           helpCenterGet<ZendeskListResponse<ZendeskSection>>(
             subdomain,
             token,
             sectionListPath(category_id, undefined),
-            pageParams,
+            buildCursorParams(MAX_PAGE_SIZE, undefined),
           ),
         ]);
 
-        // Scoping to one category filters the same listing rather than fetching
-        // the category on its own: the request is already paid for.
-        const allCategories = (categoriesRes.categories ?? []).filter(
-          (category) => category_id === undefined || category.id === category_id,
-        );
+        const allCategories = categoryScope.categories;
         const allSections = sectionsRes.sections ?? [];
 
         // Categories first, sections with whatever budget is left: a caller
@@ -1202,7 +1241,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
                 scanned: { categories: categories.length, sections: sections.length },
                 found: { categories: allCategories.length, sections: allSections.length },
                 listingIncomplete:
-                  extractPaginationMeta(categoriesRes, allCategories.length).has_more ||
+                  categoryScope.hasMore ||
                   extractPaginationMeta(sectionsRes, allSections.length).has_more,
               }),
             },

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -402,6 +402,21 @@ export const formatTranslationSummary = (translation: ZendeskTranslation): strin
 export const formatTranslation = (translation: ZendeskTranslation): string =>
   [formatTranslationSummary(translation), '', translation.body].join('\n');
 
+// Translations of a section or a category, which reuse the article translation
+// object with different meanings: `title` is the localized *name* and `body` the
+// localized *description*. Rendered with the vocabulary list_sections /
+// list_categories already use, so the caller never has to map the two. The
+// description is reported as present/absent rather than inlined — it is metadata
+// here, not content, and Zendesk leaves it empty when unset.
+export const formatNodeTranslationSummary = (translation: ZendeskTranslation): string =>
+  [
+    `## Translation: ${translation.locale} (${translation.id})`,
+    `- **Name**: ${translation.title}`,
+    `- **Description**: ${translation.body ? 'set' : 'empty'}`,
+    `- **Draft**: ${translation.draft}`,
+    `- **Updated**: ${translation.updated_at}`,
+  ].join('\n');
+
 export const formatCategory = (category: ZendeskCategory): string =>
   `- **${category.name}** (${category.id}) — ${category.description || 'No description'}`;
 

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -278,6 +278,10 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(names).not.toContain('create_ticket');
         expect(names).not.toContain('update_ticket');
         expect(names).not.toContain('archive_article');
+        expect(names).not.toContain('set_section_translation');
+        expect(names).not.toContain('set_category_translation');
+        // The read side of the same feature survives the filter.
+        expect(names).toContain('find_translation_gaps');
       });
     });
 
@@ -406,6 +410,29 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         // Per-section presence status, not a word-count verdict.
         expect(text).toContain('| Idx | Heading | Status');
         expect(text).not.toContain('different');
+      });
+
+      it('audits then publishes a section translation through the help_center proxy (#224)', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'namespace' }));
+
+        // Section 600 has a `fr` translation that is still a draft, so the audit
+        // must report it as a draft rather than as missing.
+        const audit = await connected.client.callTool({
+          name: 'zendesk_help_center',
+          arguments: { operation: 'find_translation_gaps', params: { locale: 'fr' } },
+        });
+        expect(audit.isError).toBeFalsy();
+        expect(textOf(audit)).toContain('(600) — draft translation (not published)');
+
+        const published = await connected.client.callTool({
+          name: 'zendesk_help_center',
+          arguments: {
+            operation: 'set_section_translation',
+            params: { section_id: 600, locale: 'fr', draft: false },
+          },
+        });
+        expect(published.isError).toBeFalsy();
+        expect(textOf(published)).toContain('Translation updated for section #600 in "fr"');
       });
 
       it('archives a Help Center article over the wire when confirmed', async () => {

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -433,6 +433,19 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         });
         expect(published.isError).toBeFalsy();
         expect(textOf(published)).toContain('Translation updated for section #600 in "fr"');
+
+        // The category level is iso with the section one and shares the same
+        // upsert, but its write path could not be validated against the live
+        // tenant (#225, S12), so it gets its own wire-level pass here.
+        const category = await connected.client.callTool({
+          name: 'zendesk_help_center',
+          arguments: {
+            operation: 'set_category_translation',
+            params: { category_id: 800, locale: 'fr', name: 'Général' },
+          },
+        });
+        expect(category.isError).toBeFalsy();
+        expect(textOf(category)).toContain('Translation updated for category #800 in "fr"');
       });
 
       it('archives a Help Center article over the wire when confirmed', async () => {

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -246,6 +246,65 @@ export const MOCK_SECTION = {
   updated_at: '2026-01-02T00:00:00Z',
 };
 
+// Translations of a section / a category. Same endpoint family as the article
+// ones, but `title` carries the localized *name* and `body` the localized
+// *description*.
+export const MOCK_SECTION_TRANSLATION = {
+  id: 7100,
+  locale: 'en-us',
+  title: 'FAQ',
+  body: 'Frequently asked questions',
+  draft: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+  source_id: 600,
+  source_type: 'Section',
+};
+
+export const MOCK_CATEGORY_TRANSLATION = {
+  ...MOCK_SECTION_TRANSLATION,
+  id: 7200,
+  title: 'General',
+  body: 'General category',
+  source_id: 800,
+  source_type: 'Category',
+};
+
+// Keyed by node id so one listing can exercise all three states the gap scan
+// distinguishes: a published target translation, a draft one, and none at all.
+// 600 / 800 are the ids the section and category list fixtures return.
+const SECTION_TRANSLATIONS: Record<string, Record<string, unknown>[]> = {
+  '600': [
+    MOCK_SECTION_TRANSLATION,
+    { ...MOCK_SECTION_TRANSLATION, id: 7101, locale: 'fr', title: 'FAQ (fr)', draft: true },
+  ],
+  '601': [{ ...MOCK_SECTION_TRANSLATION, id: 7102, source_id: 601, title: 'Billing' }],
+  '602': [
+    { ...MOCK_SECTION_TRANSLATION, id: 7103, source_id: 602, title: 'Pricing' },
+    {
+      ...MOCK_SECTION_TRANSLATION,
+      id: 7104,
+      source_id: 602,
+      locale: 'fr',
+      title: 'Tarifs',
+      draft: false,
+    },
+  ],
+};
+
+const CATEGORY_TRANSLATIONS: Record<string, Record<string, unknown>[]> = {
+  '800': [
+    MOCK_CATEGORY_TRANSLATION,
+    { ...MOCK_CATEGORY_TRANSLATION, id: 7201, locale: 'fr', title: 'Général', draft: false },
+  ],
+  '801': [{ ...MOCK_CATEGORY_TRANSLATION, id: 7202, source_id: 801, title: 'Legal' }],
+};
+
+const readTranslationPayload = async (request: Request): Promise<Record<string, unknown>> => {
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  return (body['translation'] as Record<string, unknown> | undefined) ?? {};
+};
+
 export const MOCK_PERMISSION_GROUP = {
   id: 12001,
   name: 'Editors',
@@ -882,4 +941,58 @@ export const handlers = [
       count: 1,
     }),
   ),
+
+  // Help Center - Section & Category translations. The write handlers echo the
+  // submitted `translation` object back over the fixture, so a test can assert
+  // which fields the tool actually sent (and, by omission, which it left alone).
+  http.get(`${HC_BASE}/sections/:id/translations`, ({ params }) =>
+    HttpResponse.json({ translations: SECTION_TRANSLATIONS[String(params['id'])] ?? [] }),
+  ),
+  http.post(`${HC_BASE}/sections/:id/translations`, async ({ request, params }) => {
+    const submitted = await readTranslationPayload(request);
+    return HttpResponse.json({
+      translation: {
+        ...MOCK_SECTION_TRANSLATION,
+        id: 7150,
+        source_id: Number(params['id']),
+        ...submitted,
+      },
+    });
+  }),
+  http.put(`${HC_BASE}/sections/:id/translations/:locale`, async ({ request, params }) => {
+    const submitted = await readTranslationPayload(request);
+    return HttpResponse.json({
+      translation: {
+        ...MOCK_SECTION_TRANSLATION,
+        source_id: Number(params['id']),
+        locale: params['locale'] as string,
+        ...submitted,
+      },
+    });
+  }),
+  http.get(`${HC_BASE}/categories/:id/translations`, ({ params }) =>
+    HttpResponse.json({ translations: CATEGORY_TRANSLATIONS[String(params['id'])] ?? [] }),
+  ),
+  http.post(`${HC_BASE}/categories/:id/translations`, async ({ request, params }) => {
+    const submitted = await readTranslationPayload(request);
+    return HttpResponse.json({
+      translation: {
+        ...MOCK_CATEGORY_TRANSLATION,
+        id: 7250,
+        source_id: Number(params['id']),
+        ...submitted,
+      },
+    });
+  }),
+  http.put(`${HC_BASE}/categories/:id/translations/:locale`, async ({ request, params }) => {
+    const submitted = await readTranslationPayload(request);
+    return HttpResponse.json({
+      translation: {
+        ...MOCK_CATEGORY_TRANSLATION,
+        source_id: Number(params['id']),
+        locale: params['locale'] as string,
+        ...submitted,
+      },
+    });
+  }),
 ];

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -920,6 +920,9 @@ export const handlers = [
       count: 1,
     }),
   ),
+  http.get(`${HC_BASE}/categories/:id`, ({ params }) =>
+    HttpResponse.json({ category: { ...MOCK_CATEGORY, id: Number(params['id']) } }),
+  ),
   http.get(`${HC_BASE}/sections`, () =>
     HttpResponse.json({
       sections: [MOCK_SECTION],

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -65,7 +65,7 @@ describe('groupByNamespace', () => {
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
     expect(ticketCount).toBe(18); // 17 ticket tools + 1 search
-    expect(hcCount).toBe(24);
+    expect(hcCount).toBe(29);
     expect(userCount).toBe(5);
   });
 });

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -624,6 +624,46 @@ describe('help center tools', () => {
       expect(text).toContain('ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES');
     });
 
+    it('does not pass off a level the cap never reached as an empty one', async () => {
+      // 60 categories spend the whole budget, so the sections below it are not
+      // scanned at all. Saying "none to scan at this level" there would read as
+      // "this Help Center has no sections", the opposite of the truth.
+      seedTree(
+        [600, 601],
+        Array.from({ length: 60 }, (_, i) => 900 + i),
+      );
+      const result = await findTool('find_translation_gaps').handler({ locale: 'fr' });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('## Sections (0 scanned)');
+      expect(text).not.toContain('_(none to scan at this level)_');
+      expect(text).toContain('the 60-node cap was spent before this level');
+      expect(text).toContain('2 left unchecked');
+      expect(text).toContain('covering 60/60 categories and 0/2 sections');
+    });
+
+    it('probes the tree in bounded waves rather than one burst', async () => {
+      let inFlight = 0;
+      let peak = 0;
+      seedTree(
+        Array.from({ length: 20 }, (_, i) => 1000 + i),
+        [],
+      );
+      mswServer.use(
+        http.get(`${HC_BASE}/sections/:id/translations`, async () => {
+          inFlight += 1;
+          peak = Math.max(peak, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          inFlight -= 1;
+          return HttpResponse.json({ translations: [] });
+        }),
+      );
+      const result = await findTool('find_translation_gaps').handler({ locale: 'fr' });
+      // Zendesk caps concurrent requests per account, and one 429 would sink the
+      // whole audit, so the fan-out stays small however many nodes are scanned.
+      expect(peak).toBeLessThanOrEqual(5);
+      expect(result.content[0]?.text).toContain('## Sections (20 scanned)');
+    });
+
     it('flags a tree too large to enumerate from a single listing page', async () => {
       mswServer.use(
         http.get(`${HC_BASE}/sections`, () =>
@@ -649,6 +689,26 @@ describe('help center tools', () => {
       );
       await findTool('find_translation_gaps').handler({ locale: 'fr' });
       expect(queries).toEqual(['?locales=fr']);
+    });
+
+    it("asks for the locale in Zendesk's own casing, whatever the caller passed", async () => {
+      // Locales are stored lower-cased upstream. Should the `locales` filter be
+      // case-sensitive — undocumented either way — a verbatim "FR" would come back
+      // empty and report every node as untranslated, while the active-locale check
+      // (case-insensitive) stayed mute. Normalizing removes the question.
+      const queries: string[] = [];
+      seedTree([600], [800]);
+      mswServer.use(
+        http.get(`${HC_BASE}/sections/:id/translations`, ({ request }) => {
+          queries.push(new URL(request.url).search);
+          return HttpResponse.json({
+            translations: [{ ...MOCK_SECTION_TRANSLATION, locale: 'fr', draft: false }],
+          });
+        }),
+      );
+      const result = await findTool('find_translation_gaps').handler({ locale: 'FR' });
+      expect(queries).toEqual(['?locales=fr']);
+      expect(result.content[0]?.text).not.toContain('(600) — no translation');
     });
   });
 

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -276,6 +276,23 @@ describe('help center tools', () => {
     });
   });
 
+  // The tools originally told callers that a locale-filtered listing omits a
+  // draft-translated node just as it omits an untranslated one, so "absent from
+  // list_sections(locale)" was the whole story. Validating #225 against a live
+  // tenant disproved the draft half: with an admin token such a node IS returned,
+  // under its draft name. An agent reading the old wording would conclude
+  // "listed ⇒ published" on exactly the path these tools exist to fix.
+  describe('translation-gap tool descriptions', () => {
+    it.each(['list_section_translations', 'list_category_translations', 'find_translation_gaps'])(
+      '%s does not promise that a draft translation is hidden from the locale listing',
+      (name) => {
+        const { description } = findTool(name);
+        expect(description).toMatch(/draft.*may still be listed|may still be listed.*draft/is);
+        expect(description).not.toMatch(/omits.*unpublished draft|invisible to list_sections/is);
+      },
+    );
+  });
+
   describe('list_section_translations', () => {
     it('reports each locale with its draft state and whether a description is set', async () => {
       const result = await findTool('list_section_translations').handler({ section_id: 600 });

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -293,49 +293,83 @@ describe('help center tools', () => {
     );
   });
 
-  describe('list_section_translations', () => {
-    it('reports each locale with its draft state and whether a description is set', async () => {
-      const result = await findTool('list_section_translations').handler({ section_id: 600 });
-      const text = result.content[0]?.text ?? '';
-      expect(text).toContain('Translation: en-us (7100)');
-      expect(text).toContain('Translation: fr (7101)');
+  // Sections and categories are iso by design: the same endpoint family, the same
+  // translation object, and one shared upsertNodeTranslation behind both write
+  // tools. So every behaviour is asserted on BOTH levels from one table rather
+  // than written twice — a new case added here cannot land on one level only.
+  // This matters more than usual for categories: live validation of the category
+  // write path was skipped for want of an expendable category on the tenant
+  // (#225, S12), so these are the only proof that half carries.
+  const NODE_LEVELS = [
+    {
+      level: 'section',
+      listTool: 'list_section_translations',
+      writeTool: 'set_section_translation',
+      idParam: 'section_id',
+      nodeId: 600,
+      segment: 'sections',
+      fixture: MOCK_SECTION_TRANSLATION,
+      // Ids of the fixture's own translations, and a name only that level uses.
+      sourceTranslationId: 7100,
+      targetTranslationId: 7101,
+      localizedName: 'FAQ (fr)',
+    },
+    {
+      level: 'category',
+      listTool: 'list_category_translations',
+      writeTool: 'set_category_translation',
+      idParam: 'category_id',
+      nodeId: 800,
+      segment: 'categories',
+      fixture: MOCK_CATEGORY_TRANSLATION,
+      sourceTranslationId: 7200,
+      targetTranslationId: 7201,
+      localizedName: 'Général',
+    },
+  ] as const;
+
+  describe.each(NODE_LEVELS)('$listTool', (node) => {
+    const call = (extra: Record<string, unknown> = {}) =>
+      findTool(node.listTool).handler({ [node.idParam]: node.nodeId, ...extra });
+
+    it('reports each locale with its localized name, description state and draft state', async () => {
+      const text = (await call()).content[0]?.text ?? '';
+      expect(text).toContain(`Translation: en-us (${node.sourceTranslationId})`);
+      expect(text).toContain(`Translation: fr (${node.targetTranslationId})`);
       // `title` is the localized NAME here, not an article title — the rendering
       // has to say so, otherwise the caller maps the wrong field back.
-      expect(text).toContain('**Name**: FAQ (fr)');
+      expect(text).toContain(`**Name**: ${node.localizedName}`);
       expect(text).not.toContain('**Title**');
-      expect(text).toContain('**Draft**: true');
       expect(text).toContain('**Draft**: false');
       expect(text).toContain('**Description**: set');
     });
 
     it('renders an empty description as "empty" rather than dropping the line', async () => {
       mswServer.use(
-        http.get(`${HC_BASE}/sections/:id/translations`, () =>
+        http.get(`${HC_BASE}/${node.segment}/:id/translations`, () =>
+          HttpResponse.json({ translations: [{ ...node.fixture, body: '' }] }),
+        ),
+      );
+      expect((await call()).content[0]?.text).toContain('**Description**: empty');
+    });
+
+    it('surfaces the draft flag of an unpublished translation', async () => {
+      mswServer.use(
+        http.get(`${HC_BASE}/${node.segment}/:id/translations`, () =>
           HttpResponse.json({
-            translations: [{ ...MOCK_SECTION_TRANSLATION, body: '' }],
+            translations: [{ ...node.fixture, locale: 'fr', draft: true }],
           }),
         ),
       );
-      const result = await findTool('list_section_translations').handler({ section_id: 600 });
-      expect(result.content[0]?.text).toContain('**Description**: empty');
+      expect((await call()).content[0]?.text).toContain('**Draft**: true');
     });
   });
 
-  describe('list_category_translations', () => {
-    it('lists the category translations with the localized names', async () => {
-      const result = await findTool('list_category_translations').handler({ category_id: 800 });
-      const text = result.content[0]?.text ?? '';
-      expect(text).toContain('Translation: en-us (7200)');
-      expect(text).toContain('**Name**: Général');
-      expect(text).not.toContain('**Draft**: true');
-    });
-  });
-
-  describe('set_section_translation', () => {
+  describe.each(NODE_LEVELS)('$writeTool', (node) => {
     // Captures what actually reached Zendesk: the method, the path (locale
     // spelling included) and the `translation` payload.
     const captureWrites = () => {
-      const writes: Array<{ method: string; path: string; payload: Record<string, unknown> }> = [];
+      const writes: { method: string; path: string; payload: Record<string, unknown> }[] = [];
       const record = async (method: string, request: Request) => {
         const payload = (await request.json().catch(() => ({}))) as Record<string, unknown>;
         writes.push({
@@ -345,53 +379,58 @@ describe('help center tools', () => {
         });
       };
       mswServer.use(
-        http.post(`${HC_BASE}/sections/:id/translations`, async ({ request }) => {
+        http.post(`${HC_BASE}/${node.segment}/:id/translations`, async ({ request }) => {
           await record('POST', request.clone());
-          return HttpResponse.json({ translation: { ...MOCK_SECTION_TRANSLATION, locale: 'de' } });
+          return HttpResponse.json({ translation: { ...node.fixture, locale: 'de' } });
         }),
-        http.put(`${HC_BASE}/sections/:id/translations/:locale`, async ({ request, params }) => {
-          await record('PUT', request.clone());
-          return HttpResponse.json({
-            translation: {
-              ...MOCK_SECTION_TRANSLATION,
-              id: 7101,
-              locale: params['locale'] as string,
-              draft: false,
-            },
-          });
-        }),
+        http.put(
+          `${HC_BASE}/${node.segment}/:id/translations/:locale`,
+          async ({ request, params }) => {
+            await record('PUT', request.clone());
+            return HttpResponse.json({
+              translation: {
+                ...node.fixture,
+                locale: params['locale'] as string,
+                draft: false,
+              },
+            });
+          },
+        ),
       );
       return writes;
     };
 
+    const write = (extra: Record<string, unknown>) =>
+      findTool(node.writeTool).handler({ [node.idParam]: node.nodeId, ...extra });
+
     it('creates the translation when the locale has none, mapping name/description', async () => {
       const writes = captureWrites();
-      const result = await findTool('set_section_translation').handler({
-        section_id: 600,
+      const result = await write({
         locale: 'de',
         name: 'Häufige Fragen',
         description: 'Oft gestellte Fragen',
       });
       expect(writes).toHaveLength(1);
       expect(writes[0]?.method).toBe('POST');
+      expect(writes[0]?.path).toBe(
+        `/api/v2/help_center/${node.segment}/${node.nodeId}/translations`,
+      );
       expect(writes[0]?.payload).toEqual({
         locale: 'de',
         title: 'Häufige Fragen',
         body: 'Oft gestellte Fragen',
-        // Creating publishes by default, so the section is actually reachable.
+        // Creating publishes by default, so the node is actually reachable.
         draft: false,
       });
-      expect(result.content[0]?.text).toContain('Translation created for section #600 in "de"');
+      expect(result.content[0]?.text).toContain(
+        `Translation created for ${node.level} #${node.nodeId} in "de"`,
+      );
       expect(result.content[0]?.text).toContain('(published)');
     });
 
     it('defaults the description to empty on creation rather than omitting it', async () => {
       const writes = captureWrites();
-      await findTool('set_section_translation').handler({
-        section_id: 600,
-        locale: 'de',
-        name: 'Häufige Fragen',
-      });
+      await write({ locale: 'de', name: 'Häufige Fragen' });
       expect(writes[0]?.payload).toEqual({
         locale: 'de',
         title: 'Häufige Fragen',
@@ -400,111 +439,67 @@ describe('help center tools', () => {
       });
     });
 
-    it('refuses to create without a name, naming the section and the locale', async () => {
-      await expect(
-        findTool('set_section_translation').handler({ section_id: 600, locale: 'de' }),
-      ).rejects.toThrow(/section #600 has no "de" translation yet.*"name" is required/s);
+    it('honours draft: true on creation instead of publishing anyway', async () => {
+      const writes = captureWrites();
+      await write({ locale: 'de', name: 'Häufige Fragen', draft: true });
+      expect(writes[0]?.payload).toMatchObject({ draft: true });
+    });
+
+    it('refuses to create without a name, naming the node and the locale', async () => {
+      const writes = captureWrites();
+      await expect(write({ locale: 'de' })).rejects.toThrow(
+        new RegExp(
+          `${node.level} #${node.nodeId} has no "de" translation yet.*"name" is required`,
+          's',
+        ),
+      );
+      expect(writes).toHaveLength(0);
     });
 
     it('updates an existing translation, sending only the fields passed', async () => {
       const writes = captureWrites();
-      const result = await findTool('set_section_translation').handler({
-        section_id: 600,
-        locale: 'fr',
-        draft: false,
-      });
+      const result = await write({ locale: 'fr', draft: false });
       expect(writes).toHaveLength(1);
       expect(writes[0]?.method).toBe('PUT');
       // Publishing a draft must not blank the existing name or description.
       expect(writes[0]?.payload).toEqual({ draft: false });
-      expect(result.content[0]?.text).toContain('Translation updated for section #600 in "fr"');
+      expect(result.content[0]?.text).toContain(
+        `Translation updated for ${node.level} #${node.nodeId} in "fr"`,
+      );
       expect(result.content[0]?.text).toContain('(published)');
     });
 
     it('clears the description when an empty string is passed explicitly', async () => {
       const writes = captureWrites();
-      await findTool('set_section_translation').handler({
-        section_id: 600,
-        locale: 'fr',
-        description: '',
-      });
+      await write({ locale: 'fr', description: '' });
       expect(writes[0]?.payload).toEqual({ body: '' });
     });
 
     it("writes to Zendesk's spelling of the locale, not the caller's casing", async () => {
       const writes = captureWrites();
-      await findTool('set_section_translation').handler({
-        section_id: 600,
-        locale: 'FR',
-        name: 'FAQ (fr)',
-      });
+      await write({ locale: 'FR', name: 'Renamed' });
       expect(writes[0]?.method).toBe('PUT');
-      expect(writes[0]?.path).toMatch(/\/sections\/600\/translations\/fr$/);
+      expect(writes[0]?.path).toBe(
+        `/api/v2/help_center/${node.segment}/${node.nodeId}/translations/fr`,
+      );
     });
 
     it('refuses a no-op update rather than reporting a write that changed nothing', async () => {
       const writes = captureWrites();
-      await expect(
-        findTool('set_section_translation').handler({ section_id: 600, locale: 'fr' }),
-      ).rejects.toThrow(/Nothing to write.*already has a "fr" translation/s);
+      await expect(write({ locale: 'fr' })).rejects.toThrow(
+        /Nothing to write.*already has a "fr" translation/s,
+      );
       expect(writes).toHaveLength(0);
     });
 
     it('reports a translation left as a draft as not visible to end users', async () => {
       mswServer.use(
-        http.put(`${HC_BASE}/sections/:id/translations/:locale`, () =>
-          HttpResponse.json({
-            translation: { ...MOCK_SECTION_TRANSLATION, locale: 'fr', draft: true },
-          }),
+        http.put(`${HC_BASE}/${node.segment}/:id/translations/:locale`, () =>
+          HttpResponse.json({ translation: { ...node.fixture, locale: 'fr', draft: true } }),
         ),
       );
-      const result = await findTool('set_section_translation').handler({
-        section_id: 600,
-        locale: 'fr',
-        draft: true,
-      });
+      const result = await write({ locale: 'fr', draft: true });
       expect(result.content[0]?.text).toContain('(draft, not visible to end users)');
-    });
-  });
-
-  describe('set_category_translation', () => {
-    it('creates the translation on the categories endpoint with the mapped fields', async () => {
-      let path = '';
-      let payload: Record<string, unknown> = {};
-      mswServer.use(
-        http.post(`${HC_BASE}/categories/:id/translations`, async ({ request }) => {
-          path = new URL(request.url).pathname;
-          const body = (await request.json()) as Record<string, unknown>;
-          payload = (body['translation'] as Record<string, unknown>) ?? {};
-          return HttpResponse.json({
-            translation: { ...MOCK_CATEGORY_TRANSLATION, locale: 'de', title: 'Allgemein' },
-          });
-        }),
-      );
-      const result = await findTool('set_category_translation').handler({
-        category_id: 800,
-        locale: 'de',
-        name: 'Allgemein',
-        draft: true,
-      });
-      expect(path).toMatch(/\/categories\/800\/translations$/);
-      expect(payload).toEqual({ locale: 'de', title: 'Allgemein', body: '', draft: true });
-      expect(result.content[0]?.text).toContain('Translation created for category #800 in "de"');
-    });
-
-    it('updates an existing category translation instead of creating a duplicate', async () => {
-      const result = await findTool('set_category_translation').handler({
-        category_id: 800,
-        locale: 'fr',
-        name: 'Général',
-      });
-      expect(result.content[0]?.text).toContain('Translation updated for category #800 in "fr"');
-    });
-
-    it('refuses to create without a name, naming the category', async () => {
-      await expect(
-        findTool('set_category_translation').handler({ category_id: 800, locale: 'de' }),
-      ).rejects.toThrow(/category #800 has no "de" translation yet/);
     });
   });
 

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -4,6 +4,10 @@ import type { ToolContext } from '../../../src/tools/definitions';
 import { createHelpCenterTools } from '../../../src/tools/help-center';
 import {
   MOCK_ARTICLE,
+  MOCK_CATEGORY,
+  MOCK_CATEGORY_TRANSLATION,
+  MOCK_SECTION,
+  MOCK_SECTION_TRANSLATION,
   MOCK_TRANSLATION,
   manyContentTagsHandler,
   promotedArticlesHandler,
@@ -21,8 +25,8 @@ const findTool = (name: string) => {
 };
 
 describe('help center tools', () => {
-  it('creates 24 tools', () => {
-    expect(createHelpCenterTools(ctx)).toHaveLength(24);
+  it('creates 29 tools', () => {
+    expect(createHelpCenterTools(ctx)).toHaveLength(29);
   });
 
   describe('list_promoted_articles', () => {
@@ -269,6 +273,354 @@ describe('help center tools', () => {
         title: 'Updated title',
       });
       expect(result.content[0]?.text).toContain('Translation updated');
+    });
+  });
+
+  describe('list_section_translations', () => {
+    it('reports each locale with its draft state and whether a description is set', async () => {
+      const result = await findTool('list_section_translations').handler({ section_id: 600 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('Translation: en-us (7100)');
+      expect(text).toContain('Translation: fr (7101)');
+      // `title` is the localized NAME here, not an article title — the rendering
+      // has to say so, otherwise the caller maps the wrong field back.
+      expect(text).toContain('**Name**: FAQ (fr)');
+      expect(text).not.toContain('**Title**');
+      expect(text).toContain('**Draft**: true');
+      expect(text).toContain('**Draft**: false');
+      expect(text).toContain('**Description**: set');
+    });
+
+    it('renders an empty description as "empty" rather than dropping the line', async () => {
+      mswServer.use(
+        http.get(`${HC_BASE}/sections/:id/translations`, () =>
+          HttpResponse.json({
+            translations: [{ ...MOCK_SECTION_TRANSLATION, body: '' }],
+          }),
+        ),
+      );
+      const result = await findTool('list_section_translations').handler({ section_id: 600 });
+      expect(result.content[0]?.text).toContain('**Description**: empty');
+    });
+  });
+
+  describe('list_category_translations', () => {
+    it('lists the category translations with the localized names', async () => {
+      const result = await findTool('list_category_translations').handler({ category_id: 800 });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('Translation: en-us (7200)');
+      expect(text).toContain('**Name**: Général');
+      expect(text).not.toContain('**Draft**: true');
+    });
+  });
+
+  describe('set_section_translation', () => {
+    // Captures what actually reached Zendesk: the method, the path (locale
+    // spelling included) and the `translation` payload.
+    const captureWrites = () => {
+      const writes: Array<{ method: string; path: string; payload: Record<string, unknown> }> = [];
+      const record = async (method: string, request: Request) => {
+        const payload = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+        writes.push({
+          method,
+          path: new URL(request.url).pathname,
+          payload: (payload['translation'] as Record<string, unknown>) ?? {},
+        });
+      };
+      mswServer.use(
+        http.post(`${HC_BASE}/sections/:id/translations`, async ({ request }) => {
+          await record('POST', request.clone());
+          return HttpResponse.json({ translation: { ...MOCK_SECTION_TRANSLATION, locale: 'de' } });
+        }),
+        http.put(`${HC_BASE}/sections/:id/translations/:locale`, async ({ request, params }) => {
+          await record('PUT', request.clone());
+          return HttpResponse.json({
+            translation: {
+              ...MOCK_SECTION_TRANSLATION,
+              id: 7101,
+              locale: params['locale'] as string,
+              draft: false,
+            },
+          });
+        }),
+      );
+      return writes;
+    };
+
+    it('creates the translation when the locale has none, mapping name/description', async () => {
+      const writes = captureWrites();
+      const result = await findTool('set_section_translation').handler({
+        section_id: 600,
+        locale: 'de',
+        name: 'Häufige Fragen',
+        description: 'Oft gestellte Fragen',
+      });
+      expect(writes).toHaveLength(1);
+      expect(writes[0]?.method).toBe('POST');
+      expect(writes[0]?.payload).toEqual({
+        locale: 'de',
+        title: 'Häufige Fragen',
+        body: 'Oft gestellte Fragen',
+        // Creating publishes by default, so the section is actually reachable.
+        draft: false,
+      });
+      expect(result.content[0]?.text).toContain('Translation created for section #600 in "de"');
+      expect(result.content[0]?.text).toContain('(published)');
+    });
+
+    it('defaults the description to empty on creation rather than omitting it', async () => {
+      const writes = captureWrites();
+      await findTool('set_section_translation').handler({
+        section_id: 600,
+        locale: 'de',
+        name: 'Häufige Fragen',
+      });
+      expect(writes[0]?.payload).toEqual({
+        locale: 'de',
+        title: 'Häufige Fragen',
+        body: '',
+        draft: false,
+      });
+    });
+
+    it('refuses to create without a name, naming the section and the locale', async () => {
+      await expect(
+        findTool('set_section_translation').handler({ section_id: 600, locale: 'de' }),
+      ).rejects.toThrow(/section #600 has no "de" translation yet.*"name" is required/s);
+    });
+
+    it('updates an existing translation, sending only the fields passed', async () => {
+      const writes = captureWrites();
+      const result = await findTool('set_section_translation').handler({
+        section_id: 600,
+        locale: 'fr',
+        draft: false,
+      });
+      expect(writes).toHaveLength(1);
+      expect(writes[0]?.method).toBe('PUT');
+      // Publishing a draft must not blank the existing name or description.
+      expect(writes[0]?.payload).toEqual({ draft: false });
+      expect(result.content[0]?.text).toContain('Translation updated for section #600 in "fr"');
+      expect(result.content[0]?.text).toContain('(published)');
+    });
+
+    it('clears the description when an empty string is passed explicitly', async () => {
+      const writes = captureWrites();
+      await findTool('set_section_translation').handler({
+        section_id: 600,
+        locale: 'fr',
+        description: '',
+      });
+      expect(writes[0]?.payload).toEqual({ body: '' });
+    });
+
+    it("writes to Zendesk's spelling of the locale, not the caller's casing", async () => {
+      const writes = captureWrites();
+      await findTool('set_section_translation').handler({
+        section_id: 600,
+        locale: 'FR',
+        name: 'FAQ (fr)',
+      });
+      expect(writes[0]?.method).toBe('PUT');
+      expect(writes[0]?.path).toMatch(/\/sections\/600\/translations\/fr$/);
+    });
+
+    it('reports a translation left as a draft as not visible to end users', async () => {
+      mswServer.use(
+        http.put(`${HC_BASE}/sections/:id/translations/:locale`, () =>
+          HttpResponse.json({
+            translation: { ...MOCK_SECTION_TRANSLATION, locale: 'fr', draft: true },
+          }),
+        ),
+      );
+      const result = await findTool('set_section_translation').handler({
+        section_id: 600,
+        locale: 'fr',
+        draft: true,
+      });
+      expect(result.content[0]?.text).toContain('(draft, not visible to end users)');
+    });
+  });
+
+  describe('set_category_translation', () => {
+    it('creates the translation on the categories endpoint with the mapped fields', async () => {
+      let path = '';
+      let payload: Record<string, unknown> = {};
+      mswServer.use(
+        http.post(`${HC_BASE}/categories/:id/translations`, async ({ request }) => {
+          path = new URL(request.url).pathname;
+          const body = (await request.json()) as Record<string, unknown>;
+          payload = (body['translation'] as Record<string, unknown>) ?? {};
+          return HttpResponse.json({
+            translation: { ...MOCK_CATEGORY_TRANSLATION, locale: 'de', title: 'Allgemein' },
+          });
+        }),
+      );
+      const result = await findTool('set_category_translation').handler({
+        category_id: 800,
+        locale: 'de',
+        name: 'Allgemein',
+        draft: true,
+      });
+      expect(path).toMatch(/\/categories\/800\/translations$/);
+      expect(payload).toEqual({ locale: 'de', title: 'Allgemein', body: '', draft: true });
+      expect(result.content[0]?.text).toContain('Translation created for category #800 in "de"');
+    });
+
+    it('updates an existing category translation instead of creating a duplicate', async () => {
+      const result = await findTool('set_category_translation').handler({
+        category_id: 800,
+        locale: 'fr',
+        name: 'Général',
+      });
+      expect(result.content[0]?.text).toContain('Translation updated for category #800 in "fr"');
+    });
+
+    it('refuses to create without a name, naming the category', async () => {
+      await expect(
+        findTool('set_category_translation').handler({ category_id: 800, locale: 'de' }),
+      ).rejects.toThrow(/category #800 has no "de" translation yet/);
+    });
+  });
+
+  describe('find_translation_gaps', () => {
+    // The default fixtures give category 800 a published `fr` translation and
+    // section 600 a draft one, i.e. one gap of each interesting kind once the
+    // listing is widened.
+    const seedTree = (sectionIds: number[], categoryIds: number[]) => {
+      mswServer.use(
+        http.get(`${HC_BASE}/sections`, () =>
+          HttpResponse.json({
+            sections: sectionIds.map((id) => ({ ...MOCK_SECTION, id, name: `Section ${id}` })),
+            meta: { has_more: false, after_cursor: '' },
+            count: sectionIds.length,
+          }),
+        ),
+        http.get(`${HC_BASE}/categories`, () =>
+          HttpResponse.json({
+            categories: categoryIds.map((id) => ({
+              ...MOCK_CATEGORY,
+              id,
+              name: `Category ${id}`,
+            })),
+            meta: { has_more: false, after_cursor: '' },
+            count: categoryIds.length,
+          }),
+        ),
+      );
+    };
+
+    it('tells a missing translation apart from an unpublished draft', async () => {
+      seedTree([600, 601, 602], [800, 801]);
+      const result = await findTool('find_translation_gaps').handler({ locale: 'fr' });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('# Translation gaps — "fr"');
+      expect(text).toContain('**Section 600** (600) — draft translation (not published)');
+      expect(text).toContain('**Section 601** (601) — no translation');
+      // 602 and 800 have a published `fr` translation, so they are not gaps.
+      expect(text).not.toContain('(602)');
+      expect(text).not.toContain('(800)');
+      expect(text).toContain('**Category 801** (801) — no translation');
+      expect(text).toContain('3 node(s) need a published "fr" translation');
+      expect(text).toContain('set_section_translation');
+    });
+
+    it('reports the number of nodes actually scanned per level', async () => {
+      seedTree([600, 601, 602], [800, 801]);
+      const result = await findTool('find_translation_gaps').handler({ locale: 'fr' });
+      expect(result.content[0]?.text).toContain('## Sections (3 scanned)');
+      expect(result.content[0]?.text).toContain('## Categories (2 scanned)');
+    });
+
+    it('says so positively when nothing is missing', async () => {
+      seedTree([602], [800]);
+      const result = await findTool('find_translation_gaps').handler({ locale: 'fr' });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain(
+        'No gaps: all 1 category/ies and 1 section(s) scanned have a published "fr" translation',
+      );
+      expect(text).not.toContain('node(s) need a published');
+    });
+
+    it('narrows the listing to one category when category_id is passed', async () => {
+      const paths: string[] = [];
+      seedTree([600], [800, 801]);
+      mswServer.use(
+        http.get(`${HC_BASE}/categories/:cid/sections`, ({ request }) => {
+          paths.push(new URL(request.url).pathname);
+          return HttpResponse.json({
+            sections: [{ ...MOCK_SECTION, id: 601, name: 'Section 601' }],
+            meta: { has_more: false, after_cursor: '' },
+            count: 1,
+          });
+        }),
+      );
+      const result = await findTool('find_translation_gaps').handler({
+        locale: 'fr',
+        category_id: 801,
+      });
+      const text = result.content[0]?.text ?? '';
+      expect(paths.some((p) => p.endsWith('/categories/801/sections'))).toBe(true);
+      expect(text).toContain('## Categories (1 scanned)');
+      expect(text).toContain('**Category 801** (801) — no translation');
+      expect(text).not.toContain('(800)');
+    });
+
+    it('warns when the audited locale is not active, instead of crying gap', async () => {
+      seedTree([600], [800]);
+      const result = await findTool('find_translation_gaps').handler({ locale: 'es' });
+      const text = result.content[0]?.text ?? '';
+      // MOCK_LOCALES is en-us + fr.
+      expect(text).toContain('"es" is not an active locale');
+      expect(text).toContain('en-us, fr');
+      expect(text).toContain('**Section 600** (600) — no translation');
+    });
+
+    it('does not warn for an active locale spelled with a different case', async () => {
+      seedTree([600], [800]);
+      const result = await findTool('find_translation_gaps').handler({ locale: 'FR' });
+      expect(result.content[0]?.text).not.toContain('is not an active locale');
+    });
+
+    it('caps the scan and names what it left out', async () => {
+      seedTree(
+        Array.from({ length: 61 }, (_, i) => 1000 + i),
+        [800],
+      );
+      const result = await findTool('find_translation_gaps').handler({ locale: 'fr' });
+      const text = result.content[0]?.text ?? '';
+      // 1 category consumes one slot of the 60-node budget, leaving 59 sections.
+      expect(text).toContain('## Sections (59 scanned)');
+      expect(text).toContain('the scan stopped at its 60-node cap');
+      expect(text).toContain('covering 1/1 categories and 59/61 sections');
+      expect(text).toContain('ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES');
+    });
+
+    it('flags a tree too large to enumerate from a single listing page', async () => {
+      mswServer.use(
+        http.get(`${HC_BASE}/sections`, () =>
+          HttpResponse.json({
+            sections: [MOCK_SECTION],
+            meta: { has_more: true, after_cursor: 'next' },
+            count: 1,
+          }),
+        ),
+      );
+      const result = await findTool('find_translation_gaps').handler({ locale: 'fr' });
+      expect(result.content[0]?.text).toContain('only the first page of each was considered');
+    });
+
+    it('asks Zendesk for the audited locale only', async () => {
+      const queries: string[] = [];
+      seedTree([600], [800]);
+      mswServer.use(
+        http.get(`${HC_BASE}/sections/:id/translations`, ({ request }) => {
+          queries.push(new URL(request.url).search);
+          return HttpResponse.json({ translations: [] });
+        }),
+      );
+      await findTool('find_translation_gaps').handler({ locale: 'fr' });
+      expect(queries).toEqual(['?locales=fr']);
     });
   });
 

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -425,6 +425,14 @@ describe('help center tools', () => {
       expect(writes[0]?.path).toMatch(/\/sections\/600\/translations\/fr$/);
     });
 
+    it('refuses a no-op update rather than reporting a write that changed nothing', async () => {
+      const writes = captureWrites();
+      await expect(
+        findTool('set_section_translation').handler({ section_id: 600, locale: 'fr' }),
+      ).rejects.toThrow(/Nothing to write.*already has a "fr" translation/s);
+      expect(writes).toHaveLength(0);
+    });
+
     it('reports a translation left as a draft as not visible to end users', async () => {
       mswServer.use(
         http.put(`${HC_BASE}/sections/:id/translations/:locale`, () =>
@@ -542,10 +550,16 @@ describe('help center tools', () => {
       expect(text).not.toContain('node(s) need a published');
     });
 
-    it('narrows the listing to one category when category_id is passed', async () => {
+    it('narrows the audit to one category, fetching that category directly', async () => {
       const paths: string[] = [];
       seedTree([600], [800, 801]);
       mswServer.use(
+        http.get(`${HC_BASE}/categories/:id`, ({ request, params }) => {
+          paths.push(new URL(request.url).pathname);
+          return HttpResponse.json({
+            category: { ...MOCK_CATEGORY, id: Number(params['id']), name: 'Legal' },
+          });
+        }),
         http.get(`${HC_BASE}/categories/:cid/sections`, ({ request }) => {
           paths.push(new URL(request.url).pathname);
           return HttpResponse.json({
@@ -560,10 +574,24 @@ describe('help center tools', () => {
         category_id: 801,
       });
       const text = result.content[0]?.text ?? '';
+      // The scoped category is read on its own, not filtered out of a capped
+      // listing that could omit it entirely.
+      expect(paths).toContain('/api/v2/help_center/categories/801');
       expect(paths.some((p) => p.endsWith('/categories/801/sections'))).toBe(true);
       expect(text).toContain('## Categories (1 scanned)');
-      expect(text).toContain('**Category 801** (801) — no translation');
+      expect(text).toContain('**Legal** (801) — no translation');
+      expect(text).toContain('**Section 601** (601) — no translation');
       expect(text).not.toContain('(800)');
+      expect(text).not.toContain('(600)');
+    });
+
+    it('does not claim an empty level is fully translated', async () => {
+      seedTree([], [800]);
+      const result = await findTool('find_translation_gaps').handler({ locale: 'fr' });
+      const text = result.content[0]?.text ?? '';
+      expect(text).toContain('## Sections (0 scanned)');
+      expect(text).toContain('_(none to scan at this level)_');
+      expect(text).not.toContain('every one scanned has a published translation\n\n_(none to');
     });
 
     it('warns when the audited locale is not active, instead of crying gap', async () => {


### PR DESCRIPTION
## Summary

Translations were only reachable at the article level, so publishing an article in a second locale left it unreachable: readers browse the tree, and a translated article sat under a section title that only existed in the source locale. This adds five `help_center` tools that read, audit and write section and category translations, so "translate the article in both locales in the same pass" also holds for the tree it lives in.

## Linked issue

Closes #224

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## What is added

| Tool | Mode | Shape |
|------|------|-------|
| `list_section_translations` | read | `{ section_id }` → per locale: localized name, description set/empty, draft state |
| `list_category_translations` | read | `{ category_id }` → same |
| `find_translation_gaps` | read | `{ locale, category_id? }` → every node with *no translation* vs *draft translation* |
| `set_section_translation` | write | `{ section_id, locale, name?, description?, draft? }` → create-or-update |
| `set_category_translation` | write | `{ category_id, locale, name?, description?, draft? }` → create-or-update |

The `set_*` tools probe the node's translations, then `POST` when the locale is absent and `PUT` when it exists, sending **only** the fields passed. So publishing a draft is a single `draft: false`, and omitting `description` never blanks an existing one.

`find_translation_gaps` fetches `/locales` plus the two listings, then one `translations?locales=…` request per node, in waves of 5, bounded by `ZENDESK_TRANSLATION_GAP_SCAN_MAX_NODES` (default 60). Categories are scanned first; the report names what it left unscanned. An inactive locale is flagged as a warning rather than reported as a tree-wide catastrophe.

The tools speak `name` / `description` — the vocabulary `list_sections` and `list_categories` already return — and map onto the API's `title` / `body`, so a caller never has to know those two fields change meaning on a section or a category.

**Why the audit probes each node instead of diffing two listings.** A locale-filtered listing answers neither question: a node with no translation in the locale is absent from it *without saying why*, and a node whose translation is an unpublished **draft** is still returned, under the draft's own name (measured with an admin token during validation — see below). So absence there is ambiguous and presence does not mean published. The listing-diff design would have been far cheaper and was considered; it would also have missed every draft-translated node, i.e. exactly the case #224 was opened about. The per-node fan-out is the price of the honest answer, which is what the cap and the wave size exist to bound.

## Notes for the reviewer (human or AI)

**Two deliberate departures from the shape proposed in the issue**, both following the usage-first rule in `AGENTS.md` (also flagged on the issue before starting):

1. **One upsert per level instead of a `create_*` / `update_*` pair.** A split pair forces a listing call before every write, or eats the `400 "translation already exists"` the API returns on a duplicate `POST`. Two write tools instead of four, and no guaranteed error path. The cost is a naming divergence from `create_article_translation` / `update_article_translation`.
2. **The gap report is its own opt-in tool, not a `zendesk-hc://topology` section** (which the issue suggested). Topology is ambient context, auto-read by clients and cached per session, so a per-locale scan there would make every read pay for it. `docs/help-center-context.md` is therefore unchanged.

Kept from the issue: separate tools per level, mirroring `list_sections` / `list_categories`, rather than one tool with a `type` discriminator that would add a wrong-type-404 failure mode.

**Sections and categories are treated as iso** — same endpoint family, same translation object, one shared `upsertNodeTranslation`, parameterised by kind rather than written twice. The API reference backs this: identical endpoint shapes for list/show/create/update, the same Translation object with `title` mandatory on both, and `name`/`description` documented identically on the Section and Category objects. The rule is stated on `TreeNodeKind`, and the unit tests enforce it by running every read and write case over both levels from one table (12/12 parity), so a new case cannot land on one level only.

**API surface confirmed** against the [Translations reference](https://developer.zendesk.com/api-reference/help_center/help-center-api/translations/): the endpoints, `title`/`body`/`draft`/`locale` writable, `title` mandatory on create, the `locales` filter on list endpoints. There is **no** missing-translations endpoint for sections or categories (only `articles/{id}/translations/missing`), which is why the audit has to fan out. That `title` is the localized *name* and `body` the localized *description* is **not** documented for either level; validation scenario **S1** confirmed it on a live section.

**Commit trail** — everything after the first commit is a review or validation pass, not new feature work:

- `2276cb8`: the scoped audit reads its category directly (filtering a one-page listing silently reported "0 categories scanned" for a category further down); a no-op update is refused instead of reported as a write; an empty level no longer claims to be fully translated.
- `aee3d5e`: the scan probes in waves of 5 instead of firing up to 60 requests at once (Zendesk caps concurrent requests per account, there is no retry here, and one 429 discarded the whole audit — follows the `VIEW_COUNT_BATCH` pattern in `tickets.ts`); a level the cap never reached is no longer rendered like a genuinely empty one; the `locales` filter value is normalized so it cannot disagree with the case-insensitive local comparison.
- `2140595`: corrects the overclaim S3/S7 caught (below). Wording only, no logic.
- `1267a5f`: both-levels test table, so nothing is asserted on sections alone; category write over the namespace proxy in the integration suite.
- `2194ad5`: records the untaken sideload route (#226) next to the cost it would remove.

**Mutation gate** reports `No changed lines inside the mutate scope` — `stryker.config.mjs` scopes mutation to `src/auth`, `src/client`, `src/routing`, `src/utils` (minus `formatting.ts`) and `src/config.ts`, none of which this PR touches.

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #224`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally (705 tests)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a review pass on the diff and addressed its findings — see `2276cb8` and `aee3d5e`
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
- [x] If the change has **MCP-runtime-observable** behaviour: this PR carries a `## Functional validation plan` below, executed by an independent validator, reports posted as PR comments

## Functional validation plan

### Validation outcome — green

Independently validated end-to-end against a live tenant, twice.

| Run | Commit | Result |
|-----|--------|--------|
| 1 | `aee3d5e` | [report](https://github.com/fruggr/zendesk-mcp-server/pull/225#issuecomment-5255363078) — 11/13 OK, **S3 + S7 FAILED** on one shared point, S12 write half skipped |
| 2 | `2140595` | [report](https://github.com/fruggr/zendesk-mcp-server/pull/225#issuecomment-5255534401) — **12/13 OK**, S12 write half skipped |

**What run 1 caught.** `list_sections({ locale })` **does** return sections whose translation in that locale is an unpublished draft (admin token), rendered under the draft name. Three tool descriptions, two code comments and the `docs/configuration.md` cost note claimed such a node was omitted — which would lead an agent to read "listed ⇒ published", wrong on exactly the path these tools address. The other half of the claim, that a node with *no* translation is omitted, was verified exhaustively across all 45 sections and 13 categories. Fixed in `2140595`, wording only. **The implementation never depended on the false half**: the audit reads the draft flag per node rather than diffing the two listings, a choice made in the plan precisely so as not to rest on undocumented listing behaviour — a listing-diff audit would have missed every draft-translated node.

S3 and S7 in the table below are **amended**: their original wording expected a draft-translated node to be *absent* from the locale listing, which is what run 1 disproved. A re-run should expect such a node to remain listed.

**Later commits are not covered by run 2, and do not need to be.** `git diff 2140595 2194ad5 -- src/` with comment lines filtered out is empty: everything since is tests, an integration scenario and comments. Nothing run 2 measured can have moved.

**Still unvalidated, accepted:** S12's write half. There is no expendable category on this production tenant, so the category *write* path has unit and integration coverage only. `1267a5f` brings it to full parity with the section path, but those assertions run against MSW — they prove the request built and the text rendered, not that Zendesk answers `POST /categories/{id}/translations` like its section twin. The API reference says they are one endpoint family with an identical object; that is documentation, not a measurement. First thing to suspect if a category write ever misbehaves.

**Follow-up filed:** #226 — both list endpoints document a `translations` sideload that could collapse the per-node fan-out into the two listings already fetched. Not taken here: the docs never say whether a sideloaded translation carries `draft`, which is the whole point, and settling it needs one live call.

> Placeholders below are written `{like_this}` — substitute before calling.

### Context

Five new tools on the `help_center` namespace, exercised by calling `mcp__zendesk-local__list_section_translations`, `list_category_translations`, `find_translation_gaps`, `set_section_translation` and `set_category_translation` directly. Nothing about transports, auth or the resource surface changed, so the HTTP transport and the OAuth paths need no coverage here; `zendesk-hc://topology` is deliberately untouched and its output must be **identical** to `main`.

Unit tests already cover the rendering, the POST-vs-PUT decision, the payload built on each path, the cap arithmetic, the wave bound and the inactive-locale warning against MSW mocks. What they cannot cover — and what this plan is for — is whether the real Zendesk API agrees with our reading of it on two points: that `title`/`body` on a section/category translation really are the name and the description, and that `draft` behaves as the publish switch.

### Setup & prerequisites

- No build, checkout or credential work: the environment is on this branch with the server running and authenticated. Record `git rev-parse HEAD` and put it in the report.
- **Pick a throwaway section** for the write scenarios — one whose localized name you may change. Get candidates from `zendesk-hc://topology` or `list_sections`. Note its id, and capture its current translations (`list_section_translations`) **before touching anything**, so the original state can be restored and pasted into the report.
- **Pick the target locale**, `{locale}`: a non-default active locale from `zendesk-hc://topology`.
- Everything is observable in the tool output; no log level to raise.
- A `403` on the write scenarios is a `BLOCKED` finding — report it, do not go looking for another token.

### Scenarios

| id | Validates | Manipulation / call | Expected observable |
|----|-----------|---------------------|---------------------|
| **S1** | **`title` is the name, `body` the description** — the assumption the whole mapping rests on | `list_sections` (default locale); note a section's name and description. Then `list_section_translations` with that `section_id` | The default-locale entry's `**Name**` equals the name from `list_sections`, and `**Description**` reads `set` when the section has a description, `empty` when it has none. **If `Name` shows anything other than the section name, stop and report — the rest of the plan is invalid.** |
| **S2** | Reads report draft state per locale | `list_section_translations` and `list_category_translations` on a section and a category translated in `{locale}` | One entry per locale, each with `Name`, `Description`, `Draft`, `Updated`. `Draft` is `false` for a published translation. No article-style `**Title**` label anywhere. |
| **S3** | The audit finds real gaps and classifies them | `find_translation_gaps({ locale: "{locale}" })` | A `# Translation gaps` report with `## Categories (N scanned)` / `## Sections (N scanned)`. Cross-check against `list_sections({ locale: "{locale}" })`: every node reported as *no translation* is **absent** from it; every node reported as *draft translation* **may still be present** (under its draft name); every node **not** reported is present. A node reported *no translation* yet present in the listing, or an unreported node missing from it, is a FAIL — paste both listings side by side. |
| **S4** | The audit's classification matches the per-node read | For one node reported *draft translation* (if any) and one reported *no translation*, call `list_section_translations` on it | *draft* ⇒ an entry for `{locale}` with `Draft: true`. *no translation* ⇒ no entry for `{locale}` at all. |
| **S5** | Create path: a locale with no translation | On the throwaway section: `set_section_translation({ section_id: {id}, locale: "{locale}", name: "{a recognizable test name}", description: "validation probe" })` | `Translation created for section #{id} in "{locale}" (published).` Then `list_section_translations` shows a new `{locale}` entry with `Draft: false`, `Description: set`. Then the section appears in `list_sections({ locale: "{locale}" })` under the new name — **this is the user-facing point of the whole PR**. |
| **S6** | Update path leaves omitted fields alone | `set_section_translation({ section_id: {id}, locale: "{locale}", name: "{a different test name}" })` — no `description`, no `draft` | `Translation updated …`, the name changes, and `Description` is **still** `set` (the description from S5 survived). |
| **S7** | `draft` is the publish switch, both ways | `set_section_translation({ section_id: {id}, locale: "{locale}", draft: true })`, then the same with `draft: false` | First call: `(draft, not visible to end users)`, `Draft: true` on the per-node read, and `find_translation_gaps` reports the node as *draft translation (not published)*. The node **stays** in `list_sections({ locale: "{locale}" })`, under the draft's own name — that is the documented behaviour, not a failure. Second call: `(published)`, and the node drops out of the audit. |
| **S8** | No-op writes are refused, not faked | `set_section_translation({ section_id: {id}, locale: "{locale}" })` — nothing else | An error saying `Nothing to write`, naming the locale. **No** "Translation updated" message. |
| **S9** | Creation requires a name | `set_section_translation({ section_id: {id}, locale: "{an active locale this section has no translation in}" })` | An error saying the section has no translation in that locale yet and that `name` is required. Nothing is created — confirm with `list_section_translations`. |
| **S10** | Scoping reads the category itself | `find_translation_gaps({ locale: "{locale}", category_id: {a real category id} })`, then again with a **nonexistent** category id | First: exactly `## Categories (1 scanned)`, that category only, and its own sections under `## Sections`. Second: a Zendesk `404`-shaped error, **not** an empty report. |
| **S11** | Inactive locale is flagged, not reported as catastrophe | `find_translation_gaps({ locale: "zz" })` | A warning that `"zz"` is not an active locale, naming the real active locales, above the (all-missing) listing. |
| **S12** | Category write path | `set_category_translation` on a category — same create-then-publish shape as S5/S7. If no category is expendable, run only the read half and mark the write half `SKIPPED` with the reason | Same messages with `category #{id}`, and the category becomes visible in `list_categories({ locale: "{locale}" })`. |
| **S13** | Nothing else regressed | `zendesk-hc://topology`, `list_sections`, `list_categories`, `list_article_translations`, `compare_translations` | Output shape unchanged from `main` — in particular topology carries **no** new translation-coverage section. |

**Cleanup.** After S5–S7 and S12, restore the throwaway node with `set_section_translation` back to the name captured in Setup. If the `{locale}` translation did not exist beforehand, say so in the report: there is no delete-translation tool here, so a leftover test translation must be flagged explicitly for manual removal in Guide.

### Long-running behaviours

None. No timers, no TTL, no polling. The two bounded-cost paths (the 60-node cap and the wave size) are covered by unit tests — the wave test observes peak in-flight requests — and neither needs a 60+-node Help Center to validate.

### Priorities

Do **S1 first and block on it** — it is the ground-truth check for the field mapping every other scenario assumes. Then **S3, S5, S7**: the audit-then-publish loop is the actual user story from the issue. **S6, S8, S9, S10** are the guard rails. **S2, S4, S11, S12, S13** last.

### Reporting instructions

Post a PR comment (English) with: the commit SHA tested, one line per scenario id with `OK` / `FAIL` / `BLOCKED` / `SKIPPED` plus the observed evidence (paste the relevant tool output, trimmed), an explicit note on whether the throwaway node was restored, and a one-line overall verdict. For any FAIL, include both what you expected and what you got.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tools to list, create, update, and publish Help Center translations for sections and categories.
  - Added translation-gap audits identifying missing and draft translations.
  - Added locale filtering, scoped audits, and scan-limit reporting.
- **Documentation**
  - Documented translation tools and configurable scan limits.
- **Bug Fixes**
  - Improved locale handling, validation, and preservation of existing translation values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->