### PR TITLE
ci: push the release commit with a GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,34 +8,22 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+# Every write in this job goes through the App installation token minted
+# below, so the built-in GITHUB_TOKEN only ever reads the tree for checkout.
+# `id-token: write` is what NPM Trusted Publishing and the MCP registry login
+# exchange for their OIDC credentials.
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
   id-token: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    # The whole pipeline runs in about a minute. A wedged step should fail
+    # rather than hold the runner for the 6-hour default, which would also
+    # outlive the App installation token minted below.
+    timeout-minutes: 30
     steps:
-      # semantic-release pushes the `chore(release)` commit straight to main,
-      # and main requires status checks that only ever report on a pull
-      # request — a direct push can never satisfy them, so the built-in
-      # GITHUB_TOKEN is rejected with GH006. This App is on the branch
-      # ruleset's bypass list; its installation token is what gets past it.
-      # Short-lived (1h) and revoked in post-job, unlike a PAT.
-      - uses: actions/create-github-app-token@v3
-        id: app-token
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          # Without these the token inherits every permission the installation
-          # holds. Pinning them stops a later permission grant to the App from
-          # silently widening what a release run can do.
-          permission-contents: write
-          permission-issues: write
-          permission-pull-requests: write
-
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -86,6 +74,26 @@ jobs:
         id: before
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
+      # main is protected by a ruleset that requires a pull request *and*
+      # status checks which only ever report on one, so a direct push of the
+      # `chore(release)` commit is refused twice over and the built-in
+      # GITHUB_TOKEN comes back with GH006. This App is on that ruleset's
+      # bypass list, and a bypass actor skips every rule in it. The token is
+      # minted here rather than at the top of the job because it lives one hour
+      # and is revoked in post-job: install, test and build must not eat into
+      # that window.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Without these the token inherits every permission the installation
+          # holds. Pinning them stops a later permission grant to the App from
+          # silently widening what a release run can do.
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - run: pnpm exec semantic-release
         env:
           # The App token, not secrets.GITHUB_TOKEN: it authenticates both the
@@ -95,9 +103,12 @@ jobs:
           # third-party identity, so unlike the repository-generated
           # GITHUB_TOKEN its pushes *do* start workflow runs. What keeps this
           # release commit from starting another Release run is the `[skip ci]`
-          # in its message, which suppresses `push` and `pull_request`
-          # workflows — the only events any workflow here listens on. Nothing
-          # listens on `release`, so publishing one starts nothing either.
+          # in its message (asserted by tests/unit/releaserc-skip-ci.test.ts,
+          # since nothing else would catch its removal). That marker only
+          # suppresses `push` and `pull_request`, so it is no help against the
+          # `pull_request_target` and `workflow_dispatch` triggers elsewhere in
+          # this repo — neither of which a push can raise. Nothing listens on
+          # `release` either, so publishing one starts nothing.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Auth to npm is via NPM Trusted Publishing (OIDC), configured on
           # npmjs.com against this workflow file. The `id-token: write`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Without these the token inherits every permission the installation
+          # holds. Pinning them stops a later permission grant to the App from
+          # silently widening what a release run can do.
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@v7
         with:
@@ -85,10 +91,13 @@ jobs:
           # The App token, not secrets.GITHUB_TOKEN: it authenticates both the
           # `git push HEAD:main` of @semantic-release/git (which needs the
           # ruleset bypass) and the GitHub release + issue comments of
-          # @semantic-release/github. A side effect worth knowing: pushes made
-          # with an App token don't trigger workflows, which is the behaviour
-          # we want here and is belt-and-braces with the `[skip ci]` in the
-          # release commit message.
+          # @semantic-release/github. Note that an App installation token is a
+          # third-party identity, so unlike the repository-generated
+          # GITHUB_TOKEN its pushes *do* start workflow runs. What keeps this
+          # release commit from starting another Release run is the `[skip ci]`
+          # in its message, which suppresses `push` and `pull_request`
+          # workflows — the only events any workflow here listens on. Nothing
+          # listens on `release`, so publishing one starts nothing either.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Auth to npm is via NPM Trusted Publishing (OIDC), configured on
           # npmjs.com against this workflow file. The `id-token: write`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,18 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # semantic-release pushes the `chore(release)` commit straight to main,
+      # and main requires status checks that only ever report on a pull
+      # request — a direct push can never satisfy them, so the built-in
+      # GITHUB_TOKEN is rejected with GH006. This App is on the branch
+      # ruleset's bypass list; its installation token is what gets past it.
+      # Short-lived (1h) and revoked in post-job, unlike a PAT.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -70,7 +82,14 @@ jobs:
 
       - run: pnpm exec semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The App token, not secrets.GITHUB_TOKEN: it authenticates both the
+          # `git push HEAD:main` of @semantic-release/git (which needs the
+          # ruleset bypass) and the GitHub release + issue comments of
+          # @semantic-release/github. A side effect worth knowing: pushes made
+          # with an App token don't trigger workflows, which is the behaviour
+          # we want here and is belt-and-braces with the `[skip ci]` in the
+          # release commit message.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Auth to npm is via NPM Trusted Publishing (OIDC), configured on
           # npmjs.com against this workflow file. The `id-token: write`
           # permission above is all that's needed — no NPM_TOKEN secret.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,11 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          # `client-id`, not the deprecated `app-id`. A variable rather than a
+          # secret because the Client ID is public: `GET /apps/{slug}` serves it
+          # to anyone. The private key is the credential, and it alone lives in
+          # this job's environment.
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           # Without these the token inherits every permission the installation
           # holds. Pinning them stops a later permission grant to the App from

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # The App's private key lives in this environment, not in repository
+    # secrets, and the environment only admits workflows running on `main`.
+    # Without that boundary any branch could mint the App token and push
+    # straight to `main`, since the App bypasses every rule in the ruleset.
+    environment: release
     # The whole pipeline runs in about a minute. A wedged step should fail
     # rather than hold the runner for the 6-hour default, which would also
     # outlive the App installation token minted below.

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -116,9 +116,8 @@ explicitly in `plugins` instead.
 
 > **This is wired.** `.github/workflows/mutation.yml` implements it, backed by
 > `stryker.config.mjs`, `scripts/mutation-scope.mjs` and the `pnpm test:mutation`
-> script. The gate runs on every pull request but **does not block a merge until
-> branch protection marks the `Changed lines` check required** — flip that once
-> one real PR has been through it.
+> script. The gate runs on every pull request and **does block a merge**: the
+> ruleset on `main` lists `Changed lines` as a required status check.
 
 The Vitest runner only supports `threads: true` and sets the pool itself,
 overriding this repo's default (`forks`). The suite passes under both — 10.2 s

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -194,14 +194,18 @@ These cannot be versioned; a repository (or org) admin must apply them **once**:
    - Repository permissions: Contents write for the push, the tag and the
      release; Issues and Pull requests write for the comments
      `@semantic-release/github` posts. No webhook, installed on this repo only.
-   - `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` live in a **`release`
-     environment** whose deployment branch policy admits `main` only, not in
-     repository secrets. `release.yml` names that environment and exchanges them
-     for a one-hour installation token through `actions/create-github-app-token`
-     (revoked in post-job). The boundary is the point: repository secrets are
-     readable by a workflow run on any branch, and the App bypasses every rule
-     in the ruleset, so a branch that could read the key could push anything to
-     `main` unchecked.
+   - The private key goes in `RELEASE_APP_PRIVATE_KEY`, a secret of a **`release`
+     environment** whose deployment branch policy admits `main` only, never a
+     repository secret. `release.yml` names that environment and exchanges the
+     key for a one-hour installation token through
+     `actions/create-github-app-token` (revoked in post-job). The boundary is the
+     point: repository secrets are readable by a workflow run on any branch, and
+     the App bypasses every rule in the ruleset, so a branch that could read the
+     key could push anything to `main` unchecked.
+   - The App's Client ID goes in the repository variable
+     `RELEASE_APP_CLIENT_ID`. It is public (`GET /apps/{slug}` serves it to
+     anyone), so it is a variable, not a secret. Use it with the action's
+     `client-id` input; `app-id` still works but is deprecated.
    - The ruleset grants no bypass to admins, so there is no manual fallback:
      a maintainer with a PAT gets the same `GH006` as `GITHUB_TOKEN`. Recovering
      a stuck release means fixing the App path, or temporarily adding a bypass

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -169,11 +169,32 @@ These cannot be versioned; a repository (or org) admin must apply them **once**:
    - Allow auto-merge ✓
    - Allow squash merging ✓
    - Default to PR title for squash merges ✓ (**critical**: without this, the `fix(security):` prefix is not carried into the squash commit on `main`, and no release is published)
-3. **Settings → Branches → Branch protection rules** for `main`:
-   - Require status checks to pass before merging ✓
-   - Required check: `CI / build-and-test`
-   - (Without this protection, `platformAutomerge` would merge the PR before CI finishes.)
-4. **Settings → Code security → Dependabot security updates**: OFF. Renovate takes over via `vulnerabilityAlerts` (GHSA) + `osvVulnerabilityAlerts` (Google OSV), and we avoid duplicate PRs.
+3. **Settings → Rules → Rulesets**: one ruleset on `main` carrying every rule.
+   - Require a pull request before merging (squash only); required status checks
+     `build-and-test`, `Changed lines` and `CodeQL`. (Without the status-check
+     rule, `platformAutomerge` would merge the PR before CI finishes.)
+   - Bypass list: the `fruggr-release-bot` App (point 4).
+   - Two constraints explain that shape. A bypass actor skips the rules of the
+     ruleset it is listed on and nothing else, so splitting the rules over two
+     rulesets means maintaining two bypass entries. And the rules cannot live in
+     a classic branch protection rule, which has no bypass list at all: the
+     `chore(release)` commit `semantic-release` pushes to `main` gets refused
+     with `GH006`, since `build-and-test` and `Changed lines` only run on
+     `pull_request` and no check can report on a commit the remote just refused.
+     The `[skip ci]` marker does not help, because rulesets ignore it.
+4. **A dedicated GitHub App, `fruggr-release-bot`**, on that bypass list:
+   - Repository permissions: Contents write for the push, the tag and the
+     release; Issues and Pull requests write for the comments
+     `@semantic-release/github` posts. No webhook, installed on this repo only.
+   - Repo secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`, which
+     `release.yml` exchanges for a one-hour installation token through
+     `actions/create-github-app-token` (revoked in post-job).
+   - An admin PAT would also clear the ruleset while `enforce_admins` is off, at
+     the cost of a long-lived secret tied to one person. If required signed
+     commits are ever enabled, remember that `semantic-release` pushes through
+     the git CLI and signs nothing, so that rule has to sit in the bypassed
+     ruleset too.
+5. **Settings → Code security → Dependabot security updates**: OFF. Renovate takes over via `vulnerabilityAlerts` (GHSA) + `osvVulnerabilityAlerts` (Google OSV), and we avoid duplicate PRs.
 
 ## Pause or disable
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -194,9 +194,14 @@ These cannot be versioned; a repository (or org) admin must apply them **once**:
    - Repository permissions: Contents write for the push, the tag and the
      release; Issues and Pull requests write for the comments
      `@semantic-release/github` posts. No webhook, installed on this repo only.
-   - Repo secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`, which
-     `release.yml` exchanges for a one-hour installation token through
-     `actions/create-github-app-token` (revoked in post-job).
+   - `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` live in a **`release`
+     environment** whose deployment branch policy admits `main` only, not in
+     repository secrets. `release.yml` names that environment and exchanges them
+     for a one-hour installation token through `actions/create-github-app-token`
+     (revoked in post-job). The boundary is the point: repository secrets are
+     readable by a workflow run on any branch, and the App bypasses every rule
+     in the ruleset, so a branch that could read the key could push anything to
+     `main` unchecked.
    - The ruleset grants no bypass to admins, so there is no manual fallback:
      a maintainer with a PAT gets the same `GH006` as `GITHUB_TOKEN`. Recovering
      a stuck release means fixing the App path, or temporarily adding a bypass

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -170,18 +170,26 @@ These cannot be versioned; a repository (or org) admin must apply them **once**:
    - Allow squash merging ✓
    - Default to PR title for squash merges ✓ (**critical**: without this, the `fix(security):` prefix is not carried into the squash commit on `main`, and no release is published)
 3. **Settings → Rules → Rulesets**: one ruleset on `main` carrying every rule.
-   - Require a pull request before merging (squash only); required status checks
-     `build-and-test`, `Changed lines` and `CodeQL`. (Without the status-check
-     rule, `platformAutomerge` would merge the PR before CI finishes.)
-   - Bypass list: the `fruggr-release-bot` App (point 4).
+   Five of them, and re-creating the ruleset means re-creating all five:
+   - Require a pull request before merging, squash the only allowed method,
+     zero required approvals, conversation resolution required.
+   - Required status checks `build-and-test`, `Changed lines` and `CodeQL`, with
+     "require branches to be up to date" on. (Without the status-check rule,
+     `platformAutomerge` would merge the PR before CI finishes; without the
+     up-to-date policy, a PR behind `main` can auto-merge on stale green checks.)
+   - Restrict deletions, and block force pushes.
+   - Bypass list: the `fruggr-release-bot` App (point 4), bypass mode "always".
+     Not "pull request" — that mode would still force the release commit
+     through a PR, which is the thing being avoided.
    - Two constraints explain that shape. A bypass actor skips the rules of the
      ruleset it is listed on and nothing else, so splitting the rules over two
      rulesets means maintaining two bypass entries. And the rules cannot live in
      a classic branch protection rule, which has no bypass list at all: the
      `chore(release)` commit `semantic-release` pushes to `main` gets refused
-     with `GH006`, since `build-and-test` and `Changed lines` only run on
-     `pull_request` and no check can report on a commit the remote just refused.
-     The `[skip ci]` marker does not help, because rulesets ignore it.
+     with `GH006`, both by the pull-request rule and by the status checks, since
+     `build-and-test` and `Changed lines` only run on `pull_request` and no
+     check can report on a commit the remote just refused. Neither rulesets nor
+     classic protection honour `[skip ci]`; only a bypass actor gets through.
 4. **A dedicated GitHub App, `fruggr-release-bot`**, on that bypass list:
    - Repository permissions: Contents write for the push, the tag and the
      release; Issues and Pull requests write for the comments
@@ -189,11 +197,12 @@ These cannot be versioned; a repository (or org) admin must apply them **once**:
    - Repo secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`, which
      `release.yml` exchanges for a one-hour installation token through
      `actions/create-github-app-token` (revoked in post-job).
-   - An admin PAT would also clear the ruleset while `enforce_admins` is off, at
-     the cost of a long-lived secret tied to one person. If required signed
-     commits are ever enabled, remember that `semantic-release` pushes through
-     the git CLI and signs nothing, so that rule has to sit in the bypassed
-     ruleset too.
+   - The ruleset grants no bypass to admins, so there is no manual fallback:
+     a maintainer with a PAT gets the same `GH006` as `GITHUB_TOKEN`. Recovering
+     a stuck release means fixing the App path, or temporarily adding a bypass
+     actor. If required signed commits are ever enabled, remember that
+     `semantic-release` pushes through the git CLI and signs nothing, so that
+     rule has to sit in the bypassed ruleset too.
 5. **Settings → Code security → Dependabot security updates**: OFF. Renovate takes over via `vulnerabilityAlerts` (GHSA) + `osvVulnerabilityAlerts` (Google OSV), and we avoid duplicate PRs.
 
 ## Pause or disable

--- a/tests/unit/releaserc-skip-ci.test.ts
+++ b/tests/unit/releaserc-skip-ci.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guard for the release loop-breaker.
+ *
+ * `release.yml` authenticates as a GitHub App so it can push the
+ * `chore(release)` commit past the ruleset on `main`. An App installation token
+ * is a third-party identity, so its pushes DO start workflow runs — the
+ * platform exemption that makes the built-in `GITHUB_TOKEN` safe here does not
+ * apply to it. The only thing stopping every release from re-triggering Release
+ * (and Mutation testing's full-scope job) is the `[skip ci]` marker in the
+ * `@semantic-release/git` commit message template.
+ *
+ * Nothing else would catch its removal. The release itself would still succeed,
+ * just pay for a duplicate pipeline on every version, with the cause several
+ * files away from the symptom. Hence this assertion. Why the App token is
+ * needed at all: `docs/release-automation.md` (Admin prerequisites).
+ */
+
+const rc = JSON.parse(readFileSync(new URL('../../.releaserc.json', import.meta.url), 'utf8')) as {
+  plugins: unknown[];
+};
+
+const gitPluginConfig = rc.plugins.find(
+  (p): p is [string, Record<string, unknown>] =>
+    Array.isArray(p) && p[0] === '@semantic-release/git',
+)?.[1];
+
+describe('.releaserc.json @semantic-release/git', () => {
+  it('configures a commit message template', () => {
+    expect(gitPluginConfig).toBeDefined();
+    expect(typeof gitPluginConfig?.message).toBe('string');
+  });
+
+  it('keeps [skip ci] in the literal part of the message, ahead of the release notes', () => {
+    const message = gitPluginConfig?.message as string;
+    // GitHub accepts the marker anywhere in the commit message, but only the
+    // text before `${nextRelease.notes}` is authored here — the notes are
+    // generated per release and cannot be relied on to carry it.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: matches the literal semantic-release placeholder ${nextRelease.notes}
+    const literalPrefix = message.split('${nextRelease.notes}')[0];
+    expect(literalPrefix).toContain('[skip ci]');
+  });
+});


### PR DESCRIPTION
Closes #38

## Why

Branch protection came back on `main`, and the Release workflow has been failing since (run 31517072441):

```
GH006: Protected branch update failed for refs/heads/main.
- 3 of 3 required status checks are expected.
```

`semantic-release` pushes its `chore(release)` commit straight to `main`, and the branch requires three checks:

| check | where it runs |
| --- | --- |
| `build-and-test` | `ci.yml`, `on: pull_request` only |
| `Changed lines` | `mutation.yml`, `if: github.event_name == 'pull_request'` |
| `CodeQL` | default setup, reports on pull requests |

A direct push can never satisfy them. Two of the three never fire outside a pull request, and no check can report on a commit the remote has just refused. This is a deadlock, not a race that better timing would fix. `main` is still at 2.16.1 and the feature from #225 was never published.

## What this PR does

#38 laid out three options and recommended a dedicated GitHub App, which is what this implements. Classic branch protection has no bypass list, so the rules move to a ruleset and the bypass goes to `fruggr-release-bot`.

This PR is the workflow half: a `create-github-app-token` step, and its token passed to `semantic-release` in place of `secrets.GITHUB_TOKEN`. That single token covers both the `git push` from `@semantic-release/git` (the part needing the bypass) and the release plus comments from `@semantic-release/github`.

Two deliberate departures from the plan in #38:

- `actions/checkout` keeps the default token. It runs with `persist-credentials: false`, so its credentials are never reused for the push, and read access is all it needs.
- Signed commits stay out of scope. `required_signatures` is off on the branch today. The note in `docs/release-automation.md` records what to watch if that changes, since `semantic-release` pushes through the git CLI and signs nothing.

An admin PAT would also work while `enforce_admins` is off. The App wins on a token that expires in an hour and gets revoked in post-job, and on a bypass scoped to one auditable identity rather than a person's account.

npm Trusted Publishing is untouched: it runs on job-level `id-token: write` and never reads `GITHUB_TOKEN`.

## Merge order

Merging this alone changes nothing, and merging it early leaves the release red.

1. Create the App, install it here, set `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`.
2. Mirror the three checks into the ruleset, add the App to its bypass list, set it to active.
3. Delete the classic protection on `main`. Both systems apply cumulatively, so the old one keeps refusing the push until it is gone.
4. Merge this PR. The push to `main` triggers Release, which should publish.

## Validation

Tooling only, so the standard gates cover it and no independent functional pass applies (`CLAUDE.md`, Planning section): nothing a client observes at runtime changes. Step 4 is the real proof, and it should produce a `chore(release)` commit on `main` with a matching tag, an npm version and an MCP registry entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release automation guidance to reflect current repository rules, required checks, and release permissions.
  * Clarified mutation-testing requirements for pull requests.

* **Chores**
  * Improved automated release publishing and repository update workflows for more reliable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->