### PR TITLE
ci: publish the mutation score to the Stryker dashboard

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -78,14 +78,7 @@ jobs:
         id: cache
 
       # Reports, never `break`s. No `--`: pnpm 11 forwards the separator itself.
-      #
-      # The key is scoped to this step, and this step only exists on
-      # `push`/`workflow_dispatch` — so the diff gate cannot publish even by
-      # accident, and a fork PR (which gets no secrets at all) cannot 401. It is
-      # also the switch that turns the `dashboard` reporter on: an unset secret
-      # expands to an empty string, which leaves the reporter off and this run
-      # exactly as it was before. Only the baseline writes, same rule the
-      # incremental cache already follows.
+      # Step-scoped secret, so only the baseline can publish — same rule as the cache.
       - name: Run the full scope
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -78,7 +78,18 @@ jobs:
         id: cache
 
       # Reports, never `break`s. No `--`: pnpm 11 forwards the separator itself.
-      - run: pnpm test:mutation --incremental
+      #
+      # The key is scoped to this step, and this step only exists on
+      # `push`/`workflow_dispatch` — so the diff gate cannot publish even by
+      # accident, and a fork PR (which gets no secrets at all) cannot 401. It is
+      # also the switch that turns the `dashboard` reporter on: an unset secret
+      # expands to an empty string, which leaves the reporter off and this run
+      # exactly as it was before. Only the baseline writes, same rule the
+      # incremental cache already follows.
+      - name: Run the full scope
+        env:
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        run: pnpm test:mutation --incremental
 
       - name: Score summary
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,13 @@
 # Contributing
 
+[![Mutation score](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Ffruggr%2Fzendesk-mcp-server%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/fruggr/zendesk-mcp-server/main)
+
 Thanks for considering a contribution to `@fruggr/zendesk-mcp-server`. See the
 [README](README.md) for what the project does and how to run it.
+
+The badge is `main`'s mutation score; it links to the browsable report, where
+the survivors are listed per file. That report is the fastest way to find a test
+worth writing — see [the mutation gate](#submission-quality-bar) before you push.
 
 ## Review philosophy
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Zendesk MCP Server
 
 [![Glama score](https://glama.ai/mcp/servers/fruggr/zendesk-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/fruggr/zendesk-mcp-server)
-[![Mutation score](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Ffruggr%2Fzendesk-mcp-server%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/fruggr/zendesk-mcp-server/main)
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-io.github.fruggr%2Fzendesk--mcp--server-0a7ea4)](https://registry.modelcontextprotocol.io/?search=io.github.fruggr/zendesk-mcp-server)
 [![npm version](https://img.shields.io/npm/v/@fruggr/zendesk-mcp-server?logo=npm&color=cb3837)](https://www.npmjs.com/package/@fruggr/zendesk-mcp-server)
 [![License: MIT](https://img.shields.io/npm/l/@fruggr/zendesk-mcp-server?color=blue)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Zendesk MCP Server
 
 [![Glama score](https://glama.ai/mcp/servers/fruggr/zendesk-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/fruggr/zendesk-mcp-server)
+[![Mutation score](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Ffruggr%2Fzendesk-mcp-server%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/fruggr/zendesk-mcp-server/main)
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-io.github.fruggr%2Fzendesk--mcp--server-0a7ea4)](https://registry.modelcontextprotocol.io/?search=io.github.fruggr/zendesk-mcp-server)
 [![npm version](https://img.shields.io/npm/v/@fruggr/zendesk-mcp-server?logo=npm&color=cb3837)](https://www.npmjs.com/package/@fruggr/zendesk-mcp-server)
 [![License: MIT](https://img.shields.io/npm/l/@fruggr/zendesk-mcp-server?color=blue)](LICENSE)

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -378,141 +378,99 @@ information is.
 
 ## 7. Publishing the score, so the trend outlives the run
 
-Everything above produces numbers that are thrown away. The HTML report ships as
-a CI artifact (30 days for the baseline, 7 for a PR) and then expires; the cached
-`stryker-incremental.json` is *current state*, overwritten on every push to
-`main`, not a history. So "where was `src/auth` a month ago" had no answer.
-
-The [Stryker dashboard](https://stryker-mutator.io/docs/General/dashboard/)
-answers it: free for open source, keeps a trend line per branch, hosts the full
-report per version, and serves a score badge. The reporter is **first-party** —
-`dashboard` is built into `@stryker-mutator/core`, so this adds no dependency.
+The HTML report expires as a CI artifact (30 days baseline, 7 for a PR) and the
+incremental cache is *current state*, overwritten on every push to `main`. So
+"where was `src/auth` a month ago" had no answer. The
+[Stryker dashboard](https://stryker-mutator.io/docs/General/dashboard/) keeps a
+trend line per branch and hosts the full report; its reporter ships inside
+`@stryker-mutator/core`, so this adds no dependency.
 
 ### `reportType: 'full'` — decided, not inherited
 
-`full` uploads the whole report, **source snippets included**, to a third party.
-`mutationScore` sends `{ mutationScore: 42 }` and nothing else.
+`full` uploads the report with its **source snippets** to a third party;
+`mutationScore` sends only the number. `full` wins because it makes the survivor
+table browsable per file online, which is most of what a hand-maintained
+per-area table is for. The disclosure question has a short answer here: the
+source is already public on GitHub and npm. In a private repo the choice would
+go the other way — so if a private or credential-bearing file ever enters the
+`mutate` scope, revisit this.
 
-`full` wins here for one reason: it is what makes the survivor table *browsable*
-online, per file, without downloading an artifact — which is most of what a
-hand-maintained per-area table is for. The disclosure question is real but has a
-short answer in this repo: the source is public on npm and on GitHub already, so
-the upload discloses nothing that a `git clone` does not. In a private repo the
-choice would go the other way.
+It is also Stryker's default, written out anyway because a default is not a
+decision. `project` and `version` stay unset: `GithubActionsCIProvider` derives
+them from `GITHUB_REPOSITORY` and `GITHUB_REF` (`refs/heads/main` → `main`,
+`refs/pull/7/merge` → `PR-7`).
 
-`full` also happens to be Stryker's default. It is written out in
-`stryker.config.mjs` anyway, because a default is not a decision and the next
-reader should not have to look up which one they got.
+**`module` is not used.** A trend line per scoped area needs a separate run per
+area, multiplying the cold baseline. The per-*file* breakdown comes free with a
+`full` upload, which is the part actually wanted.
 
-`project` and `version` are deliberately **not** set. `GithubActionsCIProvider`
-derives them from `GITHUB_REPOSITORY` and `GITHUB_REF` (`refs/heads/main` →
-`main`, `refs/pull/7/merge` → `PR-7`), so the baseline publishes under the branch
-it ran on and there is nothing to keep in sync.
+### Why the reporter is gated on the key
 
-**`module` is not used.** It looks like the cheap way to get a trend line per
-scoped area, and it is not: a separate module means a separate run, multiplying
-the cold baseline by the number of areas. The per-*file* breakdown comes free
-with a `full` upload, which is the part actually wanted. Revisit only if per-area
-trends prove to be a distinct need.
+Nothing guards the upload: `DashboardReporterClient` PUTs whether or not
+`STRYKER_DASHBOARD_API_KEY` is set, and the only precondition — that `project`
+and `version` resolve — always holds on Actions.
 
-### Why the reporter is gated on the key, when a missing key is harmless
-
-`DashboardReporterClient` sends the PUT whether or not `STRYKER_DASHBOARD_API_KEY`
-is set — the only guard before it checks that `project` and `version` resolve,
-which on Actions they always do. A keyless PUT comes back 401 and the client
-throws a `StrykerError`.
-
-That error does **not** fail the run. `DashboardReporter.update()` catches it and
-logs `Could not upload report.`. Measured on 9.6.1, forcing the failure with a
-dead `dashboard.baseUrl` under a faked Actions environment:
-
-```text
-INFO  DashboardReporterClient PUT report to http://127.0.0.1:9/api/reports/github.com/fruggr/zendesk-mcp-server/main (~81654 bytes)
-ERROR DashboardReporter       Could not upload report. Error: connect ECONNREFUSED 127.0.0.1:9
-INFO  MutationTestExecutor    Done in 17 seconds.
-                                                                    exit code 0
-```
-
-Worth re-checking on a major bump — an earlier reading of this code assumed the
-throw escaped and failed the job. It does not. So the honest reason for the gate
-is not "CI would break":
-
-- a red `ERROR Could not upload report.` on every local run and every fork PR is
-  a false alarm in the one job whose output people read for real alarms;
-- PR runs are diff-scoped. A PR that *did* have a key would publish a report
-  covering the changed lines only — a truncated entry corrupting the trend, which
-  is worse than not publishing.
+The resulting 401 does **not** fail the run; `DashboardReporter.update()` catches
+it and logs `Could not upload report.` (measured on 9.6.1 with a dead `baseUrl`,
+exit code 0 — an earlier reading assumed the throw escaped, so re-check on a
+major bump). The gate earns its place for two quieter reasons: a red `ERROR` on
+every fork PR is a false alarm in the one job people read for real alarms, and a
+PR run that *did* have a key would publish its diff-scoped report — a truncated
+entry corrupting the trend.
 
 So the config enables the reporter exactly when the key exists, and the workflow
-hands the secret to the `Full scope` step alone. The two together mean a PR run —
-fork or not — has no key, therefore no reporter, therefore no request. That reuses
-the rule the incremental cache already follows (*only the baseline writes*) and
-gets it structurally rather than by remembering to pass `--reporters` at the call
-site, which would restate the whole reporter list in YAML.
+hands the secret to the `Full scope` step alone. A PR run, fork or not, has no
+key, therefore no reporter, therefore no request — the same rule the incremental
+cache follows (*only the baseline writes*), and structural rather than
+remembered. Local runs never publish either: without a key there is no reporter,
+and with one `determineCIProvider()` finds no `GITHUB_ACTION` and stops before
+the PUT.
 
-A **local** run is safe twice over, which is worth knowing before anyone worries
-about a stray key in a shell: with no key the reporter is not in the list at all
-(`pnpm test:mutation --mutate src/utils/validation.ts` logs `JsonReporter` and
-`HtmlReporter` and nothing else), and even *with* a key it stops before the PUT,
-because `determineCIProvider()` finds no `GITHUB_ACTION` and logs `The report was
-not send to the dashboard. The dashboard.project and/or dashboard.version values
-were missing`.
+### One-time setup
 
-### One-time setup, and the organisation question
+The API key cannot be minted from CI. A human enables the project once at
+<https://dashboard.stryker-mutator.io>, picks the `fruggr` organisation and
+`zendesk-mcp-server`, then copies the key into the **repository secret**
+`STRYKER_DASHBOARD_API_KEY` (the Secrets tab, not Variables — `${{ secrets.X }}`
+does not read the other one). The next push to `main` publishes.
 
-The API key cannot be minted from CI; a human enables the project once:
+The baseline log tells you which of three states you are in: no
+`DashboardReporter` line at all means no key reached the run; `PUT report to …`
+followed by `Could not upload report.` means the key is wrong; `PUT report to …`
+alone means it worked.
 
-1. sign in at <https://dashboard.stryker-mutator.io> with GitHub;
-2. pick the `fruggr` organisation, find `zendesk-mcp-server`, enable it;
-3. copy the key into the repository secret `STRYKER_DASHBOARD_API_KEY`;
-4. the next push to `main` publishes.
+#### If the account picker offers only your personal account
 
-**Organisation-owned repositories are supported** — this needed checking, because
-the dashboard UI leads with personal repositories and the docs never say. The
-backend has a dedicated organisations route (`GET /organizations/:name/repositories`
-→ `GET /orgs/{login}/repos?type=member`), enabling a project requires only **push**
-permission rather than admin, and the reference deployment publishes
-`github.com/stryker-mutator/stryker-js`, itself an organisation repository.
+Expect this on the first attempt — and it is not a missing feature.
+Organisation repositories are supported: the backend has a dedicated route
+(`GET /organizations/:name/repositories` → `GET /orgs/{login}/repos?type=member`),
+enabling a project needs only **push** permission, and the reference deployment
+publishes `github.com/stryker-mutator/stryker-js`, itself an organisation repo.
 
-#### When step 2 offers only your personal account
+The picker is `GET /user/orgs`, which GitHub documents as listing *"only
+organizations that your authorization allows you to operate on in some way"*. A
+missing organisation is an OAuth grant that was never given, not a permission on
+the repository. The dashboard is a **classic OAuth App** (`user:email read:org`,
+so public repositories only), which means an organisation with OAuth App access
+restrictions hides itself until an owner approves it.
 
-Expect this on the first attempt: the account picker lists `dlecan` and no
-organisation at all. It is not a missing feature. The picker is fed by
-`GET /user/organizations` → `GithubAgent.getMyOrganizations()` →
-`GET https://api.github.com/user/orgs`, and GitHub documents that endpoint as
-listing *"only organizations that your authorization allows you to operate on in
-some way"*. A missing organisation means the OAuth authorisation does not cover
-it — nothing about permissions on the repository itself.
+Fix it at <https://github.com/settings/applications> → **Authorized OAuth Apps**
+→ Stryker Dashboard → **Organization access**:
 
-To fix it, at <https://github.com/settings/applications> → **Authorized OAuth
-Apps** → the Stryker Dashboard entry → **Organization access**, the `fruggr` row
-shows one of:
+| The `fruggr` row shows | What to do |
+| --- | --- |
+| **Grant** | you are an owner — click it |
+| **Request** | request it; an owner grants at *fruggr → Settings → Third-party Access → OAuth app policy → Review → Grant access* |
+| green check | already granted — the stored token predates it, so sign out and back in |
 
-| What the row shows | What it means | What to do |
-| --- | --- | --- |
-| **Grant** button | OAuth App restrictions are on, and you are an owner | click it |
-| **Request** button | restrictions are on, you are not an owner | request; an owner grants at *fruggr → Settings → Third-party Access → OAuth app policy → Review → Grant access* |
-| green check | already granted | the stored token predates the grant — see below |
+Signing out and back in matters in every case: the backend stores the access
+token at login, so a later grant never reaches the token already on file. If it
+still fails, revoke the app and re-authorise — the consent screen offers the
+organisation directly.
 
-Then **sign out of the dashboard and back in**. This is the step that gets
-skipped: the backend stores the access token in its `users` table at login, so a
-grant made afterwards does not reach the token already on file. If that still
-fails, revoke the app from the same settings page and re-authorise from scratch —
-the consent screen offers the organisation directly.
-
-If an owner declines outright there is no workaround worth having. The API key is
-minted per project and requires the project to be enabled, and the only fallback —
-pinning `dashboard.project` to a personal fork — puts the trend and the badge
-under someone's personal account. Park the work instead.
-
-Two organisation-specific gotchas, both one-off:
-
-- the dashboard is a **classic OAuth App** (scopes `user:email read:org`). If the
-  organisation has OAuth App access restrictions enabled, an owner must approve it
-  first — until then the organisation simply does not appear in the list, which
-  reads exactly like "orgs are not supported";
-- there is no `repo` scope, so only **public** repositories are listed. Fine here;
-  a blocker for a private one.
+If an owner declines there is no workaround worth having: the key is minted per
+project, and the only fallback (pinning `dashboard.project` to a personal fork)
+puts the trend and the badge under someone's personal account.
 
 ## Appendix — reproducing
 

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -474,6 +474,37 @@ backend has a dedicated organisations route (`GET /organizations/:name/repositor
 permission rather than admin, and the reference deployment publishes
 `github.com/stryker-mutator/stryker-js`, itself an organisation repository.
 
+#### When step 2 offers only your personal account
+
+Expect this on the first attempt: the account picker lists `dlecan` and no
+organisation at all. It is not a missing feature. The picker is fed by
+`GET /user/organizations` → `GithubAgent.getMyOrganizations()` →
+`GET https://api.github.com/user/orgs`, and GitHub documents that endpoint as
+listing *"only organizations that your authorization allows you to operate on in
+some way"*. A missing organisation means the OAuth authorisation does not cover
+it — nothing about permissions on the repository itself.
+
+To fix it, at <https://github.com/settings/applications> → **Authorized OAuth
+Apps** → the Stryker Dashboard entry → **Organization access**, the `fruggr` row
+shows one of:
+
+| What the row shows | What it means | What to do |
+| --- | --- | --- |
+| **Grant** button | OAuth App restrictions are on, and you are an owner | click it |
+| **Request** button | restrictions are on, you are not an owner | request; an owner grants at *fruggr → Settings → Third-party Access → OAuth app policy → Review → Grant access* |
+| green check | already granted | the stored token predates the grant — see below |
+
+Then **sign out of the dashboard and back in**. This is the step that gets
+skipped: the backend stores the access token in its `users` table at login, so a
+grant made afterwards does not reach the token already on file. If that still
+fails, revoke the app from the same settings page and re-authorise from scratch —
+the consent screen offers the organisation directly.
+
+If an owner declines outright there is no workaround worth having. The API key is
+minted per project and requires the project to be enabled, and the only fallback —
+pinning `dashboard.project` to a personal fork — puts the trend and the badge
+under someone's personal account. Park the work instead.
+
 Two organisation-specific gotchas, both one-off:
 
 - the dashboard is a **classic OAuth App** (scopes `user:email read:org`). If the

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -376,6 +376,113 @@ real slack against its threshold; `pnpm test:coverage` names the weakest files
 on any given day. Past that, the surviving mutants are where the new
 information is.
 
+## 7. Publishing the score, so the trend outlives the run
+
+Everything above produces numbers that are thrown away. The HTML report ships as
+a CI artifact (30 days for the baseline, 7 for a PR) and then expires; the cached
+`stryker-incremental.json` is *current state*, overwritten on every push to
+`main`, not a history. So "where was `src/auth` a month ago" had no answer.
+
+The [Stryker dashboard](https://stryker-mutator.io/docs/General/dashboard/)
+answers it: free for open source, keeps a trend line per branch, hosts the full
+report per version, and serves a score badge. The reporter is **first-party** —
+`dashboard` is built into `@stryker-mutator/core`, so this adds no dependency.
+
+### `reportType: 'full'` — decided, not inherited
+
+`full` uploads the whole report, **source snippets included**, to a third party.
+`mutationScore` sends `{ mutationScore: 42 }` and nothing else.
+
+`full` wins here for one reason: it is what makes the survivor table *browsable*
+online, per file, without downloading an artifact — which is most of what a
+hand-maintained per-area table is for. The disclosure question is real but has a
+short answer in this repo: the source is public on npm and on GitHub already, so
+the upload discloses nothing that a `git clone` does not. In a private repo the
+choice would go the other way.
+
+`full` also happens to be Stryker's default. It is written out in
+`stryker.config.mjs` anyway, because a default is not a decision and the next
+reader should not have to look up which one they got.
+
+`project` and `version` are deliberately **not** set. `GithubActionsCIProvider`
+derives them from `GITHUB_REPOSITORY` and `GITHUB_REF` (`refs/heads/main` →
+`main`, `refs/pull/7/merge` → `PR-7`), so the baseline publishes under the branch
+it ran on and there is nothing to keep in sync.
+
+**`module` is not used.** It looks like the cheap way to get a trend line per
+scoped area, and it is not: a separate module means a separate run, multiplying
+the cold baseline by the number of areas. The per-*file* breakdown comes free
+with a `full` upload, which is the part actually wanted. Revisit only if per-area
+trends prove to be a distinct need.
+
+### Why the reporter is gated on the key, when a missing key is harmless
+
+`DashboardReporterClient` sends the PUT whether or not `STRYKER_DASHBOARD_API_KEY`
+is set — the only guard before it checks that `project` and `version` resolve,
+which on Actions they always do. A keyless PUT comes back 401 and the client
+throws a `StrykerError`.
+
+That error does **not** fail the run. `DashboardReporter.update()` catches it and
+logs `Could not upload report.`. Measured on 9.6.1, forcing the failure with a
+dead `dashboard.baseUrl` under a faked Actions environment:
+
+```
+INFO  DashboardReporterClient PUT report to http://127.0.0.1:9/api/reports/github.com/fruggr/zendesk-mcp-server/main (~81654 bytes)
+ERROR DashboardReporter       Could not upload report. Error: connect ECONNREFUSED 127.0.0.1:9
+INFO  MutationTestExecutor    Done in 17 seconds.
+                                                                    exit code 0
+```
+
+Worth re-checking on a major bump — an earlier reading of this code assumed the
+throw escaped and failed the job. It does not. So the honest reason for the gate
+is not "CI would break":
+
+- a red `ERROR Could not upload report.` on every local run and every fork PR is
+  a false alarm in the one job whose output people read for real alarms;
+- PR runs are diff-scoped. A PR that *did* have a key would publish a report
+  covering the changed lines only — a truncated entry corrupting the trend, which
+  is worse than not publishing.
+
+So the config enables the reporter exactly when the key exists, and the workflow
+hands the secret to the `Full scope` step alone. The two together mean a PR run —
+fork or not — has no key, therefore no reporter, therefore no request. That reuses
+the rule the incremental cache already follows (*only the baseline writes*) and
+gets it structurally rather than by remembering to pass `--reporters` at the call
+site, which would restate the whole reporter list in YAML.
+
+A **local** run is safe twice over, which is worth knowing before anyone worries
+about a stray key in a shell: with no key the reporter is not in the list at all
+(`pnpm test:mutation --mutate src/utils/validation.ts` logs `JsonReporter` and
+`HtmlReporter` and nothing else), and even *with* a key it stops before the PUT,
+because `determineCIProvider()` finds no `GITHUB_ACTION` and logs `The report was
+not send to the dashboard. The dashboard.project and/or dashboard.version values
+were missing`.
+
+### One-time setup, and the organisation question
+
+The API key cannot be minted from CI; a human enables the project once:
+
+1. sign in at <https://dashboard.stryker-mutator.io> with GitHub;
+2. pick the `fruggr` organisation, find `zendesk-mcp-server`, enable it;
+3. copy the key into the repository secret `STRYKER_DASHBOARD_API_KEY`;
+4. the next push to `main` publishes.
+
+**Organisation-owned repositories are supported** — this needed checking, because
+the dashboard UI leads with personal repositories and the docs never say. The
+backend has a dedicated organisations route (`GET /organizations/:name/repositories`
+→ `GET /orgs/{login}/repos?type=member`), enabling a project requires only **push**
+permission rather than admin, and the reference deployment publishes
+`github.com/stryker-mutator/stryker-js`, itself an organisation repository.
+
+Two organisation-specific gotchas, both one-off:
+
+- the dashboard is a **classic OAuth App** (scopes `user:email read:org`). If the
+  organisation has OAuth App access restrictions enabled, an owner must approve it
+  first — until then the organisation simply does not appear in the list, which
+  reads exactly like "orgs are not supported";
+- there is no `repo` scope, so only **public** repositories are listed. Fine here;
+  a blocker for a private one.
+
 ## Appendix — reproducing
 
 ```sh

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -426,7 +426,7 @@ That error does **not** fail the run. `DashboardReporter.update()` catches it an
 logs `Could not upload report.`. Measured on 9.6.1, forcing the failure with a
 dead `dashboard.baseUrl` under a faked Actions environment:
 
-```
+```text
 INFO  DashboardReporterClient PUT report to http://127.0.0.1:9/api/reports/github.com/fruggr/zendesk-mcp-server/main (~81654 bytes)
 ERROR DashboardReporter       Could not upload report. Error: connect ECONNREFUSED 127.0.0.1:9
 INFO  MutationTestExecutor    Done in 17 seconds.

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -62,9 +62,35 @@ export default {
   // judge a diff, so it belongs here rather than as a `--reporters` override
   // that has to restate the whole list. Both report paths are declared so the
   // script can read them from the config instead of hardcoding a default.
-  reporters: ['html', 'json', 'clear-text', 'progress'],
+  //
+  // `dashboard` is conditional because it is the only reporter with a
+  // precondition: without `STRYKER_DASHBOARD_API_KEY` the client still PUTs,
+  // takes a 401 and logs `Could not upload report.` — a red herring on every
+  // local run and every fork PR. Gating on the variable, rather than on a
+  // `--reporters` override at the one call site that publishes, is what makes
+  // "only the baseline publishes" a property of the config instead of something
+  // the workflow has to keep remembering: the secret is exposed to the baseline
+  // step alone, so a PR run has no key and therefore no reporter. Why the
+  // keyless case is noise and not a failure: `docs/decisions/mutation-testing.md`
+  // (section 7).
+  reporters: [
+    'html',
+    'json',
+    'clear-text',
+    'progress',
+    ...(process.env.STRYKER_DASHBOARD_API_KEY ? ['dashboard'] : []),
+  ],
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation.json' },
+
+  // `full` is also Stryker's default — declared anyway, because it is a decision
+  // (source snippets leave the repo for a third party) and not a default worth
+  // inheriting silently. `project` and `version` are left unset on purpose: the
+  // GitHub Actions provider derives them from `GITHUB_REPOSITORY` and
+  // `GITHUB_REF`, so the baseline publishes under the branch it ran on with
+  // nothing to keep in sync here. Reasoning: `docs/decisions/mutation-testing.md`
+  // (section 7).
+  dashboard: { reportType: 'full' },
 
   // Score table yes, per-mutant dump no. Under `--incremental` the report is
   // project-wide, so `reportMutants` prints every survivor in the whole scope

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -64,9 +64,10 @@ export default {
   // script can read them from the config instead of hardcoding a default.
   //
   // `dashboard` is conditional because it is the only reporter with a
-  // precondition: without `STRYKER_DASHBOARD_API_KEY` the client still PUTs,
-  // takes a 401 and logs `Could not upload report.` — a red herring on every
-  // local run and every fork PR. Gating on the variable, rather than on a
+  // precondition: nothing checks for `STRYKER_DASHBOARD_API_KEY` before the
+  // request, so on CI — where `project` and `version` resolve — a keyless run
+  // PUTs anyway, takes a 401 and logs `Could not upload report.`, a red herring
+  // on every fork PR. Gating on the variable, rather than on a
   // `--reporters` override at the one call site that publishes, is what makes
   // "only the baseline publishes" a property of the config instead of something
   // the workflow has to keep remembering: the secret is exposed to the baseline

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -63,17 +63,9 @@ export default {
   // that has to restate the whole list. Both report paths are declared so the
   // script can read them from the config instead of hardcoding a default.
   //
-  // `dashboard` is conditional because it is the only reporter with a
-  // precondition: nothing checks for `STRYKER_DASHBOARD_API_KEY` before the
-  // request, so on CI — where `project` and `version` resolve — a keyless run
-  // PUTs anyway, takes a 401 and logs `Could not upload report.`, a red herring
-  // on every fork PR. Gating on the variable, rather than on a
-  // `--reporters` override at the one call site that publishes, is what makes
-  // "only the baseline publishes" a property of the config instead of something
-  // the workflow has to keep remembering: the secret is exposed to the baseline
-  // step alone, so a PR run has no key and therefore no reporter. Why the
-  // keyless case is noise and not a failure: `docs/decisions/mutation-testing.md`
-  // (section 7).
+  // `dashboard` is gated on the key because nothing else guards the upload: a
+  // keyless CI run PUTs anyway and 401s. Only the baseline step gets the secret,
+  // so only it publishes. Section 7 of the ADR.
   reporters: [
     'html',
     'json',
@@ -84,13 +76,9 @@ export default {
   htmlReporter: { fileName: 'reports/mutation/index.html' },
   jsonReporter: { fileName: 'reports/mutation/mutation.json' },
 
-  // `full` is also Stryker's default — declared anyway, because it is a decision
-  // (source snippets leave the repo for a third party) and not a default worth
-  // inheriting silently. `project` and `version` are left unset on purpose: the
-  // GitHub Actions provider derives them from `GITHUB_REPOSITORY` and
-  // `GITHUB_REF`, so the baseline publishes under the branch it ran on with
-  // nothing to keep in sync here. Reasoning: `docs/decisions/mutation-testing.md`
-  // (section 7).
+  // `full` is also the default, but spelled out: it sends source snippets to a
+  // third party, which is a decision. `project`/`version` stay unset — the
+  // Actions provider derives them. Section 7 of the ADR.
   dashboard: { reportType: 'full' },
 
   // Score table yes, per-mutant dump no. Under `--incremental` the report is

--- a/tests/unit/stryker-dashboard-reporter.test.ts
+++ b/tests/unit/stryker-dashboard-reporter.test.ts
@@ -1,0 +1,74 @@
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The `dashboard` reporter publishes to a third party, and whether it is active
+// is decided by an environment variable rather than by the reporter list being
+// read literally. That indirection is the whole safety property — the workflow
+// gives `STRYKER_DASHBOARD_API_KEY` to the baseline step only, so a PR run
+// (fork included) has no key and cannot publish a diff-scoped report over the
+// trend. Nothing else in the repo would fail if someone "simplified" the
+// conditional into an unconditional entry, so it is pinned here.
+// Reasoning: `docs/decisions/mutation-testing.md` (section 7).
+
+const CONFIG_PATH = join(fileURLToPath(new URL('../../', import.meta.url)), 'stryker.config.mjs');
+
+/**
+ * Re-imports the config with a fresh module registry, so the env var is read
+ * again instead of served from the first import's cached evaluation.
+ */
+async function loadConfig(): Promise<{
+  reporters: string[];
+  dashboard?: { reportType?: string; project?: string; version?: string; module?: string };
+}> {
+  vi.resetModules();
+  const { default: config } = await import(pathToFileURL(CONFIG_PATH).href);
+  return config;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('stryker.config.mjs — dashboard reporter gating', () => {
+  it('leaves the reporter off when no API key is set', async () => {
+    vi.stubEnv('STRYKER_DASHBOARD_API_KEY', undefined);
+
+    expect((await loadConfig()).reporters).toEqual(['html', 'json', 'clear-text', 'progress']);
+  });
+
+  it('leaves the reporter off when the key is empty, as an unset GitHub secret expands', async () => {
+    // `${{ secrets.X }}` on a repo without the secret is '', not absent — the
+    // state the workflow is in until someone enables the project.
+    vi.stubEnv('STRYKER_DASHBOARD_API_KEY', '');
+
+    expect((await loadConfig()).reporters).toEqual(['html', 'json', 'clear-text', 'progress']);
+  });
+
+  it('appends the reporter, keeping the others, once a key is present', async () => {
+    vi.stubEnv('STRYKER_DASHBOARD_API_KEY', 'dashboard-key');
+
+    expect((await loadConfig()).reporters).toEqual([
+      'html',
+      'json',
+      'clear-text',
+      'progress',
+      'dashboard',
+    ]);
+  });
+
+  it('publishes a full report, and leaves project/version to CI auto-detection', async () => {
+    vi.stubEnv('STRYKER_DASHBOARD_API_KEY', 'dashboard-key');
+    const { dashboard } = await loadConfig();
+
+    // `full` is a deliberate choice (source snippets leave the repo), not an
+    // inherited default; `mutationScore` would silently drop the hosted report.
+    expect(dashboard?.reportType).toBe('full');
+    // Unset on purpose: GithubActionsCIProvider derives these from
+    // GITHUB_REPOSITORY / GITHUB_REF. Pinning either here would freeze the
+    // trend onto one branch. `module` stays out — see the ADR.
+    expect(dashboard?.project).toBeUndefined();
+    expect(dashboard?.version).toBeUndefined();
+    expect(dashboard?.module).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Enables Stryker's first-party `dashboard` reporter so the mutation score gets a
history instead of expiring with each CI artifact. The reporter is switched on
from `stryker.config.mjs` only when `STRYKER_DASHBOARD_API_KEY` is present, and
the workflow gives that secret to the `Full scope` step alone — so only the
baseline can publish, structurally rather than by convention.

## Linked issue

Closes #214

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [x] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally — 36 files, 899 tests
- [x] `pnpm test:coverage` meets the thresholds — 97.54 / 85.59 / 98.65 / 98.04
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings — `/security-review`, no HIGH or MEDIUM findings; CodeRabbit's one finding (MD040) fixed in `89872b6`
- [x] Documentation is updated where needed — `docs/decisions/mutation-testing.md` §7, badge in `CONTRIBUTING.md`
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` — n/a
- [x] Pure tooling / dev-tooling, so exempt from the functional validation plan: no tool surface, transport, auth, resource, prompt, persistence or timing changes. A running server behaves identically; the standard gates cover it.

## Notes for the reviewer (human or AI)

### One correction to the issue's premise, measured

The issue states that a keyless run takes a 401 and **throws**, so a fork PR
would fail the mutation gate. That is not what 9.6.1 does:
`DashboardReporter.update()` wraps the client call in a `try/catch` that logs
and swallows. Forced the failure with a dead `baseUrl` under a faked Actions
environment:

```text
INFO  DashboardReporterClient PUT report to http://127.0.0.1:9/api/reports/github.com/fruggr/zendesk-mcp-server/main (~81654 bytes)
ERROR DashboardReporter       Could not upload report. Error: connect ECONNREFUSED 127.0.0.1:9
INFO  MutationTestExecutor    Done in 17 seconds.
                                                                    exit code 0
```

The gating design in the issue is still the right one, for quieter reasons — a
false red `ERROR` on every fork PR, and a diff-scoped PR run publishing a
truncated report over the trend. The ADR records the corrected reasoning rather
than repeating the original claim.

That output also confirms the auto-detection the design leans on: `project` and
`version` resolve to `github.com/fruggr/zendesk-mcp-server` and `main` with
nothing configured.

### Acceptance evidence

- **Reporter off without a key**, verified on a real run, not just by reading the
  config: `pnpm test:mutation --mutate src/utils/validation.ts` with the variable
  unset logs `JsonReporter` and `HtmlReporter` and nothing else, exit 0. A local
  run is in fact safe twice over — even *with* a key, `determineCIProvider()`
  finds no `GITHUB_ACTION` and the reporter stops before the PUT.
- **A PR run cannot publish**: the `env:` block sits on the baseline's run step,
  which only exists on `push`/`workflow_dispatch`. Every CI run on this PR shows
  `Full scope` as `skipped`. A fork PR gets no secrets at all.
- **Unset secret is a no-op**: `${{ secrets.STRYKER_DASHBOARD_API_KEY }}` expands
  to `''` before anyone configures it, which is falsy — this PR changes nothing
  about the current baseline run until the secret exists.

### `reportType: 'full'` — the decision the issue left open

Chosen deliberately: it is what makes the survivor table browsable per file
online, which is most of what #208's hand-maintained table is for. The upload
includes source snippets, but this repo is public on GitHub and npm already, so
nothing is disclosed that a `git clone` does not give. In a private repo the
answer would be `mutationScore` — and the ADR now names the trigger to revisit:
a private or credential-bearing file entering the `mutate` scope.

`module` is deliberately not used: a per-area trend line means a separate run per
area, multiplying the cold baseline. The per-*file* breakdown comes free with a
`full` upload.

### On the feasibility doubt: organisations are supported

Worth recording, because the dashboard UI leads with personal repositories and
the docs never address it — and because the account picker did in fact show only
the personal account on the first attempt. Checked against the dashboard's own
backend:

- a dedicated organisations route exists — `GET /organizations/:name/repositories`
  → `GithubAgent.getOrganizationRepositories()` → `GET /orgs/{login}/repos?type=member`;
- enabling a project requires **push** permission, not admin (`#guardUserHasAccess`);
- the reference deployment publishes `github.com/stryker-mutator/stryker-js`,
  itself an organisation repository (live report: 82.26 %).

The picker is `GET /user/orgs`, which GitHub documents as listing only
organisations *"that your authorization allows you to operate on"*. A missing
organisation is an OAuth grant that was never given, not a repository permission.
The dashboard is a classic OAuth App (`user:email read:org`, so public repos
only), so an org with OAuth App access restrictions hides itself until an owner
approves it — and the stored access token needs a re-login afterwards. The ADR
carries the settings path and the three states the org row can show.

### Merge ordering — the one thing that needs a human first

The API key cannot be minted from CI. Before merging, the key must be in the
**repository secret** `STRYKER_DASHBOARD_API_KEY` (Secrets tab, not Variables —
`${{ secrets.X }}` does not read the other one).

Two consequences worth expecting:

- the badge renders as an error until the first publish, so the secret should
  land before merge rather than after;
- **the first post-merge baseline is a cold run, roughly an hour.**
  `stryker.config.mjs` is part of the `hashFiles(...)` cache key in
  `.github/actions/mutation-baseline/action.yml`, so this PR invalidates the
  baseline by design. The job's timeout is 120 minutes.

The first entry should match the reference baseline in the issue — 77.19 % total
/ 79.23 % covered — modulo scope changes since `31df70c`.

### Test

`tests/unit/stryker-dashboard-reporter.test.ts` pins the gating, since nothing
else in the repo would fail if the conditional were "simplified" into an
unconditional entry. Confirmed it actually guards: making the entry
unconditional fails 2 of its 4 cases.

### Review round

Four review comments applied in `9bff998`: the badge moved from `README.md` to
`CONTRIBUTING.md` (the README is for users), and the commentary in the workflow,
`stryker.config.mjs` and ADR §7 cut back to what the code does not already say.