### PR TITLE
docs(http): document SSE keep-alive, anti-buffering and session eviction

### DIFF
--- a/docs/http-deployment.md
+++ b/docs/http-deployment.md
@@ -144,6 +144,14 @@ zendesk-mcp-server acme --transport http --port 3000 \
 
 The defaults are always applied: your additions extend them, they don't replace them.
 
+## Long-lived SSE streams behind a proxy
+
+Streamable HTTP keeps some responses open as an SSE stream, and the SDK maintains them itself: a comment frame roughly every 15 seconds (its default, not ours), well under the 60-second idle timeout nginx, Caddy and ALB ship with. No `proxy_read_timeout` tuning needed.
+
+Every SSE response also carries `X-Accel-Buffering: no` and `Cache-Control: no-cache, no-transform`, so the classic "SSE arrives in bursts behind nginx" fix is obsolete — don't re-apply it.
+
+The heartbeat does **not** keep the *session* alive: the idle sweeper evicts it after 30 minutes with no inbound `/mcp` request, however healthy the stream looks. See [My HTTP session disappears after a pause](troubleshooting.md#my-http-session-disappears-after-a-pause-even-though-the-stream-stayed-up).
+
 ## Operator responsibilities
 
 This server provides the MCP transport and the OAuth discovery metadata. The operator is still responsible for:

--- a/docs/http-deployment.md
+++ b/docs/http-deployment.md
@@ -146,7 +146,7 @@ The defaults are always applied: your additions extend them, they don't replace 
 
 ## Long-lived SSE streams behind a proxy
 
-Streamable HTTP keeps some responses open as an SSE stream, and the SDK maintains them itself: a comment frame roughly every 15 seconds (its default, not ours), well under the 60-second idle timeout nginx, Caddy and ALB ship with. No `proxy_read_timeout` tuning needed.
+Streamable HTTP keeps some responses open as an SSE stream, and the SDK maintains them itself: a comment frame roughly every 15 seconds (its default, not ours), well under the 60 seconds nginx (`proxy_read_timeout`) and AWS ALB (idle timeout) default to. Caddy sets no stream timeout at all. No proxy-side tuning needed either way.
 
 Every SSE response also carries `X-Accel-Buffering: no` and `Cache-Control: no-cache, no-transform`, so the classic "SSE arrives in bursts behind nginx" fix is obsolete — don't re-apply it.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -91,9 +91,11 @@ clocks. The SDK's heartbeat keeps the SSE connection up, but the server evicts a
 session after **30 minutes with no inbound `/mcp` request** — heartbeat frames go
 server-to-client and don't reset that timer.
 
-The tell: a request carrying a now-unknown `mcp-session-id` gets `No active
-session; initialize via POST first.` A well-behaved client re-initializes and the
-next tool call goes through. See
+The tell depends on the verb. A GET or DELETE carrying a now-unknown
+`mcp-session-id` gets `No active session; initialize via POST first.`; a POST
+tool call gets `Bad Request: Server not initialized` from the SDK, because it
+lands on a fresh transport that has seen no `initialize`. Either way a
+well-behaved client re-initializes and the next tool call goes through. See
 [Long-lived SSE streams behind a proxy](http-deployment.md#long-lived-sse-streams-behind-a-proxy).
 
 ## `Permission denied` on `list_permission_groups`, `list_user_segments`, or the topology resource

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -84,6 +84,18 @@ If you still re-authenticate every time, check that the file is writable
 ([`ZENDESK_TOKEN_FILE`](configuration.md#zendesk_token_file) to relocate it) and
 look for `token_persist_failed` in the logs.
 
+## My HTTP session disappears after a pause, even though the stream stayed up
+
+Expected, and not an error: stream liveness and session lifetime are separate
+clocks. The SDK's heartbeat keeps the SSE connection up, but the server evicts a
+session after **30 minutes with no inbound `/mcp` request** — heartbeat frames go
+server-to-client and don't reset that timer.
+
+The tell: a request carrying a now-unknown `mcp-session-id` gets `No active
+session; initialize via POST first.` A well-behaved client re-initializes and the
+next tool call goes through. See
+[Long-lived SSE streams behind a proxy](http-deployment.md#long-lived-sse-streams-behind-a-proxy).
+
 ## `Permission denied` on `list_permission_groups`, `list_user_segments`, or the topology resource
 
 Enumerating Guide permission groups and Help Center user segments requires


### PR DESCRIPTION
## Summary

The SDK keeps SSE streams alive itself and ships anti-buffering headers; our `node:http` transport wraps the SDK's, so we inherit both — and `docs/http-deployment.md`, whose audience runs behind a reverse proxy, said nothing about it. Adds that, plus the adjacent trap that a live stream is not a live session. Docs only, no `src/` change.

## Linked issue

Closes #207

## Type of change
- [x] Documentation

## Author checklist
- [x] No open or merged PR already addresses the issue; it is not closed as completed / `released`
- [x] Description links the issue with a closing keyword
- [x] `pnpm test` (770 tests), `pnpm check`, `pnpm typecheck` all pass locally
- [x] `pnpm test:coverage` — no source file changed, coverage untouched
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff
- [ ] Functional validation plan — n/a, see below

## Notes for the reviewer

Claims verified against the installed SDK, not release notes: `DEFAULT_SSE_KEEP_ALIVE_MS = 15000` and the literal `': keepalive\n\n'` frame; `X-Accel-Buffering: no` + `Cache-Control: no-cache, no-transform` on **all three** SSE response paths, which is what lets the doc state it for GET and POST alike; `StreamableHTTPServerTransport` constructing a `WebStandardStreamableHTTPServerTransport` internally. And `lastActivityAt` is written only in `dispatchToSession` (`src/transports/http.ts:390`), which is the basis for the "live stream ≠ live session" point.

Three deliberate calls, per the issue: no `keepAliveMs` (exposing it is out of scope), the 15 s attributed to the SDK so it can't go stale silently, and no SDK version number in prose.

`docs/troubleshooting.md` carried **no** obsolete SSE-buffering advice — grepped `docs/` and the README for `SSE|buffering|Server-Sent`, zero hits. The new entry there is an addition rather than a fix, slightly beyond the issue's checklist: nothing documented the 30-minute eviction, and that symptom is what a reader will search for. Easy to drop if you'd rather keep this to one file.

**Functional-validation gate: n/a.** No source file is touched, so a running server behaves identically for every client. The standard gates are the validation.

Both cross-link anchors were checked by hand against the new headings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running long-lived SSE streams behind reverse proxies.
  * Documented SDK heartbeats, proxy buffering configuration, and the distinction between stream heartbeats and session expiration.
  * Added troubleshooting steps for 30-minute session expiration, unknown-session errors, and client re-initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->