### PR TITLE
feat(client): retry transient failures and name network errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,11 @@ Zod schema. Each proxy dispatches only within its own scoped handler map, so a
 `--read-only` / `--tool` are applied by `filterTools` *before* the mode switch;
 `--tool` also forces `mode: all` (`config.ts`).
 
+Every request goes through `performFetch` in `client/zendesk-api.ts`, so retry and
+network-error wrapping are decided once, in `client/retry.ts`: a new client method must
+pick its row in that policy table, where a write is never replayed once it may have
+reached Zendesk.
+
 **Auth** — per-user OAuth 2.1 PKCE only, no static API-token mode. stdio: lazy
 browser PKCE via `token-store.ts`. HTTP: per-session bearer captured from
 `Authorization:`. Dropping API-token auth is deliberate (static shared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ Every Zendesk API request goes through `performFetch` in `client/zendesk-api.ts`
 (the OAuth token exchange in `auth/browser-oauth.ts` deliberately does not), so retry and
 network-error wrapping are decided once, in `client/retry.ts`: a new client method must
 pick its row in that policy table, where a write is never replayed once it may have
-reached Zendesk.
+reached Zendesk. Why the loop is ours rather than a library's — and what would change
+that: `docs/decisions/client-retry.md`.
 
 **Auth** — per-user OAuth 2.1 PKCE only, no static API-token mode. stdio: lazy
 browser PKCE via `token-store.ts`. HTTP: per-session bearer captured from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ Zod schema. Each proxy dispatches only within its own scoped handler map, so a
 `--read-only` / `--tool` are applied by `filterTools` *before* the mode switch;
 `--tool` also forces `mode: all` (`config.ts`).
 
-Every request goes through `performFetch` in `client/zendesk-api.ts`, so retry and
+Every Zendesk API request goes through `performFetch` in `client/zendesk-api.ts`
+(the OAuth token exchange in `auth/browser-oauth.ts` deliberately does not), so retry and
 network-error wrapping are decided once, in `client/retry.ts`: a new client method must
 pick its row in that policy table, where a write is never replayed once it may have
 reached Zendesk.

--- a/docs/decisions/client-retry.md
+++ b/docs/decisions/client-retry.md
@@ -1,0 +1,127 @@
+# Client retry: why the policy is ours and the mechanics are hand-rolled
+
+> **Build documentation, not user documentation.** This records why
+> `src/client/retry.ts` implements its own retry loop instead of delegating to a
+> library. Client-facing behaviour is described in
+> [`docs/troubleshooting.md`](../troubleshooting.md).
+
+| | |
+| --- | --- |
+| **Status** | Decided and applied |
+| **Date** | 2026-08-14 |
+| **Applied in** | [#236](https://github.com/fruggr/zendesk-mcp-server/pull/236) ([#193](https://github.com/fruggr/zendesk-mcp-server/issues/193)) |
+| **Question** | Should the retry layer use an off-the-shelf library rather than its own loop, backoff and `Retry-After` handling? |
+| **Answer** | **Not yet** — for one measured reason, not on principle: the library that removes the most is invisible to the test suite, and the one that is testable removes ~40 lines while adding a dependency last published in March 2024. |
+
+## The argument that does *not* justify hand-rolling
+
+Zendesk's `PUT /tickets/{id}` **appends** a comment, so replaying it emails a
+customer twice. That is real, and it is why `POST`/`PUT`/`DELETE` only replay a
+`429` or a connection that never opened.
+
+It is tempting to conclude "a library would get this wrong by default, so we
+write our own". That conclusion is wrong, and this section exists so nobody
+reaches for it again. Every candidate below exposes that choice as
+**configuration** — `methods`, a predicate, a callback. Knowing that a `PUT` is
+not idempotent here is a *requirement*: it has to be stated either way, in a
+config value or in a policy table. Owning the requirement never implies owning
+the loop, the jitter or the header parsing. **Maintain the need, not the how.**
+
+The decision below rests only on what was measured.
+
+## What was measured
+
+Spike against `undici` 8.10.0 and the repo's `msw` 2.15.0.
+
+| | undici `RetryAgent` / `interceptors.retry` | `fetch-retry` 6.0.0 | `p-retry` |
+| --- | --- | --- | --- |
+| Policy expressible as config | yes (`methods`, `statusCodes`, `errorCodes`, `retry` callback) | yes (`retryOn`, `retryDelay`) | partly — HTTP-agnostic, predicate is ours |
+| Works with MSW | **no** | yes | yes |
+| Parses `Retry-After` for us | yes | no | no |
+| Last publish | current | **2024-03-17** | 2026-03-26 |
+
+### 1. undici's interceptor is invisible to MSW
+
+The strongest candidate — it owns the loop, the backoff, `Retry-After` *and* the
+socket handling. It is unusable here because MSW intercepts **above** the
+dispatcher layer:
+
+| Wiring | MSW intercepts | Retry runs |
+| --- | --- | --- |
+| global `fetch` + per-call `dispatcher` | yes | **never** |
+| `setGlobalDispatcher` + global `fetch` | yes | **never** |
+| `undici.fetch` + `dispatcher` | **no** | yes — against the real API |
+
+The third row is not theoretical: the probe received a genuine
+`No help desk at testsubdomain.zendesk.com` from Zendesk. So the choice would be
+an untested write-safety policy, or real API calls in the suite — and
+[`AGENTS.md`](../../AGENTS.md) requires MSW.
+
+Its defaults are also unsafe for this API (`methods` includes `PUT` and `DELETE`,
+`errorCodes` includes the post-send `ECONNRESET`), but per the section above that
+is configuration, not an argument.
+
+### 2. `fetch-retry` is testable, and expresses the policy exactly
+
+A fetch-level wrapper stays above MSW. All three cases behave as specified, with
+the policy living entirely in `retryOn` / `retryDelay`:
+
+| Call | Result |
+| --- | --- |
+| `GET` + `500` | retried, 3 requests, ends `200` |
+| `POST` + `429` (`Retry-After: 0`) | replayed once, 2 requests, ends `200` |
+| `PUT` + `500` | 1 request, ends `500` — never replayed |
+
+Two findings decide against it for now:
+
+- **It removes less than it looks.** Gone: the loop and the backoff maths, ~40
+  lines. Still ours: `parseRetryAfter` (a `retryDelay` callback must return a
+  number, so someone reads the header — including the trap that
+  `Date.parse('-1')` yields the year 2001), the pre-send/unknown classification,
+  the error wrapping and credential redaction, the per-attempt deadline, and
+  draining a discarded response body to release the socket.
+- **A fetch wrapper replays the same `init`, so it replays the same
+  `AbortSignal`.** With one `AbortSignal.timeout` in `init`, a first attempt that
+  hits the deadline ends the call: the probe stayed at 1 request and surfaced
+  `TimeoutError` with no retry. Fixable — inject a fresh signal in the fetch
+  function handed to the factory, which *is* called per attempt — but it is a
+  trap, and `performFetch` already avoids it by building the signal inside the
+  retry thunk.
+
+Weigh that against a dependency with no release in over two years, on the path
+that keeps a customer-facing comment from being sent twice.
+
+## What would reverse this
+
+- **`fetch-retry` resumes releases.** The leverage stays small, but the principle
+  holds; swap then.
+- **The client layer stops being tested through MSW** — a local `node:http`
+  server for `tests/unit/client/` would let a custom dispatcher run, unlocking
+  undici's interceptor, which is the real prize since it owns `Retry-After`
+  parsing too. That is a test-architecture decision in its own right, not a
+  drive-by swap.
+
+Until then the mechanics stay in `src/client/retry.ts`, where the diff gate holds
+them at a 100 % mutation score.
+
+## Reproducing
+
+```js
+// MSW + a custom undici dispatcher: intercepted, but the retry never runs.
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { Agent, interceptors } from 'undici';
+
+let hits = 0;
+const server = setupServer(
+  http.get('https://testsubdomain.zendesk.com/api/v2/flaky', () => {
+    hits += 1;
+    return hits === 1 ? HttpResponse.json({}, { status: 500 }) : HttpResponse.json({ ok: true });
+  }),
+);
+server.listen();
+
+const agent = new Agent().compose(interceptors.retry({ maxRetries: 2, methods: ['GET'] }));
+const res = await fetch('https://testsubdomain.zendesk.com/api/v2/flaky', { dispatcher: agent });
+console.log(res.status, hits); // 500 1 — one attempt, no retry
+```

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -91,8 +91,8 @@ runner supplies the misbehaviour:
 
 ```bash
 pnpm build
-node scripts/validate-retry.mjs             # 8 scenarios, ~40 s
-node scripts/validate-retry.mjs --skip-slow # drops the 30 s deadline scenario
+node scripts/validate-retry.mjs             # 11 scenarios, ~80 s
+node scripts/validate-retry.mjs --skip-slow # drops the two that wait out a deadline
 ```
 
 Each scenario boots the real server with `scripts/fault-inject.mjs` preloaded —
@@ -102,8 +102,8 @@ on how many requests Zendesk actually saw**: that count is what proves a write w
 not replayed, where a message could be misread. The run exits non-zero if any
 scenario fails, so a green result is a fact rather than an impression.
 
-To exercise a mode by hand, set `FAULT` (`none`, `flaky-then-ok`, `500`, `429`,
-`network`, `stall`) and preload the same file:
+To exercise a mode by hand, set `FAULT` (`none`, `flaky-then-ok`, `500`, `404`,
+`429`, `429-brief`, `network`, `stall`, `slow-transfer`) and preload the same file:
 
 ```bash
 FAULT=500 SUB=validation node --import ./scripts/fault-inject.mjs \

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -82,3 +82,37 @@ It links a real MCP `Client` to the server over an in-memory transport
 `tools/call`, `resources/list` and `resources/read` cross the wire and dispatch
 through the genuine handlers. Use it for quick manual checks, or as a basis for
 scripted or CI assertions.
+
+## C. `scripts/validate-retry.mjs`: failure paths, without a flaky network
+
+The retry, timeout and write-safety behaviour of the client only shows itself
+when Zendesk misbehaves, which a healthy tenant never does on request. This
+runner supplies the misbehaviour:
+
+```bash
+pnpm build
+node scripts/validate-retry.mjs             # 8 scenarios, ~40 s
+node scripts/validate-retry.mjs --skip-slow # drops the 30 s deadline scenario
+```
+
+Each scenario boots the real server with `scripts/fault-inject.mjs` preloaded —
+MSW patching the same global `fetch` the Zendesk client uses — then drives a real
+MCP tool call over stdio. It judges the outcome on what the caller received **and
+on how many requests Zendesk actually saw**: that count is what proves a write was
+not replayed, where a message could be misread. The run exits non-zero if any
+scenario fails, so a green result is a fact rather than an impression.
+
+To exercise a mode by hand, set `FAULT` (`none`, `flaky-then-ok`, `500`, `429`,
+`network`, `stall`) and preload the same file:
+
+```bash
+FAULT=500 SUB=validation node --import ./scripts/fault-inject.mjs \
+  dist/index.js validation --mode all
+```
+
+Two things it cannot do. `HttpResponse.error()` raises a failure with **no syscall
+code**, so it cannot tell a pre-send `ENOTFOUND` from an in-flight `ECONNRESET` —
+the "never reached Zendesk, retrying is safe" branch is covered by unit tests
+only, and a real fault-injecting proxy would be needed to go further. And nothing
+here reaches production: `msw` is a devDependency, and no file under `src/`
+imports it.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -101,22 +101,23 @@ reports; omitting `user_segment_id` on create/update keeps the default visibilit
 
 The request never got an HTTP response — DNS, a refused or reset connection, a
 proxy dropping the link. The message names the method and the path so you know
-what failed; the query string is dropped and no token appears in it.
+what failed, with credentials stripped: no bearer token, no query string, and an
+attachment URL's download token redacted from the path.
 
-Transient failures are already retried up to 3 times with backoff before you see
-this, so a message here means every attempt failed. What gets retried depends on
-the method, because a replay must never duplicate a write:
+The request is tried up to 3 times (so up to two retries) with backoff before you
+see this, meaning every attempt failed. What gets retried depends on the method,
+because a replay must never duplicate a write:
 
 | | Network failure | `5xx` | `429` |
 | --- | --- | --- | --- |
 | `GET` | retried | retried | retried |
-| `DELETE` | retried only if the connection never opened | retried | retried |
-| `POST`, `PUT` | retried only if the connection never opened | **not retried** | retried |
+| `POST`, `PUT`, `DELETE` | retried only if the connection never opened | **not retried** | retried |
 
-So a create or a comment is never sent twice: a `429` means Zendesk refused the
-request, but a `5xx` may have applied it, and it is surfaced rather than replayed.
-A `429` carrying a `Retry-After` above 5 s is surfaced too instead of parking the
-call — wait and ask again.
+So a create, a comment or a delete is never sent twice: a `429` means Zendesk
+refused the request, but a `5xx` may have applied it, so it is surfaced rather
+than replayed — including on a delete, where a replay would report a misleading
+`404` for work that succeeded. A `429` carrying a `Retry-After` above 5 s is
+surfaced too instead of parking the call — wait and ask again.
 
 Where each client writes the server's stderr:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -97,6 +97,27 @@ those rights, read an existing article with `get_article` and reuse the IDs it
 reports; omitting `user_segment_id` on create/update keeps the default visibility
 (everyone).
 
+## A tool call fails with `Network error on GET https://…`
+
+The request never got an HTTP response — DNS, a refused or reset connection, a
+proxy dropping the link. The message names the method and the path so you know
+what failed; the query string is dropped and no token appears in it.
+
+Transient failures are already retried up to 3 times with backoff before you see
+this, so a message here means every attempt failed. What gets retried depends on
+the method, because a replay must never duplicate a write:
+
+| | Network failure | `5xx` | `429` |
+| --- | --- | --- | --- |
+| `GET` | retried | retried | retried |
+| `DELETE` | retried only if the connection never opened | retried | retried |
+| `POST`, `PUT` | retried only if the connection never opened | **not retried** | retried |
+
+So a create or a comment is never sent twice: a `429` means Zendesk refused the
+request, but a `5xx` may have applied it, and it is surfaced rather than replayed.
+A `429` carrying a `Retry-After` above 5 s is surfaced too instead of parking the
+call — wait and ask again.
+
 Where each client writes the server's stderr:
 
 | Client | Log location |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -132,6 +132,17 @@ refused the request, but a `5xx` may have applied it, so it is surfaced rather
 than replayed — including on a delete, where a replay would report a misleading
 `404` for work that succeeded.
 
+A failed **write** says which of the two it was, so that retrying it by hand (or
+having an assistant retry it) does not create the duplicate the client just
+avoided:
+
+| The message ends with | What it means |
+| --- | --- |
+| *The write may already have been applied…* | check the ticket or article before retrying |
+| *…nothing was applied. Retrying is safe.* | the request was refused or never left; send it again |
+
+A read never carries either note: replaying a `GET` cannot duplicate anything.
+
 When a response carries `Retry-After` (Zendesk sends it on a `429`, and on a `503`
 during maintenance), that delay is used instead of the backoff — unless it exceeds
 5 s, in which case the response is surfaced rather than parking the call for that

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,8 +116,12 @@ because a replay must never duplicate a write:
 So a create, a comment or a delete is never sent twice: a `429` means Zendesk
 refused the request, but a `5xx` may have applied it, so it is surfaced rather
 than replayed — including on a delete, where a replay would report a misleading
-`404` for work that succeeded. A `429` carrying a `Retry-After` above 5 s is
-surfaced too instead of parking the call — wait and ask again.
+`404` for work that succeeded.
+
+When a response carries `Retry-After` (Zendesk sends it on a `429`, and on a `503`
+during maintenance), that delay is used instead of the backoff — unless it exceeds
+5 s, in which case the response is surfaced rather than parking the call for that
+long. Wait and ask again.
 
 Where each client writes the server's stderr:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -123,6 +123,12 @@ during maintenance), that delay is used instead of the backoff — unless it exc
 5 s, in which case the response is surfaced rather than parking the call for that
 long. Wait and ask again.
 
+Each attempt also has its own deadline — 30 s, or 120 s for attachment downloads
+and uploads — because Node's `fetch` otherwise waits up to 300 s on a stalled
+socket. Hitting it reads `TimeoutError: The operation was aborted due to timeout`.
+A read is retried after a timeout; a write is not, since the request may have
+reached Zendesk before the deadline passed.
+
 Where each client writes the server's stderr:
 
 | Client | Log location |

--- a/scripts/fault-inject.mjs
+++ b/scripts/fault-inject.mjs
@@ -45,6 +45,9 @@ const respond = async () => {
       return hits === 1
         ? HttpResponse.json({}, { status: 429, headers: { 'Retry-After': '0' } })
         : HttpResponse.json({ user: USER, ticket: { id: 1, subject: 'ok', status: 'open' } });
+    case '404':
+      // Terminal: a read must not spend its budget on something retrying cannot fix.
+      return HttpResponse.json({ error: 'RecordNotFound' }, { status: 404 });
     case 'network':
       return HttpResponse.error();
     case 'flaky-then-ok':
@@ -56,11 +59,55 @@ const respond = async () => {
   }
 };
 
+// A one-pixel PNG, enough for the attachment path to have real bytes to carry.
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+);
+const ATTACHMENT_URL = `https://${SUB}.zendesk.com/attachments/token/injected-token/`;
+
+// `slow-transfer` answers the download after longer than the 30 s JSON deadline
+// but well inside the 120 s transfer one: it is the only way to show the binary
+// path really gets the longer budget rather than merely being configured with it.
+const transferDelayMs = FAULT === 'slow-transfer' ? 35_000 : 0;
+
 // Add a route here to reach another tool; the mode logic is shared.
 const server = setupServer(
   http.get(`${BASE}/users/me`, respond),
   http.get(`${BASE}/tickets/:id`, respond),
   http.put(`${BASE}/tickets/:id`, respond),
+  http.get(`${BASE}/tickets/:id/comments`, () => {
+    hits += 1;
+    process.stderr.write(`[fault] hit #${hits} (${FAULT}) comments\n`);
+    return HttpResponse.json({
+      comments: [
+        {
+          id: 1,
+          type: 'Comment',
+          body: 'with an attachment',
+          public: true,
+          created_at: '2026-01-01T00:00:00Z',
+          attachments: [
+            {
+              id: 42,
+              file_name: 'shot.png',
+              content_type: 'image/png',
+              size: PNG.length,
+              content_url: ATTACHMENT_URL,
+            },
+          ],
+        },
+      ],
+    });
+  }),
+  http.get(ATTACHMENT_URL, async () => {
+    hits += 1;
+    process.stderr.write(`[fault] hit #${hits} (${FAULT}) download\n`);
+    if (transferDelayMs > 0) await delay(transferDelayMs);
+    return HttpResponse.arrayBuffer(PNG.buffer.slice(PNG.byteOffset, PNG.byteOffset + PNG.length), {
+      headers: { 'Content-Type': 'image/png' },
+    });
+  }),
 );
 
 server.listen({ onUnhandledRequest: 'bypass' });

--- a/scripts/fault-inject.mjs
+++ b/scripts/fault-inject.mjs
@@ -38,7 +38,13 @@ const respond = async () => {
     case '500':
       return HttpResponse.json({ error: 'injected' }, { status: 500 });
     case '429':
+      // Beyond the client's Retry-After cap: it must surface, not park the call.
       return HttpResponse.json({}, { status: 429, headers: { 'Retry-After': '600' } });
+    case '429-brief':
+      // Within the cap: Zendesk refused the request, so a write may be re-sent.
+      return hits === 1
+        ? HttpResponse.json({}, { status: 429, headers: { 'Retry-After': '0' } })
+        : HttpResponse.json({ user: USER, ticket: { id: 1, subject: 'ok', status: 'open' } });
     case 'network':
       return HttpResponse.error();
     case 'flaky-then-ok':

--- a/scripts/fault-inject.mjs
+++ b/scripts/fault-inject.mjs
@@ -1,0 +1,61 @@
+// Fault-injecting Zendesk, loaded into the real server process with
+// `node --import ./scripts/fault-inject.mjs dist/index.js <subdomain> --mode all`.
+//
+// MSW patches the same global `fetch` the Zendesk client uses, so the running MCP
+// server talks to a Zendesk that fails on demand — with no product code involved.
+// Dev-only by construction: `msw` is a devDependency and nothing in `src/` imports
+// it, so this cannot run from a published install.
+//
+// The mode comes from FAULT; every intercepted request prints `[fault] hit #N` on
+// stderr, and that count is the evidence a retry policy is judged on — a write
+// that must not be replayed shows exactly one hit, whatever its error message says.
+//
+// Known limit: `HttpResponse.error()` raises a failure with no syscall code, so
+// this cannot tell a pre-send `ENOTFOUND` from an in-flight `ECONNRESET`. The
+// "never reached Zendesk, retrying is safe" branch needs a real endpoint (a
+// fault-injecting proxy) and is covered by unit tests only.
+
+import { delay, HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+
+const SUB = process.env['SUB'] ?? 'validation';
+const FAULT = process.env['FAULT'] ?? 'none';
+const BASE = `https://${SUB}.zendesk.com/api/v2`;
+
+let hits = 0;
+
+const USER = { id: 9999, name: 'Validation User', email: 'validation@example.com', role: 'admin' };
+
+const respond = async () => {
+  hits += 1;
+  process.stderr.write(`[fault] hit #${hits} (${FAULT})\n`);
+
+  switch (FAULT) {
+    case 'stall':
+      // Never answers: the client's own per-attempt deadline has to fire.
+      await delay('infinite');
+      return HttpResponse.json({}, { status: 500 });
+    case '500':
+      return HttpResponse.json({ error: 'injected' }, { status: 500 });
+    case '429':
+      return HttpResponse.json({}, { status: 429, headers: { 'Retry-After': '600' } });
+    case 'network':
+      return HttpResponse.error();
+    case 'flaky-then-ok':
+      return hits === 1
+        ? HttpResponse.json({ error: 'injected' }, { status: 500 })
+        : HttpResponse.json({ user: USER, ticket: { id: 1, subject: 'ok', status: 'open' } });
+    default:
+      return HttpResponse.json({ user: USER, ticket: { id: 1, subject: 'ok', status: 'open' } });
+  }
+};
+
+// Add a route here to reach another tool; the mode logic is shared.
+const server = setupServer(
+  http.get(`${BASE}/users/me`, respond),
+  http.get(`${BASE}/tickets/:id`, respond),
+  http.put(`${BASE}/tickets/:id`, respond),
+);
+
+server.listen({ onUnhandledRequest: 'bypass' });
+process.stderr.write(`[fault] armed on ${BASE}, mode=${FAULT}\n`);

--- a/scripts/validate-retry.mjs
+++ b/scripts/validate-retry.mjs
@@ -9,7 +9,7 @@
 // cannot.
 //
 // Exits non-zero if any scenario fails, so a green run is a fact rather than an
-// impression. `--skip-slow` drops the 30 s deadline scenario.
+// impression. `--skip-slow` drops the two scenarios that wait out a real deadline.
 
 import { spawn } from 'node:child_process';
 import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
@@ -97,6 +97,15 @@ const SCENARIOS = [
   {
     id: 'S9',
     slow: true,
+    what: 'a transfer slower than the 30 s JSON deadline still completes on the binary path',
+    fault: 'slow-transfer',
+    tool: 'get_ticket_attachments',
+    args: { ticket_id: 1 },
+    expect: { requests: 2, isError: false, contains: ['shot.png'], minMs: 34_000 },
+  },
+  {
+    id: 'S10',
+    slow: true,
     what: 'a stalled socket is cut by the per-attempt deadline, not left hanging',
     fault: 'stall',
     tool: 'add_private_note',
@@ -104,6 +113,15 @@ const SCENARIOS = [
     expect: { requests: 1, isError: true, contains: ['TimeoutError'], minMs: 29_000 },
   },
 ];
+
+SCENARIOS.push({
+  id: 'S11',
+  what: 'a 404 is terminal: one request, and the wording is untouched',
+  fault: '404',
+  tool: 'get_current_user',
+  args: {},
+  expect: { requests: 1, isError: true, contains: ['Resource not found'] },
+});
 
 const seedTokenFile = () => {
   const file = join(mkdtempSync(join(tmpdir(), 'zendesk-validation-')), 'token.json');
@@ -242,7 +260,7 @@ for (const scenario of chosen) {
 
 console.log(
   failed === 0
-    ? `All ${chosen.length} scenarios passed.${skipSlow ? ' (deadline scenario skipped)' : ''}`
+    ? `All ${chosen.length} scenarios passed.${skipSlow ? ` (${SCENARIOS.length - chosen.length} slow scenarios skipped)` : ''}`
     : `${failed} of ${chosen.length} scenarios failed.`,
 );
 process.exit(failed === 0 ? 0 : 1);

--- a/scripts/validate-retry.mjs
+++ b/scripts/validate-retry.mjs
@@ -1,0 +1,235 @@
+// Executes the retry/timeout validation matrix and prints a report.
+//
+//   pnpm build && node scripts/validate-retry.mjs [--skip-slow]
+//
+// Each scenario boots the real server behind `scripts/fault-inject.mjs`, drives a
+// real MCP tool call over stdio, and judges the outcome on two things: what the
+// caller received, and **how many requests Zendesk actually saw**. The count is
+// what proves the write-safety guarantee — a message can be misread, a counter
+// cannot.
+//
+// Exits non-zero if any scenario fails, so a green run is a fact rather than an
+// impression. `--skip-slow` drops the 30 s deadline scenario.
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SUB = 'validation';
+const SERVER = 'dist/index.js';
+const PRELOAD = 'scripts/fault-inject.mjs';
+const skipSlow = process.argv.includes('--skip-slow');
+
+const NOTE_MAY_APPLY = 'The write may already have been applied.';
+const NOTE_REFUSED = 'Zendesk refused the request, so nothing was applied.';
+
+const SCENARIOS = [
+  {
+    id: 'S1',
+    what: 'a healthy read goes through untouched',
+    fault: 'none',
+    tool: 'get_current_user',
+    args: {},
+    expect: { requests: 1, isError: false },
+  },
+  {
+    id: 'S2',
+    what: 'a transient failure is absorbed, the caller never sees it',
+    fault: 'flaky-then-ok',
+    tool: 'get_current_user',
+    args: {},
+    expect: { requests: 2, isError: false },
+  },
+  {
+    id: 'S3',
+    what: 'a read spends its whole budget on a 5xx',
+    fault: '500',
+    tool: 'get_current_user',
+    args: {},
+    expect: { requests: 3, isError: true, contains: ['Zendesk API error 500'] },
+  },
+  {
+    id: 'S4',
+    what: 'a 5xx write is never replayed, and says it may have applied',
+    fault: '500',
+    tool: 'add_private_note',
+    args: { ticket_id: 1, body: 'validation note' },
+    expect: { requests: 1, isError: true, contains: [NOTE_MAY_APPLY] },
+  },
+  {
+    id: 'S5',
+    what: 'a throttled write is refused outright, so retrying is safe',
+    fault: '429',
+    tool: 'add_private_note',
+    args: { ticket_id: 1, body: 'validation note' },
+    expect: { requests: 1, isError: true, contains: ['Rate limit exceeded', NOTE_REFUSED] },
+  },
+  {
+    id: 'S6',
+    what: 'a write that failed with no response is not replayed either',
+    fault: 'network',
+    tool: 'add_private_note',
+    args: { ticket_id: 1, body: 'validation note' },
+    expect: {
+      requests: 1,
+      isError: true,
+      contains: ['Network error on PUT', NOTE_MAY_APPLY],
+      absent: ['Bearer', 'accessToken'],
+    },
+  },
+  {
+    id: 'S7',
+    what: 'a read retries a failure with no response, then names it',
+    fault: 'network',
+    tool: 'get_current_user',
+    args: {},
+    expect: { requests: 3, isError: true, contains: ['Network error on GET', 'after 3 attempts'] },
+  },
+  {
+    id: 'S8',
+    slow: true,
+    what: 'a stalled socket is cut by the per-attempt deadline, not left hanging',
+    fault: 'stall',
+    tool: 'add_private_note',
+    args: { ticket_id: 1, body: 'validation note' },
+    expect: { requests: 1, isError: true, contains: ['TimeoutError'], minMs: 29_000 },
+  },
+];
+
+const seedTokenFile = () => {
+  const file = join(mkdtempSync(join(tmpdir(), 'zendesk-validation-')), 'token.json');
+  // A non-expiring token: the server reuses it and never opens a browser.
+  writeFileSync(file, JSON.stringify({ accessToken: 'validation-token' }), { mode: 0o600 });
+  return file;
+};
+
+const runScenario = (scenario, tokenPath) =>
+  new Promise((resolve) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', `./${PRELOAD}`, SERVER, SUB, '--mode', 'all'],
+      {
+        env: {
+          ...process.env,
+          SUB,
+          FAULT: scenario.fault,
+          ZENDESK_TOKEN_FILE: tokenPath,
+          ZENDESK_OAUTH_CLIENT_ID: 'validation_client',
+          LOG_LEVEL: 'error',
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
+
+    let requests = 0;
+    let stdout = '';
+    let settled = false;
+    const started = Date.now();
+
+    child.stderr.on('data', (chunk) => {
+      requests += (chunk.toString().match(/\[fault] hit #/g) ?? []).length;
+    });
+
+    const finish = (outcome) => {
+      if (settled) return;
+      settled = true;
+      child.kill();
+      resolve({ ...outcome, requests, elapsedMs: Date.now() - started });
+    };
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+      for (const line of stdout.split('\n')) {
+        if (!line.trim()) continue;
+        let message;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (message.id !== 2) continue;
+        const payload = message.result ?? message.error;
+        const text =
+          payload?.content?.map((part) => part.text).join('\n') ??
+          payload?.message ??
+          JSON.stringify(payload);
+        finish({ isError: Boolean(payload?.isError ?? message.error), text });
+      }
+    });
+
+    const send = (msg) => child.stdin.write(`${JSON.stringify(msg)}\n`);
+    send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'validate-retry', version: '0' },
+      },
+    });
+    send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    send({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: scenario.tool, arguments: scenario.args },
+    });
+
+    setTimeout(() => finish({ isError: true, text: '<no response within 60 s>' }), 60_000);
+  });
+
+const judge = (scenario, outcome) => {
+  const { expect } = scenario;
+  const failures = [];
+  if (outcome.requests !== expect.requests) {
+    failures.push(`Zendesk saw ${outcome.requests} request(s), expected ${expect.requests}`);
+  }
+  if (outcome.isError !== expect.isError) {
+    failures.push(`isError=${outcome.isError}, expected ${expect.isError}`);
+  }
+  for (const needle of expect.contains ?? []) {
+    if (!outcome.text.includes(needle)) failures.push(`message is missing "${needle}"`);
+  }
+  for (const needle of expect.absent ?? []) {
+    if (outcome.text.includes(needle)) failures.push(`message leaks "${needle}"`);
+  }
+  if (expect.minMs !== undefined && outcome.elapsedMs < expect.minMs) {
+    failures.push(`returned after ${outcome.elapsedMs} ms, expected at least ${expect.minMs} ms`);
+  }
+  return failures;
+};
+
+if (!existsSync(SERVER)) {
+  console.error(`${SERVER} is missing. Run \`pnpm build\` first.`);
+  process.exit(1);
+}
+
+const tokenFile = seedTokenFile();
+const chosen = SCENARIOS.filter((scenario) => !(scenario.slow && skipSlow));
+let failed = 0;
+
+console.log(`Retry and timeout validation — ${chosen.length} scenarios\n`);
+
+for (const scenario of chosen) {
+  const outcome = await runScenario(scenario, tokenFile);
+  const failures = judge(scenario, outcome);
+  const verdict = failures.length === 0 ? 'OK  ' : 'FAIL';
+  if (failures.length > 0) failed += 1;
+
+  console.log(`${verdict} ${scenario.id}  ${scenario.what}`);
+  console.log(
+    `       fault=${scenario.fault} tool=${scenario.tool} requests=${outcome.requests} elapsed=${outcome.elapsedMs}ms`,
+  );
+  console.log(`       ${outcome.text.replace(/\n/g, ' ').slice(0, 220)}`);
+  for (const failure of failures) console.log(`       -> ${failure}`);
+  console.log();
+}
+
+console.log(
+  failed === 0
+    ? `All ${chosen.length} scenarios passed.${skipSlow ? ' (deadline scenario skipped)' : ''}`
+    : `${failed} of ${chosen.length} scenarios failed.`,
+);
+process.exit(failed === 0 ? 0 : 1);

--- a/scripts/validate-retry.mjs
+++ b/scripts/validate-retry.mjs
@@ -150,12 +150,15 @@ const runScenario = (scenario, tokenPath) =>
 
     let requests = 0;
     let stdout = '';
+    let stderr = '';
     let settled = false;
     let watchdog;
     const started = Date.now();
 
     child.stderr.on('data', (chunk) => {
-      requests += (chunk.toString().match(/\[fault] hit #/g) ?? []).length;
+      const text = chunk.toString();
+      stderr += text;
+      requests += (text.match(/\[fault] hit #/g) ?? []).length;
     });
 
     const finish = (outcome) => {
@@ -184,6 +187,21 @@ const runScenario = (scenario, tokenPath) =>
           JSON.stringify(payload);
         finish({ isError: Boolean(payload?.isError ?? message.error), text });
       }
+    });
+
+    // A child that dies before answering would otherwise sit out the watchdog.
+    // `close` rather than `exit`, so a response already in the pipe still wins.
+    child.on('error', (error) =>
+      finish({ isError: true, text: `<spawn failed: ${error.message}>` }),
+    );
+    child.stdin.on('error', () => {});
+    child.on('close', (code, signal) => {
+      const lines = stderr.split('\n').filter((line) => line.trim());
+      const why = lines.find((line) => /Error/.test(line)) ?? lines.at(-1) ?? '';
+      finish({
+        isError: true,
+        text: `<server exited (code=${code}, signal=${signal}) before responding> ${why.trim()}`,
+      });
     });
 
     const send = (msg) => child.stdin.write(`${JSON.stringify(msg)}\n`);

--- a/scripts/validate-retry.mjs
+++ b/scripts/validate-retry.mjs
@@ -59,14 +59,22 @@ const SCENARIOS = [
   },
   {
     id: 'S5',
-    what: 'a throttled write is refused outright, so retrying is safe',
+    what: 'a throttled write IS replayed, exactly once — Zendesk refused it, so it never applied',
+    fault: '429-brief',
+    tool: 'add_private_note',
+    args: { ticket_id: 1, body: 'validation note' },
+    expect: { requests: 2, isError: false },
+  },
+  {
+    id: 'S6',
+    what: 'a Retry-After beyond the cap is surfaced instead of parking the call',
     fault: '429',
     tool: 'add_private_note',
     args: { ticket_id: 1, body: 'validation note' },
     expect: { requests: 1, isError: true, contains: ['Rate limit exceeded', NOTE_REFUSED] },
   },
   {
-    id: 'S6',
+    id: 'S7',
     what: 'a write that failed with no response is not replayed either',
     fault: 'network',
     tool: 'add_private_note',
@@ -79,7 +87,7 @@ const SCENARIOS = [
     },
   },
   {
-    id: 'S7',
+    id: 'S8',
     what: 'a read retries a failure with no response, then names it',
     fault: 'network',
     tool: 'get_current_user',
@@ -87,7 +95,7 @@ const SCENARIOS = [
     expect: { requests: 3, isError: true, contains: ['Network error on GET', 'after 3 attempts'] },
   },
   {
-    id: 'S8',
+    id: 'S9',
     slow: true,
     what: 'a stalled socket is cut by the per-attempt deadline, not left hanging',
     fault: 'stall',
@@ -125,6 +133,7 @@ const runScenario = (scenario, tokenPath) =>
     let requests = 0;
     let stdout = '';
     let settled = false;
+    let watchdog;
     const started = Date.now();
 
     child.stderr.on('data', (chunk) => {
@@ -134,6 +143,7 @@ const runScenario = (scenario, tokenPath) =>
     const finish = (outcome) => {
       if (settled) return;
       settled = true;
+      clearTimeout(watchdog);
       child.kill();
       resolve({ ...outcome, requests, elapsedMs: Date.now() - started });
     };
@@ -177,7 +187,10 @@ const runScenario = (scenario, tokenPath) =>
       params: { name: scenario.tool, arguments: scenario.args },
     });
 
-    setTimeout(() => finish({ isError: true, text: '<no response within 60 s>' }), 60_000);
+    watchdog = setTimeout(
+      () => finish({ isError: true, text: '<no response within 60 s>' }),
+      60_000,
+    );
   });
 
 const judge = (scenario, outcome) => {

--- a/src/client/retry.ts
+++ b/src/client/retry.ts
@@ -6,6 +6,20 @@ export type NetworkPhase = 'pre-send' | 'unknown';
 const MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 250;
 const MAX_DELAY_MS = 4_000;
+
+// Undici gives `fetch` no overall deadline — its headersTimeout/bodyTimeout
+// default to 300 s — so a stalled socket would hold a tool call open long past
+// the retry budget, which cannot fire while an attempt is pending. Transfers get
+// a longer one: a large attachment on a slow link legitimately takes a while.
+export const REQUEST_TIMEOUT_MS = 30_000;
+export const TRANSFER_TIMEOUT_MS = 120_000;
+
+/**
+ * A deadline for one attempt. The abort surfaces as a `TimeoutError` whose `code`
+ * is numeric, not a syscall string, so it classifies as `unknown`: a GET is
+ * retried, a write is not — the request may have arrived before the deadline.
+ */
+export const deadlineSignal = (timeoutMs: number): AbortSignal => AbortSignal.timeout(timeoutMs);
 // Beyond this, honoring Retry-After would park the tool call; surface the 429
 // and let the caller come back later instead.
 const MAX_RETRY_AFTER_MS = 5_000;
@@ -94,17 +108,25 @@ export type ZendeskNetworkError = Error & {
   readonly attempts: number;
 };
 
+// `fetch failed` / a bare Error name says nothing worth printing; a DOMException
+// name like TimeoutError is the only label that failure carries.
+const UNINFORMATIVE_NAMES: ReadonlySet<string> = new Set(['Error', 'TypeError']);
+
+const failureDetail = (cause: unknown): string => {
+  if (!(cause instanceof Error)) return String(cause);
+  const code = errorCode(cause);
+  if (code !== undefined) return `${code}: ${cause.message}`;
+  return UNINFORMATIVE_NAMES.has(cause.name) ? cause.message : `${cause.name}: ${cause.message}`;
+};
+
 const networkErrorMessage = (
   method: HttpMethod,
   target: string,
   attempts: number,
   cause: unknown,
 ): string => {
-  const reason = cause instanceof Error ? cause.message : String(cause);
-  const code = errorCode(cause);
-  const detail = code === undefined ? reason : `${code}: ${reason}`;
   const tries = attempts === 1 ? '1 attempt' : `${attempts} attempts`;
-  return toAscii(`Network error on ${method} ${target} after ${tries}: ${detail}`);
+  return toAscii(`Network error on ${method} ${target} after ${tries}: ${failureDetail(cause)}`);
 };
 
 export const createZendeskNetworkError = (

--- a/src/client/retry.ts
+++ b/src/client/retry.ts
@@ -1,0 +1,189 @@
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+/** 'pre-send': the request provably never reached Zendesk. */
+export type NetworkPhase = 'pre-send' | 'unknown';
+
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 250;
+const MAX_DELAY_MS = 4_000;
+// Beyond this, honoring Retry-After would park the tool call; surface the 429
+// and let the caller come back later instead.
+const MAX_RETRY_AFTER_MS = 5_000;
+
+interface RetryPolicy {
+  /** Which network failures may be replayed. */
+  readonly network: NetworkPhase | 'any';
+  /** Whether a 5xx may be replayed. */
+  readonly serverErrors: boolean;
+}
+
+// The client sits below the tool layer, so the method is all it has to judge
+// idempotency by — and `PUT /tickets/{id}` with a `comment` *appends* one, so PUT
+// counts as a create too. A 429 is always retried: Zendesk refused the request,
+// so it provably did not apply. A 5xx on a write may have applied before failing.
+// DELETE is pre-send only: replaying a lost response turns a completed delete
+// into a misleading 404.
+const POLICIES: Record<HttpMethod, RetryPolicy> = {
+  GET: { network: 'any', serverErrors: true },
+  DELETE: { network: 'pre-send', serverErrors: true },
+  POST: { network: 'pre-send', serverErrors: false },
+  PUT: { network: 'pre-send', serverErrors: false },
+};
+
+const DELAY_SECONDS = /^\d+$/;
+// Every HTTP-date format starts with the day name; Date.parse is lenient enough
+// to read '-1' as a year, so require it.
+const HTTP_DATE_START = /^[A-Za-z]/;
+const NON_ASCII = /[^ -~]/g;
+
+const PRE_SEND_CODES = new Set([
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'UND_ERR_CONNECT_TIMEOUT',
+]);
+
+export interface RetryDeps {
+  readonly sleep: (ms: number) => Promise<void>;
+  readonly random: () => number;
+}
+
+export const defaultRetryDeps: RetryDeps = {
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  random: Math.random,
+};
+
+/** Non-ASCII bytes break `node:http` headers, so client error text stays ASCII. */
+const toAscii = (text: string): string => text.replace(NON_ASCII, '?');
+
+/** Identifies the request without leaking the query string (uploads put a token there). */
+export const describeTarget = (url: string): string => {
+  const parsed = new URL(url);
+  return `${parsed.origin}${parsed.pathname}`;
+};
+
+/** First `code` in the cause chain; depth-bounded so a cyclic chain cannot hang. */
+const errorCode = (err: unknown): string | undefined => {
+  let current: unknown = err;
+  for (let depth = 0; depth < 5 && current !== null && typeof current === 'object'; depth += 1) {
+    const { code, cause } = current as { code?: unknown; cause?: unknown };
+    if (typeof code === 'string') return code;
+    current = cause;
+  }
+  return undefined;
+};
+
+export const classifyNetworkError = (err: unknown): NetworkPhase =>
+  PRE_SEND_CODES.has(errorCode(err) ?? '') ? 'pre-send' : 'unknown';
+
+/**
+ * A failure with no HTTP response at all: DNS, refused connection, reset socket.
+ * Unlike the bare `fetch failed` that `fetch` throws, it names the request that
+ * failed. An Error factory, not a class, to match the repo's functional style.
+ */
+export type ZendeskNetworkError = Error & {
+  readonly method: HttpMethod;
+  readonly target: string;
+  readonly attempts: number;
+};
+
+const networkErrorMessage = (
+  method: HttpMethod,
+  target: string,
+  attempts: number,
+  cause: unknown,
+): string => {
+  const reason = cause instanceof Error ? cause.message : String(cause);
+  const code = errorCode(cause);
+  const detail = code === undefined ? reason : `${code}: ${reason}`;
+  const tries = attempts === 1 ? '1 attempt' : `${attempts} attempts`;
+  return toAscii(`Network error on ${method} ${target} after ${tries}: ${detail}`);
+};
+
+export const createZendeskNetworkError = (
+  method: HttpMethod,
+  target: string,
+  attempts: number,
+  cause: unknown,
+): ZendeskNetworkError =>
+  Object.assign(new Error(networkErrorMessage(method, target, attempts, cause), { cause }), {
+    name: 'ZendeskNetworkError',
+    method,
+    target,
+    attempts,
+  } as const);
+
+export const isZendeskNetworkError = (err: unknown): err is ZendeskNetworkError =>
+  err instanceof Error &&
+  err.name === 'ZendeskNetworkError' &&
+  typeof (err as ZendeskNetworkError).target === 'string';
+
+/** Exponential backoff with equal jitter: half the window fixed, half random. */
+export const computeBackoffMs = (attempt: number, random: () => number): number => {
+  const window = Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS);
+  return Math.round(window / 2 + (window * random()) / 2);
+};
+
+/** `Retry-After` in ms — delay-seconds or HTTP-date. */
+export const parseRetryAfter = (header: string | null, now = Date.now()): number | undefined => {
+  if (header === null) return undefined;
+  const value = header.trim();
+  if (DELAY_SECONDS.test(value)) return Number(value) * 1000;
+  if (!HTTP_DATE_START.test(value)) return undefined;
+  const date = Date.parse(value);
+  if (Number.isNaN(date)) return undefined;
+  return Math.max(0, date - now);
+};
+
+/** How long to wait before replaying this response, or undefined to accept it. */
+const retryDelayFor = (
+  response: Response,
+  policy: RetryPolicy,
+  attempt: number,
+  random: () => number,
+): number | undefined => {
+  if (response.status === 429) {
+    const retryAfter = parseRetryAfter(response.headers.get('retry-after'));
+    if (retryAfter === undefined) return computeBackoffMs(attempt, random);
+    return retryAfter > MAX_RETRY_AFTER_MS ? undefined : retryAfter;
+  }
+  if (response.status >= 500 && policy.serverErrors) return computeBackoffMs(attempt, random);
+  return undefined;
+};
+
+/**
+ * Runs `attempt` until it succeeds, hits a terminal outcome, or spends the
+ * attempt budget. Returns the last response for the caller to inspect (a
+ * non-ok status is still the caller's to turn into a `ZendeskApiError`), and
+ * throws `ZendeskNetworkError` when no response was ever obtained.
+ */
+export const fetchWithRetry = async (
+  attempt: () => Promise<Response>,
+  method: HttpMethod,
+  target: string,
+  deps: RetryDeps = defaultRetryDeps,
+): Promise<Response> => {
+  const policy = POLICIES[method];
+
+  for (let tries = 1; ; tries += 1) {
+    const last = tries >= MAX_ATTEMPTS;
+    let response: Response;
+
+    try {
+      response = await attempt();
+    } catch (err) {
+      const replayable = policy.network === 'any' || classifyNetworkError(err) === policy.network;
+      if (last || !replayable) throw createZendeskNetworkError(method, target, tries, err);
+      await deps.sleep(computeBackoffMs(tries, deps.random));
+      continue;
+    }
+
+    if (last) return response;
+    const delayMs = retryDelayFor(response, policy, tries, deps.random);
+    if (delayMs === undefined) return response;
+
+    // This body is discarded; drain it so the socket is released.
+    await response.text();
+    await deps.sleep(delayMs);
+  }
+};

--- a/src/client/retry.ts
+++ b/src/client/retry.ts
@@ -142,20 +142,24 @@ export const parseRetryAfter = (header: string | null, now = Date.now()): number
   return Math.max(0, date - now);
 };
 
-/** How long to wait before replaying this response, or undefined to accept it. */
+/**
+ * How long to wait before replaying this response, or undefined to accept it.
+ * `Retry-After` wins over backoff wherever it appears — Zendesk sends it on a 503
+ * during maintenance as well as on a 429 — and a value past the cap means the
+ * response is surfaced rather than parking the call for that long.
+ */
 const retryDelayFor = (
   response: Response,
   policy: RetryPolicy,
   attempt: number,
   random: () => number,
 ): number | undefined => {
-  if (response.status === 429) {
-    const retryAfter = parseRetryAfter(response.headers.get('retry-after'));
-    if (retryAfter === undefined) return computeBackoffMs(attempt, random);
-    return retryAfter > MAX_RETRY_AFTER_MS ? undefined : retryAfter;
-  }
-  if (response.status >= 500 && policy.serverErrors) return computeBackoffMs(attempt, random);
-  return undefined;
+  const replayable = response.status === 429 || (response.status >= 500 && policy.serverErrors);
+  if (!replayable) return undefined;
+
+  const retryAfter = parseRetryAfter(response.headers.get('retry-after'));
+  if (retryAfter === undefined) return computeBackoffMs(attempt, random);
+  return retryAfter > MAX_RETRY_AFTER_MS ? undefined : retryAfter;
 };
 
 /**

--- a/src/client/retry.ts
+++ b/src/client/retry.ts
@@ -36,7 +36,9 @@ const DELAY_SECONDS = /^\d+$/;
 const HTTP_DATE_START = /^[A-Za-z]/;
 const NON_ASCII = /[^ -~]/g;
 
-const PRE_SEND_CODES = new Set([
+// Typed as unknown so a missing code can be looked up as-is: no code is simply
+// not in the set.
+const PRE_SEND_CODES: ReadonlySet<unknown> = new Set([
   'ENOTFOUND',
   'EAI_AGAIN',
   'ECONNREFUSED',
@@ -73,10 +75,8 @@ const errorCode = (err: unknown): string | undefined => {
   return undefined;
 };
 
-export const classifyNetworkError = (err: unknown): NetworkPhase => {
-  const code = errorCode(err);
-  return code !== undefined && PRE_SEND_CODES.has(code) ? 'pre-send' : 'unknown';
-};
+export const classifyNetworkError = (err: unknown): NetworkPhase =>
+  PRE_SEND_CODES.has(errorCode(err)) ? 'pre-send' : 'unknown';
 
 /**
  * A failure with no HTTP response at all: DNS, refused connection, reset socket.

--- a/src/client/retry.ts
+++ b/src/client/retry.ts
@@ -19,13 +19,13 @@ interface RetryPolicy {
 
 // The client sits below the tool layer, so the method is all it has to judge
 // idempotency by — and `PUT /tickets/{id}` with a `comment` *appends* one, so PUT
-// counts as a create too. A 429 is always retried: Zendesk refused the request,
-// so it provably did not apply. A 5xx on a write may have applied before failing.
-// DELETE is pre-send only: replaying a lost response turns a completed delete
-// into a misleading 404.
+// counts as a create too. Everything that is not a GET therefore only replays
+// what provably did not apply: a 429 (Zendesk refused the request) or a
+// connection that never opened. A 5xx may have applied — replaying a DELETE
+// there would turn a completed delete into a misleading 404.
 const POLICIES: Record<HttpMethod, RetryPolicy> = {
   GET: { network: 'any', serverErrors: true },
-  DELETE: { network: 'pre-send', serverErrors: true },
+  DELETE: { network: 'pre-send', serverErrors: false },
   POST: { network: 'pre-send', serverErrors: false },
   PUT: { network: 'pre-send', serverErrors: false },
 };
@@ -35,6 +35,7 @@ const DELAY_SECONDS = /^\d+$/;
 // to read '-1' as a year, so require it.
 const HTTP_DATE_START = /^[A-Za-z]/;
 const NON_ASCII = /[^ -~]/g;
+const TOKEN_SEGMENT = /\/token\/[^/]+/;
 
 // Typed as unknown so a missing code can be looked up as-is: no code is simply
 // not in the set.
@@ -58,10 +59,14 @@ export const defaultRetryDeps: RetryDeps = {
 /** Non-ASCII bytes break `node:http` headers, so client error text stays ASCII. */
 const toAscii = (text: string): string => text.replace(NON_ASCII, '?');
 
-/** Identifies the request without leaking the query string (uploads put a token there). */
+/**
+ * Identifies the request without leaking a credential: uploads carry an upload
+ * token in the query string, and an attachment `content_url` carries a download
+ * token as a path segment (`/attachments/token/<token>/`).
+ */
 export const describeTarget = (url: string): string => {
-  const parsed = new URL(url);
-  return `${parsed.origin}${parsed.pathname}`;
+  const { origin, pathname } = new URL(url);
+  return `${origin}${pathname.replace(TOKEN_SEGMENT, '/token/[redacted]')}`;
 };
 
 /** First `code` in the cause chain, inspecting 5 levels so a cycle cannot hang. */
@@ -184,8 +189,9 @@ export const fetchWithRetry = async (
     const delayMs = retryDelayFor(response, policy, tries, deps.random);
     if (delayMs === undefined) return response;
 
-    // This body is discarded; drain it so the socket is released.
-    await response.text();
+    // This body is discarded; drain it so the socket is released. A truncated
+    // body throws here, which must not escape the retry we are about to make.
+    await response.text().catch(() => undefined);
     await deps.sleep(delayMs);
   }
 };

--- a/src/client/retry.ts
+++ b/src/client/retry.ts
@@ -62,7 +62,7 @@ export const describeTarget = (url: string): string => {
   return `${parsed.origin}${parsed.pathname}`;
 };
 
-/** First `code` in the cause chain; depth-bounded so a cyclic chain cannot hang. */
+/** First `code` in the cause chain, inspecting 5 levels so a cycle cannot hang. */
 const errorCode = (err: unknown): string | undefined => {
   let current: unknown = err;
   for (let depth = 0; depth < 5 && current !== null && typeof current === 'object'; depth += 1) {
@@ -73,8 +73,10 @@ const errorCode = (err: unknown): string | undefined => {
   return undefined;
 };
 
-export const classifyNetworkError = (err: unknown): NetworkPhase =>
-  PRE_SEND_CODES.has(errorCode(err) ?? '') ? 'pre-send' : 'unknown';
+export const classifyNetworkError = (err: unknown): NetworkPhase => {
+  const code = errorCode(err);
+  return code !== undefined && PRE_SEND_CODES.has(code) ? 'pre-send' : 'unknown';
+};
 
 /**
  * A failure with no HTTP response at all: DNS, refused connection, reset socket.

--- a/src/client/retry.ts
+++ b/src/client/retry.ts
@@ -50,6 +50,7 @@ const DELAY_SECONDS = /^\d+$/;
 const HTTP_DATE_START = /^[A-Za-z]/;
 const NON_ASCII = /[^ -~]/g;
 const TOKEN_SEGMENT = /\/token\/[^/]+/;
+const URL_IN_TEXT = /[a-z][a-z0-9+.-]*:\/\/\S+/gi;
 
 // Typed as unknown so a missing code can be looked up as-is: no code is simply
 // not in the set.
@@ -112,11 +113,28 @@ export type ZendeskNetworkError = Error & {
 // name like TimeoutError is the only label that failure carries.
 const UNINFORMATIVE_NAMES: ReadonlySet<string> = new Set(['Error', 'TypeError']);
 
+/**
+ * A cause message can quote the URL it failed on — Node's `fetch` refuses a URL
+ * carrying credentials by printing the whole thing, query string included — which
+ * would smuggle back exactly what `describeTarget` drops. Same treatment for both,
+ * so one function owns what a URL may look like in our output.
+ */
+const redactUrls = (text: string): string =>
+  text.replace(URL_IN_TEXT, (found) => {
+    try {
+      // A non-special scheme has no origin to keep; drop it whole.
+      return new URL(found).origin === 'null' ? '[url]' : describeTarget(found);
+    } catch {
+      return '[url]';
+    }
+  });
+
 const failureDetail = (cause: unknown): string => {
-  if (!(cause instanceof Error)) return String(cause);
+  if (!(cause instanceof Error)) return redactUrls(String(cause));
+  const message = redactUrls(cause.message);
   const code = errorCode(cause);
-  if (code !== undefined) return `${code}: ${cause.message}`;
-  return UNINFORMATIVE_NAMES.has(cause.name) ? cause.message : `${cause.name}: ${cause.message}`;
+  if (code !== undefined) return `${code}: ${message}`;
+  return UNINFORMATIVE_NAMES.has(cause.name) ? message : `${cause.name}: ${message}`;
 };
 
 const networkErrorMessage = (

--- a/src/client/retry.ts
+++ b/src/client/retry.ts
@@ -114,6 +114,23 @@ export type ZendeskNetworkError = Error & {
 const UNINFORMATIVE_NAMES: ReadonlySet<string> = new Set(['Error', 'TypeError']);
 
 /**
+ * The client refuses to replay a write that may have landed — but the caller is
+ * an LLM whose reflex on a failed tool call is to try again, which would undo
+ * that. So a failed write says whether it may have taken effect. ASCII only,
+ * same rule as the rest of the message.
+ */
+export const MAY_HAVE_APPLIED_NOTE =
+  'The write may already have been applied. Check the current state before retrying, or you may duplicate it.';
+export const NEVER_SENT_NOTE =
+  'The request never reached Zendesk, so nothing was applied. Retrying is safe.';
+export const REFUSED_NOTE =
+  'Zendesk refused the request, so nothing was applied. Retrying is safe.';
+
+/** Only a write can be duplicated by a replay, so only a write carries a note. */
+export const writeNote = (method: HttpMethod, note: string): string =>
+  method === 'GET' ? '' : ` ${note}`;
+
+/**
  * A cause message can quote the URL it failed on — Node's `fetch` refuses a URL
  * carrying credentials by printing the whole thing, query string included — which
  * would smuggle back exactly what `describeTarget` drops. Same treatment for both,
@@ -144,7 +161,11 @@ const networkErrorMessage = (
   cause: unknown,
 ): string => {
   const tries = attempts === 1 ? '1 attempt' : `${attempts} attempts`;
-  return toAscii(`Network error on ${method} ${target} after ${tries}: ${failureDetail(cause)}`);
+  const base = `Network error on ${method} ${target} after ${tries}: ${failureDetail(cause)}`;
+  // The phase of the *last* failure is what decides: the loop stops at the first
+  // one the policy will not replay.
+  const note = classifyNetworkError(cause) === 'pre-send' ? NEVER_SENT_NOTE : MAY_HAVE_APPLIED_NOTE;
+  return toAscii(method === 'GET' ? base : `${base}.${writeNote(method, note)}`);
 };
 
 export const createZendeskNetworkError = (

--- a/src/client/zendesk-api.ts
+++ b/src/client/zendesk-api.ts
@@ -1,5 +1,12 @@
 import { getBaseUrl, getHelpCenterBaseUrl } from '../constants.js';
-import { describeTarget, fetchWithRetry, type HttpMethod } from './retry';
+import {
+  deadlineSignal,
+  describeTarget,
+  fetchWithRetry,
+  type HttpMethod,
+  REQUEST_TIMEOUT_MS,
+  TRANSFER_TIMEOUT_MS,
+} from './retry';
 
 export class ZendeskApiError extends Error {
   constructor(
@@ -48,15 +55,22 @@ const buildUrl = (base: string, path: string, params?: Record<string, string>): 
   return url.toString();
 };
 
-// Every request in this module goes through here: transient failures are retried
-// per the method's policy (`retry.ts`) and a failure with no response at all is
-// wrapped with the method and path instead of surfacing a bare `fetch failed`.
+// Every request in this module goes through here: each attempt gets its own
+// deadline, transient failures are retried per the method's policy (`retry.ts`),
+// and a failure with no response at all is wrapped with the method and path
+// instead of surfacing a bare `fetch failed`. The signal is built inside the
+// thunk so every attempt starts its deadline fresh.
 const performFetch = (
   method: HttpMethod,
   url: string,
-  init: Omit<RequestInit, 'method'>,
+  init: Omit<RequestInit, 'method' | 'signal'>,
+  timeoutMs: number = REQUEST_TIMEOUT_MS,
 ): Promise<Response> =>
-  fetchWithRetry(() => fetch(url, { ...init, method }), method, describeTarget(url));
+  fetchWithRetry(
+    () => fetch(url, { ...init, method, signal: deadlineSignal(timeoutMs) }),
+    method,
+    describeTarget(url),
+  );
 
 const executeRequest = async <T>(
   url: string,
@@ -168,7 +182,7 @@ export const fetchZendeskBinary = async (
   if (new URL(contentUrl).hostname === expectedHost) {
     headers['Authorization'] = buildAuthHeader(token);
   }
-  const response = await performFetch('GET', contentUrl, { headers });
+  const response = await performFetch('GET', contentUrl, { headers }, TRANSFER_TIMEOUT_MS);
   if (!response.ok) {
     const body = await response.text();
     throw new ZendeskApiError(response.status, response.statusText, body);
@@ -194,10 +208,15 @@ export const zendeskUpload = async <T>(
   const params: Record<string, string> = { filename };
   if (uploadToken) params['token'] = uploadToken;
   const url = buildUrl(getBaseUrl(subdomain), '/uploads', params);
-  const response = await performFetch('POST', url, {
-    headers: { Authorization: buildAuthHeader(token), 'Content-Type': contentType },
-    body: data,
-  });
+  const response = await performFetch(
+    'POST',
+    url,
+    {
+      headers: { Authorization: buildAuthHeader(token), 'Content-Type': contentType },
+      body: data,
+    },
+    TRANSFER_TIMEOUT_MS,
+  );
 
   if (!response.ok) {
     const responseBody = await response.text();
@@ -214,10 +233,12 @@ export const helpCenterUpload = async <T>(
   formData: FormData,
 ): Promise<T> => {
   const url = buildUrl(getHelpCenterBaseUrl(subdomain), path);
-  const response = await performFetch('POST', url, {
-    headers: { Authorization: buildAuthHeader(token) },
-    body: formData,
-  });
+  const response = await performFetch(
+    'POST',
+    url,
+    { headers: { Authorization: buildAuthHeader(token) }, body: formData },
+    TRANSFER_TIMEOUT_MS,
+  );
 
   if (!response.ok) {
     const responseBody = await response.text();

--- a/src/client/zendesk-api.ts
+++ b/src/client/zendesk-api.ts
@@ -4,8 +4,11 @@ import {
   describeTarget,
   fetchWithRetry,
   type HttpMethod,
+  MAY_HAVE_APPLIED_NOTE,
+  REFUSED_NOTE,
   REQUEST_TIMEOUT_MS,
   TRANSFER_TIMEOUT_MS,
+  writeNote,
 } from './retry';
 
 export class ZendeskApiError extends Error {
@@ -13,12 +16,20 @@ export class ZendeskApiError extends Error {
     public readonly status: number,
     public readonly statusText: string,
     public readonly body: string,
+    // Only used to tell a failed write whether it may have taken effect; the
+    // per-status wording is otherwise unchanged.
+    method: HttpMethod = 'GET',
   ) {
-    super(ZendeskApiError.buildMessage(status, statusText, body));
+    super(ZendeskApiError.buildMessage(status, statusText, body, method));
     this.name = 'ZendeskApiError';
   }
 
-  private static buildMessage(status: number, statusText: string, body: string): string {
+  private static buildMessage(
+    status: number,
+    statusText: string,
+    body: string,
+    method: HttpMethod,
+  ): string {
     switch (status) {
       case 401:
         return 'Authentication failed. Your Zendesk token may be expired or invalid. Re-authenticate to get a new token.';
@@ -29,9 +40,14 @@ export class ZendeskApiError extends Error {
       case 422:
         return `Validation error: ${body}`;
       case 429:
-        return 'Rate limit exceeded. Please wait before making more requests.';
-      default:
-        return `Zendesk API error ${status}: ${statusText}. ${body}`;
+        // A 429 was refused outright, so a write is safe to send again later.
+        return `Rate limit exceeded. Please wait before making more requests.${writeNote(method, REFUSED_NOTE)}`;
+      default: {
+        const message = `Zendesk API error ${status}: ${statusText}. ${body}`;
+        // A 5xx is the dangerous one: the write is not replayed here precisely
+        // because it may have applied, so say so rather than let the caller retry.
+        return status >= 500 ? `${message}${writeNote(method, MAY_HAVE_APPLIED_NOTE)}` : message;
+      }
     }
   }
 }
@@ -97,7 +113,7 @@ const executeRequest = async <T>(
 
   if (!response.ok) {
     const responseBody = await response.text();
-    throw new ZendeskApiError(response.status, response.statusText, responseBody);
+    throw new ZendeskApiError(response.status, response.statusText, responseBody, method);
   }
 
   if (response.status === 204) {
@@ -185,7 +201,7 @@ export const fetchZendeskBinary = async (
   const response = await performFetch('GET', contentUrl, { headers }, TRANSFER_TIMEOUT_MS);
   if (!response.ok) {
     const body = await response.text();
-    throw new ZendeskApiError(response.status, response.statusText, body);
+    throw new ZendeskApiError(response.status, response.statusText, body, 'GET');
   }
   const contentType = response.headers.get('content-type') ?? 'application/octet-stream';
   const arrayBuffer = await response.arrayBuffer();
@@ -220,7 +236,7 @@ export const zendeskUpload = async <T>(
 
   if (!response.ok) {
     const responseBody = await response.text();
-    throw new ZendeskApiError(response.status, response.statusText, responseBody);
+    throw new ZendeskApiError(response.status, response.statusText, responseBody, 'POST');
   }
 
   return response.json() as Promise<T>;
@@ -242,7 +258,7 @@ export const helpCenterUpload = async <T>(
 
   if (!response.ok) {
     const responseBody = await response.text();
-    throw new ZendeskApiError(response.status, response.statusText, responseBody);
+    throw new ZendeskApiError(response.status, response.statusText, responseBody, 'POST');
   }
 
   return response.json() as Promise<T>;

--- a/src/client/zendesk-api.ts
+++ b/src/client/zendesk-api.ts
@@ -1,4 +1,5 @@
 import { getBaseUrl, getHelpCenterBaseUrl } from '../constants.js';
+import { describeTarget, fetchWithRetry, type HttpMethod } from './retry';
 
 export class ZendeskApiError extends Error {
   constructor(
@@ -29,7 +30,7 @@ export class ZendeskApiError extends Error {
 }
 
 export interface ZendeskRequestOptions {
-  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  method?: HttpMethod;
   body?: unknown;
   params?: Record<string, string>;
 }
@@ -47,6 +48,16 @@ const buildUrl = (base: string, path: string, params?: Record<string, string>): 
   return url.toString();
 };
 
+// Every request in this module goes through here: transient failures are retried
+// per the method's policy (`retry.ts`) and a failure with no response at all is
+// wrapped with the method and path instead of surfacing a bare `fetch failed`.
+const performFetch = (
+  method: HttpMethod,
+  url: string,
+  init: Omit<RequestInit, 'method'>,
+): Promise<Response> =>
+  fetchWithRetry(() => fetch(url, { ...init, method }), method, describeTarget(url));
+
 const executeRequest = async <T>(
   url: string,
   token: string,
@@ -63,12 +74,12 @@ const executeRequest = async <T>(
     headers['Content-Type'] = 'application/json';
   }
 
-  const init: RequestInit = { method, headers };
+  const init: Omit<RequestInit, 'method'> = { headers };
   if (body) {
     init.body = JSON.stringify(body);
   }
 
-  const response = await fetch(url, init);
+  const response = await performFetch(method, url, init);
 
   if (!response.ok) {
     const responseBody = await response.text();
@@ -157,7 +168,7 @@ export const fetchZendeskBinary = async (
   if (new URL(contentUrl).hostname === expectedHost) {
     headers['Authorization'] = buildAuthHeader(token);
   }
-  const response = await fetch(contentUrl, { headers });
+  const response = await performFetch('GET', contentUrl, { headers });
   if (!response.ok) {
     const body = await response.text();
     throw new ZendeskApiError(response.status, response.statusText, body);
@@ -169,8 +180,9 @@ export const fetchZendeskBinary = async (
 
 // Zendesk Uploads API: POST /uploads?filename=... with the raw file bytes as the
 // body and Content-Type set to the file's MIME type. `executeRequest` always
-// JSON-encodes, so this goes direct to fetch (like helpCenterUpload). Pass
-// `uploadToken` to aggregate another file under an existing upload token.
+// JSON-encodes, so this builds its own request (like helpCenterUpload) while
+// still sharing `performFetch`. Pass `uploadToken` to aggregate another file
+// under an existing upload token.
 export const zendeskUpload = async <T>(
   subdomain: string,
   token: string,
@@ -182,8 +194,7 @@ export const zendeskUpload = async <T>(
   const params: Record<string, string> = { filename };
   if (uploadToken) params['token'] = uploadToken;
   const url = buildUrl(getBaseUrl(subdomain), '/uploads', params);
-  const response = await fetch(url, {
-    method: 'POST',
+  const response = await performFetch('POST', url, {
     headers: { Authorization: buildAuthHeader(token), 'Content-Type': contentType },
     body: data,
   });
@@ -203,8 +214,7 @@ export const helpCenterUpload = async <T>(
   formData: FormData,
 ): Promise<T> => {
   const url = buildUrl(getHelpCenterBaseUrl(subdomain), path);
-  const response = await fetch(url, {
-    method: 'POST',
+  const response = await performFetch('POST', url, {
     headers: { Authorization: buildAuthHeader(token) },
     body: formData,
   });

--- a/src/client/zendesk-api.ts
+++ b/src/client/zendesk-api.ts
@@ -18,7 +18,7 @@ export class ZendeskApiError extends Error {
     public readonly body: string,
     // Only used to tell a failed write whether it may have taken effect; the
     // per-status wording is otherwise unchanged.
-    method: HttpMethod = 'GET',
+    method: HttpMethod,
   ) {
     super(ZendeskApiError.buildMessage(status, statusText, body, method));
     this.name = 'ZendeskApiError';

--- a/src/client/zendesk-api.ts
+++ b/src/client/zendesk-api.ts
@@ -16,9 +16,10 @@ export class ZendeskApiError extends Error {
     public readonly status: number,
     public readonly statusText: string,
     public readonly body: string,
-    // Only used to tell a failed write whether it may have taken effect; the
-    // per-status wording is otherwise unchanged.
-    method: HttpMethod,
+    // Decides whether a failed write is told it may have taken effect; the
+    // per-status wording is otherwise unchanged. Exposed like ZendeskNetworkError's
+    // so a caller can branch on it rather than parse the message.
+    public readonly method: HttpMethod,
   ) {
     super(ZendeskApiError.buildMessage(status, statusText, body, method));
     this.name = 'ZendeskApiError';

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest';
 import {
   classifyNetworkError,
   computeBackoffMs,
+  deadlineSignal,
   defaultRetryDeps,
   describeTarget,
   fetchWithRetry,
   isZendeskNetworkError,
   parseRetryAfter,
+  REQUEST_TIMEOUT_MS,
+  TRANSFER_TIMEOUT_MS,
   type ZendeskNetworkError,
 } from '../../../src/client/retry';
 
@@ -161,6 +164,59 @@ describe('isZendeskNetworkError', () => {
     ],
   ])('rejects %s', (_label, candidate) => {
     expect(isZendeskNetworkError(candidate)).toBe(false);
+  });
+});
+
+describe('deadlineSignal', () => {
+  it('aborts with a TimeoutError once the deadline passes', async () => {
+    const signal = deadlineSignal(10);
+    expect(signal.aborted).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    expect(signal.aborted).toBe(true);
+    expect((signal.reason as Error).name).toBe('TimeoutError');
+  });
+
+  it('gives a longer deadline to transfers than to JSON calls', () => {
+    expect(REQUEST_TIMEOUT_MS).toBe(30_000);
+    expect(TRANSFER_TIMEOUT_MS).toBeGreaterThan(REQUEST_TIMEOUT_MS);
+  });
+});
+
+// A deadline abort arrives as a DOMException: no string `code`, only a name, and
+// a *numeric* `code` that must not be mistaken for a syscall code.
+describe('deadline aborts', () => {
+  const timeoutError = (): Error =>
+    Object.assign(new Error('The operation was aborted due to timeout'), {
+      name: 'TimeoutError',
+      code: 23,
+    });
+
+  it('classifies as unknown, so a write is never replayed', () => {
+    expect(classifyNetworkError(timeoutError())).toBe('unknown');
+  });
+
+  it('names the timeout in the error message', async () => {
+    const { attempt, calls } = attempts(timeoutError());
+    const { deps } = recordingDeps();
+
+    const error = await fetchWithRetry(attempt, 'POST', TARGET, deps).catch((e: unknown) => e);
+
+    expect(calls.count).toBe(1);
+    expect((error as ZendeskNetworkError).message).toBe(
+      `Network error on POST ${TARGET} after 1 attempt: TimeoutError: The operation was aborted due to timeout`,
+    );
+  });
+
+  it('is retried on a GET', async () => {
+    const { attempt, calls } = attempts(timeoutError(), timeoutError(), status(200));
+    const { deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(response.status).toBe(200);
+    expect(calls.count).toBe(3);
   });
 });
 

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -62,6 +62,18 @@ describe('describeTarget', () => {
     ).toBe('https://acme.zendesk.com/api/v2/uploads');
   });
 
+  it('redacts the download token an attachment URL carries in its path', () => {
+    expect(
+      describeTarget('https://acme.zendesk.com/attachments/token/AbCdEf123/?name=shot.png'),
+    ).toBe('https://acme.zendesk.com/attachments/token/[redacted]/');
+  });
+
+  it('leaves a token-free attachment path alone', () => {
+    expect(describeTarget('https://acme.zendesk.com/attachments/42/shot.png')).toBe(
+      'https://acme.zendesk.com/attachments/42/shot.png',
+    );
+  });
+
   it('drops the fragment', () => {
     expect(describeTarget('https://acme.zendesk.com/api/v2/tickets#frag')).toBe(
       'https://acme.zendesk.com/api/v2/tickets',
@@ -333,18 +345,38 @@ describe('fetchWithRetry — network failures', () => {
 });
 
 describe('fetchWithRetry — server errors', () => {
-  it.each(['GET', 'DELETE'] as const)('retries a 500 on %s', async (method) => {
+  it('retries a 500 on GET', async () => {
     const { attempt, calls } = attempts(status(500), status(200));
     const { sleeps, deps } = recordingDeps();
 
-    const response = await fetchWithRetry(attempt, method, TARGET, deps);
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
 
     expect(response.status).toBe(200);
     expect(calls.count).toBe(2);
     expect(sleeps).toStrictEqual([125]);
   });
 
-  it.each(['POST', 'PUT'] as const)(
+  // A body that dies mid-read must not abort the retry: it is being discarded.
+  it('retries even when the discarded body cannot be drained', async () => {
+    const truncated = () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(new Error('terminated'));
+          },
+        }),
+        { status: 500 },
+      );
+    const { attempt, calls } = attempts(truncated, status(200));
+    const { deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(response.status).toBe(200);
+    expect(calls.count).toBe(2);
+  });
+
+  it.each(['POST', 'PUT', 'DELETE'] as const)(
     'never retries a 500 on %s, which may already have applied',
     async (method) => {
       const { attempt, calls } = attempts(status(500), status(200));

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyNetworkError,
+  computeBackoffMs,
+  describeTarget,
+  fetchWithRetry,
+  isZendeskNetworkError,
+  parseRetryAfter,
+  type ZendeskNetworkError,
+} from '../../../src/client/retry';
+
+const TARGET = 'https://testsubdomain.zendesk.com/api/v2/tickets';
+
+// A network failure as `fetch` throws it: a generic outer error whose `cause`
+// carries the syscall/undici code.
+const netError = (code?: string): Error =>
+  new TypeError('fetch failed', {
+    cause: code === undefined ? new Error('boom') : Object.assign(new Error('boom'), { code }),
+  });
+
+/** Records the delays a run asks for, and pins jitter to its lower bound. */
+const recordingDeps = (random = 0) => {
+  const sleeps: number[] = [];
+  return {
+    sleeps,
+    deps: {
+      sleep: async (ms: number): Promise<void> => {
+        sleeps.push(ms);
+      },
+      random: () => random,
+    },
+  };
+};
+
+/** Plays the given outcomes in order, one per attempt, and counts the attempts. */
+const attempts = (...outcomes: (Error | (() => Response))[]) => {
+  const calls = { count: 0 };
+  const attempt = async (): Promise<Response> => {
+    const outcome = outcomes[calls.count] ?? outcomes.at(-1);
+    calls.count += 1;
+    if (outcome instanceof Error) throw outcome;
+    // A factory, not a Response: every attempt needs an unconsumed body.
+    return (outcome as () => Response)();
+  };
+  return { attempt, calls };
+};
+
+const status = (code: number, headers?: Record<string, string>) => () =>
+  new Response('payload', { status: code, ...(headers && { headers }) });
+
+describe('describeTarget', () => {
+  it('keeps origin and path', () => {
+    expect(describeTarget('https://acme.zendesk.com/api/v2/tickets/1')).toBe(
+      'https://acme.zendesk.com/api/v2/tickets/1',
+    );
+  });
+
+  it('drops the query string, which can carry an upload token', () => {
+    expect(
+      describeTarget('https://acme.zendesk.com/api/v2/uploads?filename=a.png&token=secret'),
+    ).toBe('https://acme.zendesk.com/api/v2/uploads');
+  });
+
+  it('drops the fragment', () => {
+    expect(describeTarget('https://acme.zendesk.com/api/v2/tickets#frag')).toBe(
+      'https://acme.zendesk.com/api/v2/tickets',
+    );
+  });
+});
+
+describe('classifyNetworkError', () => {
+  it.each(['ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED', 'UND_ERR_CONNECT_TIMEOUT'])(
+    'treats %s as pre-send',
+    (code) => {
+      expect(classifyNetworkError(netError(code))).toBe('pre-send');
+    },
+  );
+
+  it.each(['ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'UND_ERR_SOCKET'])(
+    'treats %s as unknown, since the request may have been sent',
+    (code) => {
+      expect(classifyNetworkError(netError(code))).toBe('unknown');
+    },
+  );
+
+  it('treats a code-less error as unknown', () => {
+    expect(classifyNetworkError(netError())).toBe('unknown');
+  });
+
+  it('finds a code on a plain-object cause', () => {
+    expect(
+      classifyNetworkError(new TypeError('fetch failed', { cause: { code: 'ENOTFOUND' } })),
+    ).toBe('pre-send');
+  });
+
+  it('does not hang on a cyclic cause chain', () => {
+    const err = new Error('loop') as Error & { cause?: unknown };
+    err.cause = err;
+    expect(classifyNetworkError(err)).toBe('unknown');
+  });
+
+  it('treats a non-error value as unknown', () => {
+    expect(classifyNetworkError('nope')).toBe('unknown');
+  });
+});
+
+describe('parseRetryAfter', () => {
+  it('reads delay-seconds', () => {
+    expect(parseRetryAfter('2')).toBe(2000);
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseRetryAfter(' 2 ')).toBe(2000);
+  });
+
+  it('reads an HTTP-date as a delta from now', () => {
+    const now = Date.parse('2026-01-01T00:00:00Z');
+    expect(parseRetryAfter('Thu, 01 Jan 2026 00:00:03 GMT', now)).toBe(3000);
+  });
+
+  it('clamps a past HTTP-date to zero', () => {
+    const now = Date.parse('2026-01-01T00:00:10Z');
+    expect(parseRetryAfter('Thu, 01 Jan 2026 00:00:03 GMT', now)).toBe(0);
+  });
+
+  it.each([null, '', '   ', 'soon', '-1'])('returns undefined for %j', (header) => {
+    expect(parseRetryAfter(header)).toBeUndefined();
+  });
+});
+
+describe('computeBackoffMs', () => {
+  // Equal jitter over a 250 ms base: half the window is fixed, half is random,
+  // so a retry never fires instantly and never lands on a fixed grid.
+  it.each([
+    [1, 0, 125],
+    [1, 1, 250],
+    [2, 0, 250],
+    [2, 1, 500],
+    [3, 0, 500],
+    [3, 1, 1000],
+  ])('attempt %i with random %i waits %i ms', (attempt, random, expected) => {
+    expect(computeBackoffMs(attempt, () => random)).toBe(expected);
+  });
+
+  it('caps the exponential growth at 4 s', () => {
+    expect(computeBackoffMs(9, () => 1)).toBe(4000);
+    expect(computeBackoffMs(9, () => 0)).toBe(2000);
+  });
+
+  it('grows monotonically until the cap', () => {
+    const delays = [1, 2, 3, 4].map((n) => computeBackoffMs(n, () => 1));
+    expect(delays).toStrictEqual([250, 500, 1000, 2000]);
+  });
+});
+
+describe('fetchWithRetry — network failures', () => {
+  it('retries a GET through transient failures and returns the success', async () => {
+    const { attempt, calls } = attempts(
+      netError('ECONNRESET'),
+      netError('ECONNRESET'),
+      status(200),
+    );
+    const { sleeps, deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(response.status).toBe(200);
+    expect(calls.count).toBe(3);
+    expect(sleeps).toStrictEqual([125, 250]);
+  });
+
+  it('gives up after 3 attempts and wraps the failure with context', async () => {
+    const { attempt, calls } = attempts(netError('ECONNRESET'));
+    const { deps } = recordingDeps();
+
+    const error = await fetchWithRetry(attempt, 'GET', TARGET, deps).catch((e: unknown) => e);
+
+    expect(isZendeskNetworkError(error)).toBe(true);
+    const wrapped = error as ZendeskNetworkError;
+    expect(calls.count).toBe(3);
+    expect(wrapped.attempts).toBe(3);
+    expect(wrapped.method).toBe('GET');
+    expect(wrapped.target).toBe(TARGET);
+    expect(wrapped.message).toBe(
+      `Network error on GET ${TARGET} after 3 attempts: ECONNRESET: fetch failed`,
+    );
+  });
+
+  it('does not retry a POST whose request may already have been sent', async () => {
+    const { attempt, calls } = attempts(netError('ECONNRESET'));
+    const { sleeps, deps } = recordingDeps();
+
+    const error = await fetchWithRetry(attempt, 'POST', TARGET, deps).catch((e: unknown) => e);
+
+    expect(isZendeskNetworkError(error)).toBe(true);
+    expect((error as ZendeskNetworkError).attempts).toBe(1);
+    expect((error as ZendeskNetworkError).message).toContain('after 1 attempt:');
+    expect(calls.count).toBe(1);
+    expect(sleeps).toStrictEqual([]);
+  });
+
+  it.each(['POST', 'PUT', 'DELETE'] as const)(
+    'retries a %s when the connection provably never opened',
+    async (method) => {
+      const { attempt, calls } = attempts(
+        netError('ENOTFOUND'),
+        netError('ENOTFOUND'),
+        status(201),
+      );
+      const { deps } = recordingDeps();
+
+      const response = await fetchWithRetry(attempt, method, TARGET, deps);
+
+      expect(response.status).toBe(201);
+      expect(calls.count).toBe(3);
+    },
+  );
+
+  it('keeps the original failure as the cause', async () => {
+    const cause = netError('ENOTFOUND');
+    const { attempt } = attempts(cause);
+    const { deps } = recordingDeps();
+
+    const error = await fetchWithRetry(attempt, 'POST', TARGET, deps).catch((e: unknown) => e);
+
+    expect((error as ZendeskNetworkError).cause).toBe(cause);
+  });
+
+  it('describes a non-error rejection', async () => {
+    const attempt = () => Promise.reject('socket gone');
+    const { deps } = recordingDeps();
+
+    const error = await fetchWithRetry(attempt, 'POST', TARGET, deps).catch((e: unknown) => e);
+
+    expect((error as ZendeskNetworkError).message).toBe(
+      `Network error on POST ${TARGET} after 1 attempt: socket gone`,
+    );
+  });
+
+  it('strips non-ASCII bytes, which node:http rejects in headers', async () => {
+    const attempt = () => Promise.reject(new Error('échec réseau'));
+    const { deps } = recordingDeps();
+
+    const error = await fetchWithRetry(attempt, 'POST', TARGET, deps).catch((e: unknown) => e);
+
+    expect((error as ZendeskNetworkError).message).toBe(
+      `Network error on POST ${TARGET} after 1 attempt: ?chec r?seau`,
+    );
+  });
+
+  it('reports a code-less failure without an empty prefix', async () => {
+    const { attempt } = attempts(netError());
+    const { deps } = recordingDeps();
+
+    const error = await fetchWithRetry(attempt, 'GET', TARGET, deps).catch((e: unknown) => e);
+
+    expect((error as ZendeskNetworkError).message).toBe(
+      `Network error on GET ${TARGET} after 3 attempts: fetch failed`,
+    );
+  });
+});
+
+describe('fetchWithRetry — server errors', () => {
+  it.each(['GET', 'DELETE'] as const)('retries a 500 on %s', async (method) => {
+    const { attempt, calls } = attempts(status(500), status(200));
+    const { sleeps, deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, method, TARGET, deps);
+
+    expect(response.status).toBe(200);
+    expect(calls.count).toBe(2);
+    expect(sleeps).toStrictEqual([125]);
+  });
+
+  it.each(['POST', 'PUT'] as const)(
+    'never retries a 500 on %s, which may already have applied',
+    async (method) => {
+      const { attempt, calls } = attempts(status(500), status(200));
+      const { sleeps, deps } = recordingDeps();
+
+      const response = await fetchWithRetry(attempt, method, TARGET, deps);
+
+      expect(response.status).toBe(500);
+      expect(calls.count).toBe(1);
+      expect(sleeps).toStrictEqual([]);
+      // The caller still needs the body for its ZendeskApiError message.
+      await expect(response.text()).resolves.toBe('payload');
+    },
+  );
+
+  it('returns the last response instead of retrying forever', async () => {
+    const { attempt, calls } = attempts(status(503));
+    const { sleeps, deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(response.status).toBe(503);
+    expect(calls.count).toBe(3);
+    expect(sleeps).toStrictEqual([125, 250]);
+    await expect(response.text()).resolves.toBe('payload');
+  });
+
+  it.each([400, 401, 403, 404, 422])('returns a terminal %i unretried', async (code) => {
+    const { attempt, calls } = attempts(status(code));
+    const { deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(response.status).toBe(code);
+    expect(calls.count).toBe(1);
+  });
+});
+
+describe('fetchWithRetry — 429', () => {
+  it.each(['GET', 'POST', 'PUT', 'DELETE'] as const)(
+    'retries a throttled %s, since Zendesk refused the request',
+    async (method) => {
+      const { attempt, calls } = attempts(status(429, { 'Retry-After': '2' }), status(200));
+      const { sleeps, deps } = recordingDeps();
+
+      const response = await fetchWithRetry(attempt, method, TARGET, deps);
+
+      expect(response.status).toBe(200);
+      expect(calls.count).toBe(2);
+      expect(sleeps).toStrictEqual([2000]);
+    },
+  );
+
+  it('falls back to backoff when Retry-After is absent', async () => {
+    const { attempt } = attempts(status(429), status(200));
+    const { sleeps, deps } = recordingDeps();
+
+    await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(sleeps).toStrictEqual([125]);
+  });
+
+  it('surfaces the 429 instead of parking the call on a long Retry-After', async () => {
+    const { attempt, calls } = attempts(status(429, { 'Retry-After': '6' }), status(200));
+    const { sleeps, deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(response.status).toBe(429);
+    expect(calls.count).toBe(1);
+    expect(sleeps).toStrictEqual([]);
+  });
+
+  it('still waits a Retry-After sitting exactly on the cap', async () => {
+    const { attempt } = attempts(status(429, { 'Retry-After': '5' }), status(200));
+    const { sleeps, deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(response.status).toBe(200);
+    expect(sleeps).toStrictEqual([5000]);
+  });
+});

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -7,6 +7,8 @@ import {
   describeTarget,
   fetchWithRetry,
   isZendeskNetworkError,
+  MAY_HAVE_APPLIED_NOTE,
+  NEVER_SENT_NOTE,
   parseRetryAfter,
   REQUEST_TIMEOUT_MS,
   TRANSFER_TIMEOUT_MS,
@@ -205,7 +207,7 @@ describe('deadline aborts', () => {
 
     expect(calls.count).toBe(1);
     expect((error as ZendeskNetworkError).message).toBe(
-      `Network error on POST ${TARGET} after 1 attempt: TimeoutError: The operation was aborted due to timeout`,
+      `Network error on POST ${TARGET} after 1 attempt: TimeoutError: The operation was aborted due to timeout. ${MAY_HAVE_APPLIED_NOTE}`,
     );
   });
 
@@ -373,7 +375,7 @@ describe('fetchWithRetry — network failures', () => {
     const error = await fetchWithRetry(attempt, 'POST', TARGET, deps).catch((e: unknown) => e);
 
     expect((error as ZendeskNetworkError).message).toBe(
-      `Network error on POST ${TARGET} after 1 attempt: socket gone`,
+      `Network error on POST ${TARGET} after 1 attempt: socket gone. ${MAY_HAVE_APPLIED_NOTE}`,
     );
   });
 
@@ -384,7 +386,7 @@ describe('fetchWithRetry — network failures', () => {
     const error = await fetchWithRetry(attempt, 'POST', TARGET, deps).catch((e: unknown) => e);
 
     expect((error as ZendeskNetworkError).message).toBe(
-      `Network error on POST ${TARGET} after 1 attempt: ?chec r?seau`,
+      `Network error on POST ${TARGET} after 1 attempt: ?chec r?seau. ${MAY_HAVE_APPLIED_NOTE}`,
     );
   });
 
@@ -431,7 +433,7 @@ describe('fetchWithRetry — network failures', () => {
     it('drops a URL-like substring it cannot parse', async () => {
       const message = await messageFor('Failed to parse URL from http://[::1');
       expect(message).toBe(
-        `Network error on POST ${TARGET} after 1 attempt: Failed to parse URL from [url]`,
+        `Network error on POST ${TARGET} after 1 attempt: Failed to parse URL from [url]. ${MAY_HAVE_APPLIED_NOTE}`,
       );
     });
 
@@ -443,7 +445,7 @@ describe('fetchWithRetry — network failures', () => {
 
     it('leaves a message without a URL untouched', async () => {
       expect(await messageFor('socket hang up')).toBe(
-        `Network error on POST ${TARGET} after 1 attempt: socket hang up`,
+        `Network error on POST ${TARGET} after 1 attempt: socket hang up. ${MAY_HAVE_APPLIED_NOTE}`,
       );
     });
 
@@ -466,6 +468,44 @@ describe('fetchWithRetry — network failures', () => {
 
     expect((error as ZendeskNetworkError).message).toBe(
       `Network error on GET ${TARGET} after 3 attempts: fetch failed`,
+    );
+  });
+});
+
+// The client refuses to replay a write that may have landed. An LLM's reflex on a
+// failed tool call is to try again, which would undo that — so the message has to
+// say whether the write may have taken effect.
+describe('what a failed write tells the caller', () => {
+  const messageFor = async (method: 'GET' | 'POST' | 'PUT' | 'DELETE', cause: Error) => {
+    const { attempt } = attempts(cause);
+    const error = await fetchWithRetry(attempt, method, TARGET, recordingDeps().deps).catch(
+      (e: unknown) => e,
+    );
+    return (error as ZendeskNetworkError).message;
+  };
+
+  it.each(['POST', 'PUT', 'DELETE'] as const)(
+    'warns that a %s may already have applied when the request may have been sent',
+    async (method) => {
+      expect(await messageFor(method, netError('ECONNRESET'))).toContain(MAY_HAVE_APPLIED_NOTE);
+    },
+  );
+
+  it.each(['POST', 'PUT', 'DELETE'] as const)(
+    'tells a %s it is safe to retry when the connection never opened',
+    async (method) => {
+      const message = await messageFor(method, netError('ENOTFOUND'));
+      expect(message).toContain(NEVER_SENT_NOTE);
+      expect(message).not.toContain(MAY_HAVE_APPLIED_NOTE);
+    },
+  );
+
+  it('says nothing of the sort on a GET, which cannot duplicate anything', async () => {
+    const message = await messageFor('GET', netError('ECONNRESET'));
+    expect(message).not.toContain(MAY_HAVE_APPLIED_NOTE);
+    expect(message).not.toContain(NEVER_SENT_NOTE);
+    expect(message).toBe(
+      `Network error on GET ${TARGET} after 3 attempts: ECONNRESET: fetch failed`,
     );
   });
 });

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   classifyNetworkError,
   computeBackoffMs,
+  defaultRetryDeps,
   describeTarget,
   fetchWithRetry,
   isZendeskNetworkError,
@@ -93,6 +94,24 @@ describe('classifyNetworkError', () => {
     ).toBe('pre-send');
   });
 
+  // The chain walk is depth-bounded rather than cycle-detecting, so pin the
+  // bound: a code sitting deeper than 5 levels is not worth unwinding to.
+  const chainOfDepth = (depth: number, code: string): Error => {
+    let err: Error = Object.assign(new Error('inner'), { code });
+    for (let level = 1; level < depth; level += 1) {
+      err = new Error('wrapper', { cause: err });
+    }
+    return err;
+  };
+
+  it('finds a code 5 levels down', () => {
+    expect(classifyNetworkError(chainOfDepth(5, 'ENOTFOUND'))).toBe('pre-send');
+  });
+
+  it('stops looking past 5 levels', () => {
+    expect(classifyNetworkError(chainOfDepth(6, 'ENOTFOUND'))).toBe('unknown');
+  });
+
   it('does not hang on a cyclic cause chain', () => {
     const err = new Error('loop') as Error & { cause?: unknown };
     err.cause = err;
@@ -104,9 +123,36 @@ describe('classifyNetworkError', () => {
   });
 });
 
+describe('isZendeskNetworkError', () => {
+  it('accepts the error the client throws', async () => {
+    const { attempt } = attempts(netError('ENOTFOUND'));
+    const error = await fetchWithRetry(attempt, 'POST', TARGET, recordingDeps().deps).catch(
+      (e: unknown) => e,
+    );
+    expect(isZendeskNetworkError(error)).toBe(true);
+  });
+
+  it.each([
+    ['a plain error', new Error('boom')],
+    ['a non-error', 'boom'],
+    ['a look-alike that is not an Error', { name: 'ZendeskNetworkError', target: TARGET }],
+    ['an error carrying only a target', Object.assign(new Error('boom'), { target: TARGET })],
+    [
+      'an error carrying only the name',
+      Object.assign(new Error('boom'), { name: 'ZendeskNetworkError' }),
+    ],
+  ])('rejects %s', (_label, candidate) => {
+    expect(isZendeskNetworkError(candidate)).toBe(false);
+  });
+});
+
 describe('parseRetryAfter', () => {
   it('reads delay-seconds', () => {
     expect(parseRetryAfter('2')).toBe(2000);
+  });
+
+  it('reads multi-digit delay-seconds', () => {
+    expect(parseRetryAfter('12')).toBe(12000);
   });
 
   it('tolerates surrounding whitespace', () => {
@@ -123,8 +169,28 @@ describe('parseRetryAfter', () => {
     expect(parseRetryAfter('Thu, 01 Jan 2026 00:00:03 GMT', now)).toBe(0);
   });
 
-  it.each([null, '', '   ', 'soon', '-1'])('returns undefined for %j', (header) => {
-    expect(parseRetryAfter(header)).toBeUndefined();
+  // '-1' and '1.5' are the reason for the day-name guard: Date.parse reads both
+  // as dates. An ISO timestamp is not a legal HTTP-date either, so it is refused
+  // too and the caller falls back to backoff.
+  it.each([null, '', '   ', 'soon', '-1', '1.5', '2s', '2026-01-01T00:00:03Z'])(
+    'returns undefined for %j',
+    (header) => {
+      expect(parseRetryAfter(header)).toBeUndefined();
+    },
+  );
+});
+
+describe('defaultRetryDeps', () => {
+  it('waits for real', async () => {
+    const started = Date.now();
+    await defaultRetryDeps.sleep(30);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(25);
+  });
+
+  it('draws jitter from the unit interval', () => {
+    const drawn = defaultRetryDeps.random();
+    expect(drawn).toBeGreaterThanOrEqual(0);
+    expect(drawn).toBeLessThan(1);
   });
 });
 

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -388,6 +388,58 @@ describe('fetchWithRetry — network failures', () => {
     );
   });
 
+  // Node's fetch refuses a URL with credentials by printing the whole URL, so the
+  // cause message is a second path a token can travel by.
+  describe('URLs quoted by the cause message', () => {
+    const messageFor = async (causeMessage: string): Promise<string> => {
+      const { attempt } = attempts(new TypeError(causeMessage));
+      const error = await fetchWithRetry(attempt, 'POST', TARGET, recordingDeps().deps).catch(
+        (e: unknown) => e,
+      );
+      return (error as ZendeskNetworkError).message;
+    };
+
+    it('strips credentials and the query string', async () => {
+      const message = await messageFor(
+        'Request cannot be constructed from a URL that includes credentials: https://user:secret@acme.zendesk.com/api/v2/uploads?token=upload-secret',
+      );
+      expect(message).not.toContain('secret');
+      expect(message).not.toContain('user:');
+      expect(message).not.toContain('token=');
+      expect(message).toContain('https://acme.zendesk.com/api/v2/uploads');
+    });
+
+    it("redacts an attachment URL's download token", async () => {
+      const message = await messageFor(
+        'socket hang up on https://acme.zendesk.com/attachments/token/AbCdEf123/',
+      );
+      expect(message).not.toContain('AbCdEf123');
+      expect(message).toContain('/attachments/token/[redacted]/');
+    });
+
+    it('drops a URL it cannot make an origin of', async () => {
+      const message = await messageFor('bad target gopher://user:secret@host/p?token=t');
+      expect(message).not.toContain('secret');
+      expect(message).toContain('[url]');
+    });
+
+    it('leaves a message without a URL untouched', async () => {
+      expect(await messageFor('socket hang up')).toBe(
+        `Network error on POST ${TARGET} after 1 attempt: socket hang up`,
+      );
+    });
+
+    it('redacts a non-error rejection too', async () => {
+      const attempt = () => Promise.reject('died at https://user:secret@acme.zendesk.com/p?a=b');
+      const error = await fetchWithRetry(attempt, 'POST', TARGET, recordingDeps().deps).catch(
+        (e: unknown) => e,
+      );
+      const message = (error as ZendeskNetworkError).message;
+      expect(message).not.toContain('secret');
+      expect(message).toContain('https://acme.zendesk.com/p');
+    });
+  });
+
   it('reports a code-less failure without an empty prefix', async () => {
     const { attempt } = attempts(netError());
     const { deps } = recordingDeps();

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -417,6 +417,24 @@ describe('fetchWithRetry — network failures', () => {
       expect(message).toContain('/attachments/token/[redacted]/');
     });
 
+    // The match must not depend on something preceding the URL: a message can
+    // open with it.
+    it('redacts a URL sitting at the very start of the message', async () => {
+      const message = await messageFor(
+        'https://user:secret@acme.zendesk.com/api/v2/tickets?token=t failed to connect',
+      );
+      expect(message).not.toContain('secret');
+      expect(message).not.toContain('token=t');
+      expect(message).toContain('https://acme.zendesk.com/api/v2/tickets failed to connect');
+    });
+
+    it('drops a URL-like substring it cannot parse', async () => {
+      const message = await messageFor('Failed to parse URL from http://[::1');
+      expect(message).toBe(
+        `Network error on POST ${TARGET} after 1 attempt: Failed to parse URL from [url]`,
+      );
+    });
+
     it('drops a URL it cannot make an origin of', async () => {
       const message = await messageFor('bad target gopher://user:secret@host/p?token=t');
       expect(message).not.toContain('secret');

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -487,7 +487,9 @@ describe('what a failed write tells the caller', () => {
   it.each(['POST', 'PUT', 'DELETE'] as const)(
     'warns that a %s may already have applied when the request may have been sent',
     async (method) => {
-      expect(await messageFor(method, netError('ECONNRESET'))).toContain(MAY_HAVE_APPLIED_NOTE);
+      const message = await messageFor(method, netError('ECONNRESET'));
+      expect(message).toContain(MAY_HAVE_APPLIED_NOTE);
+      expect(message).toContain('The write may already have been applied.');
     },
   );
 
@@ -496,6 +498,7 @@ describe('what a failed write tells the caller', () => {
     async (method) => {
       const message = await messageFor(method, netError('ENOTFOUND'));
       expect(message).toContain(NEVER_SENT_NOTE);
+      expect(message).toContain('The request never reached Zendesk, so nothing was applied.');
       expect(message).not.toContain(MAY_HAVE_APPLIED_NOTE);
     },
   );

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -112,6 +112,12 @@ describe('classifyNetworkError', () => {
     expect(classifyNetworkError(chainOfDepth(6, 'ENOTFOUND'))).toBe('unknown');
   });
 
+  // `typeof null === 'object'`, so a null cause has to be stopped on explicitly
+  // or the walk crashes while building an error message.
+  it('stops at a null cause', () => {
+    expect(classifyNetworkError(new TypeError('fetch failed', { cause: null }))).toBe('unknown');
+  });
+
   it('does not hang on a cyclic cause chain', () => {
     const err = new Error('loop') as Error & { cause?: unknown };
     err.cause = err;

--- a/tests/unit/client/retry.test.ts
+++ b/tests/unit/client/retry.test.ts
@@ -430,6 +430,39 @@ describe('fetchWithRetry — 429', () => {
     },
   );
 
+  // Zendesk sends Retry-After on a 503 during maintenance, not only on a 429.
+  it('honors Retry-After on a retriable 5xx', async () => {
+    const { attempt } = attempts(status(503, { 'Retry-After': '3' }), status(200));
+    const { sleeps, deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(response.status).toBe(200);
+    expect(sleeps).toStrictEqual([3000]);
+  });
+
+  it('surfaces a 5xx whose Retry-After is past the cap', async () => {
+    const { attempt, calls } = attempts(status(503, { 'Retry-After': '6' }), status(200));
+    const { sleeps, deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'GET', TARGET, deps);
+
+    expect(response.status).toBe(503);
+    expect(calls.count).toBe(1);
+    expect(sleeps).toStrictEqual([]);
+  });
+
+  it('ignores Retry-After on a 5xx the policy will not replay', async () => {
+    const { attempt, calls } = attempts(status(503, { 'Retry-After': '1' }), status(200));
+    const { sleeps, deps } = recordingDeps();
+
+    const response = await fetchWithRetry(attempt, 'POST', TARGET, deps);
+
+    expect(response.status).toBe(503);
+    expect(calls.count).toBe(1);
+    expect(sleeps).toStrictEqual([]);
+  });
+
   it('falls back to backoff when Retry-After is absent', async () => {
     const { attempt } = attempts(status(429), status(200));
     const { sleeps, deps } = recordingDeps();

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -341,6 +341,7 @@ describe('what a failed write tells the caller', () => {
     expect((error as ZendeskApiError).message).toContain(
       'The write may already have been applied.',
     );
+    expect((error as ZendeskApiError).method).toBe('POST');
   });
 
   // Asserted whole, not just "does not contain the note": nothing at all may be

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -200,6 +200,72 @@ describe('transient failure handling', () => {
   });
 });
 
+// Both uploads build their own request instead of going through executeRequest,
+// so what they put on the wire is only pinned here.
+describe('uploads', () => {
+  it('sends the raw bytes with auth, content type and the aggregating token', async () => {
+    mswServer.use(
+      http.post('https://testsubdomain.zendesk.com/api/v2/uploads', async ({ request }) => {
+        const url = new URL(request.url);
+        return HttpResponse.json({
+          upload: {
+            auth: request.headers.get('Authorization'),
+            contentType: request.headers.get('Content-Type'),
+            body: await request.text(),
+            filename: url.searchParams.get('filename'),
+            token: url.searchParams.get('token'),
+          },
+        });
+      }),
+    );
+
+    const result = await zendeskUpload<{ upload: Record<string, string | null> }>(
+      SUB,
+      TOKEN,
+      'shot.png',
+      Buffer.from('PNGDATA'),
+      'image/png',
+      'agg-token',
+    );
+
+    expect(result.upload).toStrictEqual({
+      auth: `Bearer ${TOKEN}`,
+      contentType: 'image/png',
+      body: 'PNGDATA',
+      filename: 'shot.png',
+      token: 'agg-token',
+    });
+  });
+
+  it('sends the form data with auth for a Help Center attachment', async () => {
+    mswServer.use(
+      http.post(
+        'https://testsubdomain.zendesk.com/api/v2/help_center/articles/5000/attachments',
+        async ({ request }) => {
+          const form = await request.formData();
+          return HttpResponse.json({
+            article_attachment: {
+              auth: request.headers.get('Authorization'),
+              file: form.get('file'),
+            },
+          });
+        },
+      ),
+    );
+    const formData = new FormData();
+    formData.set('file', 'contents');
+
+    const result = await helpCenterUpload<{
+      article_attachment: Record<string, string | null>;
+    }>(SUB, TOKEN, '/articles/5000/attachments', formData);
+
+    expect(result.article_attachment).toStrictEqual({
+      auth: `Bearer ${TOKEN}`,
+      file: 'contents',
+    });
+  });
+});
+
 describe('per-attempt deadline', () => {
   // Undici's own defaults are 300 s, so the signal reaching fetch is what keeps a
   // stalled socket from outliving the retry budget.

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -200,6 +200,45 @@ describe('transient failure handling', () => {
   });
 });
 
+describe('per-attempt deadline', () => {
+  // Undici's own defaults are 300 s, so the signal reaching fetch is what keeps a
+  // stalled socket from outliving the retry budget.
+  it('attaches a live abort signal to the request', async () => {
+    const seen: (AbortSignal | null)[] = [];
+    mswServer.use(
+      http.get('https://testsubdomain.zendesk.com/api/v2/users/me', ({ request }) => {
+        seen.push(request.signal);
+        return HttpResponse.json({ user: { id: 9999 } });
+      }),
+    );
+
+    await zendeskGet(SUB, TOKEN, '/users/me');
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBeInstanceOf(AbortSignal);
+    expect(seen[0]?.aborted).toBe(false);
+  });
+
+  it('gives each attempt its own deadline', async () => {
+    const signals: (AbortSignal | null)[] = [];
+    let hits = 0;
+    mswServer.use(
+      http.get('https://testsubdomain.zendesk.com/api/v2/flaky', ({ request }) => {
+        hits += 1;
+        signals.push(request.signal);
+        return hits === 1
+          ? HttpResponse.json({}, { status: 500 })
+          : HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await zendeskGet(SUB, TOKEN, '/flaky');
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).not.toBe(signals[1]);
+  });
+});
+
 describe('network error context', () => {
   it('names the failing request without leaking the token or the query', async () => {
     mswServer.use(

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -289,7 +289,9 @@ describe('what a failed write tells the caller', () => {
       ticket: { comment: { body: 'hi' } },
     }).catch((e: unknown) => e);
 
-    expect((error as ZendeskApiError).message).toContain(MAY_HAVE_APPLIED_NOTE);
+    const message = (error as ZendeskApiError).message;
+    expect(message).toContain(MAY_HAVE_APPLIED_NOTE);
+    expect(message).toContain('The write may already have been applied.');
   });
 
   it('says a throttled write was refused, so retrying is safe', async () => {
@@ -302,6 +304,43 @@ describe('what a failed write tells the caller', () => {
     const message = (error as ZendeskApiError).message;
     expect(message).toContain('Rate limit exceeded');
     expect(message).toContain(REFUSED_NOTE);
+    expect(message).toContain('Zendesk refused the request, so nothing was applied.');
+  });
+
+  // 400 falls to the same branch as 5xx but must not be annotated: it did not
+  // apply, and retrying it unchanged will not help either.
+  it('leaves a 400 on a write unannotated', async () => {
+    failing('put', '/tickets/1', 400);
+
+    const error = await zendeskPut(SUB, TOKEN, '/tickets/1', { ticket: {} }).catch(
+      (e: unknown) => e,
+    );
+
+    expect((error as ZendeskApiError).message).toMatch(/^Zendesk API error 400: .*\. \{\}$/);
+  });
+
+  it.each([
+    ['zendeskUpload', () => zendeskUpload(SUB, TOKEN, 'a.png', Buffer.from('x'), 'image/png')],
+    [
+      'helpCenterUpload',
+      () => helpCenterUpload(SUB, TOKEN, '/articles/5000/attachments', new FormData()),
+    ],
+  ])('warns that a failed %s may already have applied', async (_label, call) => {
+    mswServer.use(
+      http.post('https://testsubdomain.zendesk.com/api/v2/uploads', () =>
+        HttpResponse.json({}, { status: 500 }),
+      ),
+      http.post(
+        'https://testsubdomain.zendesk.com/api/v2/help_center/articles/5000/attachments',
+        () => HttpResponse.json({}, { status: 500 }),
+      ),
+    );
+
+    const error = await call().catch((e: unknown) => e);
+
+    expect((error as ZendeskApiError).message).toContain(
+      'The write may already have been applied.',
+    );
   });
 
   // Asserted whole, not just "does not contain the note": nothing at all may be

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -176,6 +176,22 @@ describe('transient failure handling', () => {
     expect(calls.count).toBe(1);
   });
 
+  // The mirror image of the tests above: a 429 is the one case where the client
+  // deliberately re-sends a mutation, because Zendesk refused it. `Retry-After: 0`
+  // exercises that header without putting a real wait in the suite.
+  it('replays a throttled POST exactly once', async () => {
+    const calls = counting('post', '/tickets', (hits) =>
+      hits === 1
+        ? HttpResponse.json({}, { status: 429, headers: { 'Retry-After': '0' } })
+        : HttpResponse.json({ ticket: { id: 42 } }),
+    );
+
+    await expect(
+      zendeskPost<{ ticket: { id: number } }>(SUB, TOKEN, '/tickets', { ticket: {} }),
+    ).resolves.toStrictEqual({ ticket: { id: 42 } });
+    expect(calls.count).toBe(2);
+  });
+
   it('surfaces a 404 unretried, with its message intact', async () => {
     const calls = counting('get', '/tickets/404', () => HttpResponse.json({}, { status: 404 }));
 

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -207,6 +207,25 @@ describe('network error context', () => {
     expect(message).toMatch(/^[ -~]*$/);
   });
 
+  it('still carries the Bearer token on a tenant-host download', async () => {
+    mswServer.use(
+      http.get('https://testsubdomain.zendesk.com/attachments/2.png', ({ request }) =>
+        HttpResponse.text(request.headers.get('Authorization') ?? 'none', {
+          headers: { 'content-type': 'image/png' },
+        }),
+      ),
+    );
+
+    const { data, contentType } = await fetchZendeskBinary(
+      SUB,
+      TOKEN,
+      'https://testsubdomain.zendesk.com/attachments/2.png',
+    );
+
+    expect(data.toString()).toBe(`Bearer ${TOKEN}`);
+    expect(contentType).toBe('image/png');
+  });
+
   it('wraps a binary download failure', async () => {
     mswServer.use(
       http.get('https://testsubdomain.zendesk.com/attachments/1.png', () => HttpResponse.error()),

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -347,6 +347,23 @@ describe('network error context', () => {
     expect(contentType).toBe('image/png');
   });
 
+  // An attachment content_url comes from Zendesk's response, so it is external
+  // input. Node refuses a URL carrying credentials by quoting all of it, which is
+  // how a download token could reach the client through the cause message.
+  it('keeps a credential-bearing content_url out of the error', async () => {
+    const error = await fetchZendeskBinary(
+      SUB,
+      TOKEN,
+      'https://user:secret@testsubdomain.zendesk.com/attachments/token/AbCdEf123/?name=shot.png',
+    ).catch((e: unknown) => e);
+
+    expect(isZendeskNetworkError(error)).toBe(true);
+    const message = (error as ZendeskNetworkError).message;
+    expect(message).not.toContain('secret');
+    expect(message).not.toContain('AbCdEf123');
+    expect(message).not.toContain('name=shot.png');
+  });
+
   it('wraps a binary download failure', async () => {
     mswServer.use(
       http.get('https://testsubdomain.zendesk.com/attachments/1.png', () => HttpResponse.error()),

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -1,13 +1,17 @@
 import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
+import { isZendeskNetworkError, type ZendeskNetworkError } from '../../../src/client/retry';
 import {
+  fetchZendeskBinary,
   helpCenterGet,
   helpCenterPost,
   helpCenterPut,
+  helpCenterUpload,
   ZendeskApiError,
   zendeskGet,
   zendeskPost,
   zendeskPut,
+  zendeskUpload,
 } from '../../../src/client/zendesk-api';
 import { mswServer } from '../../setup';
 
@@ -102,6 +106,147 @@ describe('helpCenterPut', () => {
       article: { title: 'Updated' },
     });
     expect(result.article.id).toBe(5000);
+  });
+});
+
+// The policy itself is unit-tested in retry.test.ts; these check that every
+// fetch call site in the client is actually wired to it.
+describe('transient failure handling', () => {
+  const counting = (
+    method: 'get' | 'post' | 'put',
+    path: string,
+    respond: (hits: number) => Response,
+  ) => {
+    const calls = { count: 0 };
+    mswServer.use(
+      http[method](`https://testsubdomain.zendesk.com/api/v2${path}`, () => {
+        calls.count += 1;
+        return respond(calls.count);
+      }),
+    );
+    return calls;
+  };
+
+  it('retries a GET through a 500 and returns the eventual success', async () => {
+    const calls = counting('get', '/flaky', (hits) =>
+      hits === 1 ? HttpResponse.json({}, { status: 500 }) : HttpResponse.json({ ok: true }),
+    );
+
+    await expect(zendeskGet<{ ok: boolean }>(SUB, TOKEN, '/flaky')).resolves.toStrictEqual({
+      ok: true,
+    });
+    expect(calls.count).toBe(2);
+  });
+
+  it('retries a GET through a network failure', async () => {
+    const calls = counting('get', '/flaky', (hits) =>
+      hits === 1 ? HttpResponse.error() : HttpResponse.json({ ok: true }),
+    );
+
+    await expect(zendeskGet<{ ok: boolean }>(SUB, TOKEN, '/flaky')).resolves.toStrictEqual({
+      ok: true,
+    });
+    expect(calls.count).toBe(2);
+  });
+
+  it('never replays a POST that failed with a 500, so a create cannot double', async () => {
+    const calls = counting('post', '/tickets', () => HttpResponse.json({}, { status: 500 }));
+
+    await expect(zendeskPost(SUB, TOKEN, '/tickets', { ticket: {} })).rejects.toThrow(
+      /Zendesk API error 500/,
+    );
+    expect(calls.count).toBe(1);
+  });
+
+  it('never replays a PUT that failed with a 500, so a comment cannot double', async () => {
+    const calls = counting('put', '/tickets/1', () => HttpResponse.json({}, { status: 500 }));
+
+    await expect(
+      zendeskPut(SUB, TOKEN, '/tickets/1', { ticket: { comment: { body: 'hi' } } }),
+    ).rejects.toBeInstanceOf(ZendeskApiError);
+    expect(calls.count).toBe(1);
+  });
+
+  it('never replays a POST that failed before any response', async () => {
+    const calls = counting('post', '/tickets', () => HttpResponse.error());
+
+    await expect(zendeskPost(SUB, TOKEN, '/tickets', { ticket: {} })).rejects.toSatisfy(
+      isZendeskNetworkError,
+    );
+    expect(calls.count).toBe(1);
+  });
+
+  it('surfaces a 404 unretried, with its message intact', async () => {
+    const calls = counting('get', '/tickets/404', () => HttpResponse.json({}, { status: 404 }));
+
+    await expect(zendeskGet(SUB, TOKEN, '/tickets/404')).rejects.toThrow(/not found/);
+    expect(calls.count).toBe(1);
+  });
+});
+
+describe('network error context', () => {
+  it('names the failing request without leaking the token or the query', async () => {
+    mswServer.use(
+      http.get('https://testsubdomain.zendesk.com/api/v2/flaky', () => HttpResponse.error()),
+    );
+
+    const error = await zendeskGet(SUB, TOKEN, '/flaky', {
+      'page[size]': '10',
+      secret: 'super-secret-value',
+    }).catch((e: unknown) => e);
+
+    expect(isZendeskNetworkError(error)).toBe(true);
+    const message = (error as ZendeskNetworkError).message;
+    expect(message).toContain('Network error on GET');
+    expect(message).toContain('https://testsubdomain.zendesk.com/api/v2/flaky');
+    expect(message).toContain('after 3 attempts');
+    expect(message).not.toContain(TOKEN);
+    expect(message).not.toContain('super-secret-value');
+    expect(message).not.toContain('page[size]');
+    // ASCII only: non-ASCII bytes break node:http headers on the auth paths.
+    expect(message).toMatch(/^[ -~]*$/);
+  });
+
+  it('wraps a binary download failure', async () => {
+    mswServer.use(
+      http.get('https://testsubdomain.zendesk.com/attachments/1.png', () => HttpResponse.error()),
+    );
+
+    const error = await fetchZendeskBinary(
+      SUB,
+      TOKEN,
+      'https://testsubdomain.zendesk.com/attachments/1.png',
+    ).catch((e: unknown) => e);
+
+    expect(isZendeskNetworkError(error)).toBe(true);
+    expect((error as ZendeskNetworkError).method).toBe('GET');
+  });
+
+  it.each([
+    [
+      'zendeskUpload',
+      () => zendeskUpload(SUB, TOKEN, 'a.png', Buffer.from('x'), 'image/png', 'agg-token'),
+      'https://testsubdomain.zendesk.com/api/v2/uploads',
+    ],
+    [
+      'helpCenterUpload',
+      () => helpCenterUpload(SUB, TOKEN, '/articles/5000/attachments', new FormData()),
+      'https://testsubdomain.zendesk.com/api/v2/help_center/articles/5000/attachments',
+    ],
+  ])('wraps a %s failure without retrying the upload', async (_label, call, target) => {
+    const calls = { count: 0 };
+    mswServer.use(
+      http.post(target, () => {
+        calls.count += 1;
+        return HttpResponse.error();
+      }),
+    );
+
+    const error = await call().catch((e: unknown) => e);
+
+    expect(isZendeskNetworkError(error)).toBe(true);
+    expect((error as ZendeskNetworkError).target).toBe(target);
+    expect(calls.count).toBe(1);
   });
 });
 

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -304,17 +304,40 @@ describe('what a failed write tells the caller', () => {
     expect(message).toContain(REFUSED_NOTE);
   });
 
-  it.each([
-    ['500', 500],
-    ['429', 429],
-  ])('adds no such note to a read that got a %s', async (_label, code) => {
-    failing('get', '/flaky', code, { 'Retry-After': '600' });
+  // Asserted whole, not just "does not contain the note": nothing at all may be
+  // appended to a read's message.
+  it('leaves a read that got a 500 exactly as it was', async () => {
+    failing('get', '/flaky', 500);
 
     const error = await zendeskGet(SUB, TOKEN, '/flaky').catch((e: unknown) => e);
 
-    const message = (error as ZendeskApiError).message;
-    expect(message).not.toContain(MAY_HAVE_APPLIED_NOTE);
-    expect(message).not.toContain(REFUSED_NOTE);
+    expect((error as ZendeskApiError).message).toMatch(/^Zendesk API error 500: .*\. \{\}$/);
+  });
+
+  it('leaves a throttled read exactly as it was', async () => {
+    failing('get', '/flaky', 429, { 'Retry-After': '600' });
+
+    const error = await zendeskGet(SUB, TOKEN, '/flaky').catch((e: unknown) => e);
+
+    expect((error as ZendeskApiError).message).toBe(
+      'Rate limit exceeded. Please wait before making more requests.',
+    );
+  });
+
+  it('leaves a failed attachment download unannotated, since it is a read', async () => {
+    mswServer.use(
+      http.get('https://testsubdomain.zendesk.com/attachments/9.png', () =>
+        HttpResponse.json({}, { status: 500 }),
+      ),
+    );
+
+    const error = await fetchZendeskBinary(
+      SUB,
+      TOKEN,
+      'https://testsubdomain.zendesk.com/attachments/9.png',
+    ).catch((e: unknown) => e);
+
+    expect((error as ZendeskApiError).message).toMatch(/^Zendesk API error 500: .*\. \{\}$/);
   });
 
   it('leaves a 404 and a 422 unchanged', async () => {

--- a/tests/unit/client/zendesk-api.test.ts
+++ b/tests/unit/client/zendesk-api.test.ts
@@ -1,6 +1,11 @@
 import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
-import { isZendeskNetworkError, type ZendeskNetworkError } from '../../../src/client/retry';
+import {
+  isZendeskNetworkError,
+  MAY_HAVE_APPLIED_NOTE,
+  REFUSED_NOTE,
+  type ZendeskNetworkError,
+} from '../../../src/client/retry';
 import {
   fetchZendeskBinary,
   helpCenterGet,
@@ -263,6 +268,63 @@ describe('uploads', () => {
       auth: `Bearer ${TOKEN}`,
       file: 'contents',
     });
+  });
+});
+
+// Same reasoning as the network errors: a 5xx write is not replayed here because
+// it may have applied, so the message has to say that rather than let the caller
+// retry into a duplicate.
+describe('what a failed write tells the caller', () => {
+  const failing = (method: 'get' | 'post' | 'put', path: string, code: number, headers = {}) =>
+    mswServer.use(
+      http[method](`https://testsubdomain.zendesk.com/api/v2${path}`, () =>
+        HttpResponse.json({}, { status: code, headers }),
+      ),
+    );
+
+  it('warns that a 500 on a write may already have applied', async () => {
+    failing('put', '/tickets/1', 500);
+
+    const error = await zendeskPut(SUB, TOKEN, '/tickets/1', {
+      ticket: { comment: { body: 'hi' } },
+    }).catch((e: unknown) => e);
+
+    expect((error as ZendeskApiError).message).toContain(MAY_HAVE_APPLIED_NOTE);
+  });
+
+  it('says a throttled write was refused, so retrying is safe', async () => {
+    failing('post', '/tickets', 429, { 'Retry-After': '600' });
+
+    const error = await zendeskPost(SUB, TOKEN, '/tickets', { ticket: {} }).catch(
+      (e: unknown) => e,
+    );
+
+    const message = (error as ZendeskApiError).message;
+    expect(message).toContain('Rate limit exceeded');
+    expect(message).toContain(REFUSED_NOTE);
+  });
+
+  it.each([
+    ['500', 500],
+    ['429', 429],
+  ])('adds no such note to a read that got a %s', async (_label, code) => {
+    failing('get', '/flaky', code, { 'Retry-After': '600' });
+
+    const error = await zendeskGet(SUB, TOKEN, '/flaky').catch((e: unknown) => e);
+
+    const message = (error as ZendeskApiError).message;
+    expect(message).not.toContain(MAY_HAVE_APPLIED_NOTE);
+    expect(message).not.toContain(REFUSED_NOTE);
+  });
+
+  it('leaves a 404 and a 422 unchanged', async () => {
+    failing('put', '/tickets/1', 422);
+
+    const error = await zendeskPut(SUB, TOKEN, '/tickets/1', { ticket: {} }).catch(
+      (e: unknown) => e,
+    );
+
+    expect((error as ZendeskApiError).message).toBe('Validation error: {}');
   });
 });
 


### PR DESCRIPTION
## Summary

Every tool call reaches Zendesk through the shared client, and two rough edges surfaced during the #170 functional validation on a slow link: a `fetch` throw reached the LLM as a bare `fetch failed` naming nothing, and a single transient blip failed the whole tool call. This adds one method-keyed retry policy (`src/client/retry.ts`) and routes **all four** fetch call sites through a single `performFetch`, so transient failures recover silently while writes stay duplicate-safe.

## Linked issue

Closes #193

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## What changed

`src/client/retry.ts` (new) holds the policy and nothing else:

| Method | Network failure | `5xx` | `429` |
| --- | --- | --- | --- |
| `GET` | retried (any phase) | retried | retried |
| `POST`, `PUT`, `DELETE` | retried only pre-send | **never** | retried |

- **Network failures are named.** `Network error on GET https://acme.zendesk.com/api/v2/help_center/articles/123 after 3 attempts: ECONNRESET: fetch failed` — method + origin + path, ASCII-only, original error kept as `cause`, and credential-free: the query string is dropped (`zendeskUpload` puts an upload token there) and an attachment URL's `/token/<token>/` path segment is redacted.  An Error factory + `isZendeskNetworkError` guard, matching `createAuthRequiredError` rather than adding a second error class.
- **Bounded retry:** up to 3 attempts (two retries), 250 ms base, exponential with equal jitter, capped at 4 s. `Retry-After` wins over backoff wherever it appears (a `429`, or a `503` during maintenance) up to 5 s; past that the response is surfaced instead of parking the call. A response that will be replayed is drained first so the socket is released — and a body that dies mid-drain doesn't abort the retry.
- **Per-attempt deadline:** `AbortSignal.timeout` — 30 s for JSON calls, 120 s for attachment downloads and uploads. Node's `fetch` has no deadline of its own (undici's `headersTimeout`/`bodyTimeout` default to **300 s**), so a stalled socket could otherwise hold a tool call open long past the retry budget, which cannot fire while an attempt is pending. The signal is built inside the retry thunk, so each attempt starts fresh.
- **All four call sites** now share `performFetch`: `executeRequest`, `fetchZendeskBinary`, `zendeskUpload`, `helpCenterUpload`.
- `ZendeskApiError` and every per-status message are untouched, so the 401 backstop in `server.ts` and the `403`/`404` branches in the tools behave exactly as before.

Only a `GET` is replayed freely. Everything else replays exclusively what provably did not apply:

- **`PUT` counts as non-idempotent** despite HTTP semantics: `PUT /tickets/{id}` with a `comment` *appends* one (`add_private_note`, `add_public_comment`), so a blind replay would duplicate it. The client sits below the tool layer and cannot see `idempotentHint`, so the method is all it has.
- **`DELETE` is not "retried freely"** as the issue suggested, on either a network failure or a `5xx`: replaying a delete that already applied reports a misleading `404` for work that succeeded.
- **`429` is retried on writes** — Zendesk refused the request, so it provably did not apply. A `5xx` may have applied and is therefore terminal.
- **A deadline abort needs no new rule.** It arrives as a `TimeoutError` whose `code` is numeric rather than a syscall string, so it classifies as `unknown`: a GET is retried, a write never is, since the request may have arrived before the deadline passed.

No new env var or CLI flag: the budget is hardcoded, and timing is injected at the function level (`RetryDeps`) so tests are deterministic.

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally (871 tests)
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed (`docs/troubleshooting.md`; one durable rule in `AGENTS.md`)
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` — n/a, no tool-surface change
- [x] If the change has **MCP-runtime-observable** behaviour: this PR carries a `## Functional validation plan` below, executable end to end by one command

`pnpm test:mutation:diff origin/main HEAD`: **175 mutants in the changed lines, 175 killed, 0 escaped.**

### Review rounds

`/code-review` found four issues, fixed in `9591752`: a 5xx DELETE was being replayed (contradicting the policy's own rationale), the body drain could throw out of the retry loop, an attachment download token leaked through the path, and two inaccurate sentences in the troubleshooting doc.

CodeRabbit then found four more, all valid:

| Finding | Outcome |
| --- | --- |
| No per-attempt deadline (Major) | Fixed in `4d556d1` — was an explicit non-goal, included after the maintainer chose to |
| `Retry-After` ignored on a retriable `5xx` | Fixed in `4e31297` |
| No client-level test for a `429` replaying a write | Added in `4e31297` (`Retry-After: 0`, so the suite doesn't wait) |
| `AGENTS.md` said "every request" | Scoped to Zendesk API requests in `4e31297`; the OAuth token exchange calls `fetch` directly |

The upload call sites also turned out to have no happy-path test at all — the mutation gate caught it once those lines were touched. `afee290` pins what both uploads put on the wire (auth header, content type, body, aggregating token).

## Functional validation plan

Two parts, because they answer different questions. Part B is the one that used to
be impossible: the retry, timeout and write-safety behaviour only shows itself when
Zendesk misbehaves, which a healthy tenant never does on request. It is now one
command.

### Part A — the live tenant (the tools still work)

Only a real tenant proves the four fetch paths still function and that a write
produces exactly one artifact. Use a throwaway ticket and a draft article.

| id | Call | Expected |
| --- | --- | --- |
| **A1** | `list_articles`, then `get_article` on a returned id | both succeed, sub-second |
| **A2** | `add_private_note` with a recognizable body, then re-read the ticket | the note appears **exactly once** — report the ticket id and the count |
| **A3** | `get_ticket_attachments` on a ticket holding an image | image content back, not a `401`/`403` (which would mean the auth header was lost) |
| **A4** | `add_private_note` with a small `attachments` entry, and `create_article_attachment` on the draft | both succeed, attached once |
| **A5** | `get_article` with id `999999999` | still `Resource not found…`, returning **immediately** — a ~1 s pause would mean 4xx is being retried |
| **A6** | the largest attachment you can find (> 1 MB) | completes; the 120 s transfer deadline must not cut real work short |

### Part B — the failure paths, deterministically

```bash
pnpm build && node scripts/validate-retry.mjs      # ~40 s
```

Each scenario boots the real server with `scripts/fault-inject.mjs` preloaded and
drives a real MCP tool call over stdio. It judges on what the caller received **and
on how many requests Zendesk actually saw** — that count is what proves a write was
not replayed, where a message could be misread. Non-zero exit if any scenario
fails; `--skip-slow` drops the 30 s deadline case.

| id | Proves |
| --- | --- |
| **S1** | a healthy read goes through untouched (1 request) |
| **S2** | a transient failure is absorbed, the caller never sees it (2 requests) |
| **S3** | a read spends its whole budget on a `5xx` (3 requests) |
| **S4** | a `5xx` write is **never replayed** (1 request) and says it may have applied |
| **S5** | a throttled write **is** replayed, exactly once (2 requests, succeeds) — the only path where the client deliberately re-sends a mutation |
| **S6** | a `Retry-After` beyond the 5 s cap is surfaced instead of parking the call (1 request) |
| **S7** | a write that failed with no response is not replayed, and the message carries no credential |
| **S8** | a read retries a response-less failure and then names it (3 requests) |
| **S9** | a transfer slower than the 30 s JSON deadline still completes on the binary path — the two budgets are genuinely distinct |
| **S10** | a stalled socket is cut by the per-attempt deadline (~30 s), not left hanging |
| **S11** | a `404` is terminal: one request, wording untouched |

### What this still cannot prove

`HttpResponse.error()` raises a failure with **no syscall code**, so the simulator
cannot tell a pre-send `ENOTFOUND` from an in-flight `ECONNRESET`. The "never
reached Zendesk, retrying is safe" branch is therefore covered by unit tests only;
reaching it live would need a fault-injecting proxy, which in turn needs a base-URL
override the client deliberately does not have.

### Reporting

Post one PR comment in English: the SHA tested, the pasted output of Part B, and
per-id verdicts for Part A with the artifact counts for A2 and A4.

## Notes for the reviewer (human or AI)

- **Why the mechanics are hand-rolled rather than a library'''s** is now recorded in [`docs/decisions/client-retry.md`](docs/decisions/client-retry.md), with the spike behind it: undici'''s retry interceptor would remove the most (loop, backoff, `Retry-After`, sockets) but MSW intercepts **above** the dispatcher, so it never runs in the suite; the fetch-level alternative is testable and expresses the policy exactly, but removes only ~40 lines and last shipped in March 2024. The doc also states plainly that "a library would replay a `PUT` by default" is *not* a valid argument for owning the loop — that choice is configuration.
- **The idempotency table is the design decision to check.** Specifically: is treating `PUT` as non-idempotent the right call (it is what makes `add_public_comment` safe), and is retrying writes on `429` acceptable?
- **The two deadlines are a judgement call**: 30 s JSON / 120 s transfers. Deliberately generous, since aborting a legitimate slow upload is worse than waiting.
- The cause-chain walk is depth-bounded (5 levels) rather than cycle-detecting, and stops explicitly on `null` (`typeof null === 'object'` would otherwise crash while building an error message). Both bounds are pinned by tests.
- TLS/certificate failures are classified `unknown`, so a GET retries them 3 times (~0.5 s) before failing. Deliberate: keeping the pre-send list short and explicit beats enumerating every deterministic-but-unretriable code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resilient handling for network failures, server errors, and rate limits across Zendesk requests.
  * Added per-attempt timeouts and safer retry behavior that avoids replaying potentially completed updates.
  * Improved error messages with sanitized request details.
  * Extended reliability safeguards to downloads and attachment uploads.

* **Documentation**
  * Added troubleshooting guidance for network failures and retry behavior.
  * Documented retry policies, design considerations, and live validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
_Generated by [Claude Code](https://claude.ai/code)_