### PR TITLE
ci: correct the cold-run cost, measured instead of extrapolated

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -64,8 +64,10 @@ jobs:
     name: Full scope
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    # Only a changed cache prefix costs the full cold run (~1h on 4 cores).
-    timeout-minutes: 120
+    # Only a changed cache prefix costs a full cold run: 6-10 min measured on
+    # `main`, against 45 s to 2 min warm. The budget stays loose deliberately —
+    # it detects a hang, and the mutate scope is expected to grow. ADR section 4.
+    timeout-minutes: 45
     concurrency:
       group: mutation-baseline
       cancel-in-progress: true

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -65,8 +65,10 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     # Only a changed cache prefix costs a full cold run: 6-10 min measured on
-    # `main`, against 45 s to 2 min warm. The budget stays loose deliberately —
-    # it detects a hang, and the mutate scope is expected to grow. ADR section 4.
+    # `main`, against 45 s to 2 min warm. The budget is loose because it detects
+    # a hang, not because it anticipates growth — it is sized for *this* scope,
+    # and the ADR projects ~65 min if `src/tools/**` ever enters `mutate`, so
+    # re-measure and raise this before widening it. ADR section 4.
     timeout-minutes: 45
     concurrency:
       group: mutation-baseline

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -147,7 +147,8 @@ The point the projection served holds regardless, with more room than it claimed
 with the baseline restored a normal PR costs well under a minute, which is what
 makes a PR-time gate viable rather than a nightly one. A gate that only reports
 after merge reports too late. Re-measure if `src/tools/**` ever enters the scope —
-that is the change that would make 65 min real.
+that is the change that would make 65 min real, and it would overrun the
+baseline job's `timeout-minutes`, which is sized for the scope above.
 
 > **Note on Vitest and incremental mode.** Stryker's per-test change detection
 > is fine-grained for Jest and CucumberJS only. For Vitest it works per *file*:

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -133,11 +133,21 @@ A cold run is expensive; incremental runs are not. Measured on `src/utils`
 | `--incremental`, one source file changed | 12 | **30 s** |
 | `--incremental`, one *test* file changed | 102 | **47 s** |
 
-Extrapolated to all of `src/`, a cold run is ~7 400 mutants ≈ 65 min — well past
-the existing CI job's `timeout-minutes: 10`. With the incremental baseline
-restored, a normal PR costs well under a minute, which is what makes a PR-time
-gate viable rather than a nightly one. A gate that only reports after merge is a
-gate that reports too late.
+That extrapolated badly, and the number it produced is worth keeping as a
+warning. Projecting to all of `src/` gave ~7 400 mutants ≈ 65 min, and
+`mutation.yml` was sized against it. Two things made it wrong: the scope that
+shipped ([§5](#5-scope-and-why-label-heavy-files-stay-out-of-it)) leaves out
+`src/tools/**` and `src/utils/formatting.ts`, so it is **1 417 mutants**, five
+times fewer; and CI runs about twice the mutants per second of the 4-core figures
+above. Measured across the baselines on `main`, a **cold** run is **6–10 min**
+(6 min 22 s on `ca28fad`, 9 min 49 s on the dependency bump before it) and a warm
+one is 45 s to 2 min.
+
+The point the projection served holds regardless, with more room than it claimed:
+with the baseline restored a normal PR costs well under a minute, which is what
+makes a PR-time gate viable rather than a nightly one. A gate that only reports
+after merge reports too late. Re-measure if `src/tools/**` ever enters the scope —
+that is the change that would make 65 min real.
 
 > **Note on Vitest and incremental mode.** Stryker's per-test change detection
 > is fine-grained for Jest and CucumberJS only. For Vitest it works per *file*:
@@ -214,7 +224,7 @@ is the inter-LLM harness driven by hand through `/functional-testing`, and
 `vitest.config.ts` loads only `tests/**/*.test.ts`, so nothing in it can change a
 verdict. It also *must* stay exempt: the harness writes a report per scenario
 run, and hashing those would discard the baseline on every recorded run — a cold
-hour bought for nothing.
+baseline bought for nothing.
 
 Note what is *absent* from the hash: `src/**` and `tests/**/*.test.ts`. That is
 the point of it. Those are exactly what incremental mode does diff correctly, so


### PR DESCRIPTION
## Summary

`mutation.yml` and the ADR both claimed a cold mutation baseline costs about an
hour. The first real full-scope run with the dashboard reporter (#241) finished
in **5 min 58 s**, so the figure was checked against every baseline on `main` and
corrected with measurements.

## Linked issue

None — follow-up on the estimate that #241 disproved. Not reopening #214, which
shipped what it asked for.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [x] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main` — n/a, no issue
- [x] `pnpm test` passes locally — untouched by this diff, no source or test file changes
- [x] `pnpm test:coverage` meets the thresholds — unchanged
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings — two files, comments and one config value; reviewed inline
- [x] Documentation is updated where needed — this PR *is* the documentation fix
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` — n/a
- [x] Pure tooling / dev-tooling, so exempt from the functional validation plan: a comment, a prose section and a job timeout. Nothing a client observes.

## Notes for the reviewer (human or AI)

### Where the hour came from

Not a typo — correct arithmetic on a premise that never shipped. ADR §4 measured
`src/utils` honestly (982 mutants, 8 min 33 s, 4 cores → ~1.9 mutants/s), then
extrapolated to **all of `src/`**: ~7 400 mutants ≈ 65 min. `timeout-minutes: 120`
was sized against that.

Two things make it wrong for the scope that actually shipped:

- `mutate` excludes `src/tools/**` and `src/utils/formatting.ts` (§5), so a cold
  run is **1 417 mutants**, five times fewer than the projection assumed;
- CI runs ~4 mutants/s, about twice the 4-core rate the projection used.

Five times fewer, twice as fast: that is the missing order of magnitude.

### The measurements

Every baseline run on `main`, wall clock. Cold means the `hashFiles(...)` cache
prefix changed, so no entry could be restored.

| Run | Commit | Cache | Wall clock |
| --- | --- | --- | ---: |
| 31952392791 | `ca28fad` (#241 merge) | cold | **6 min 22 s** |
| 31947151929 | `bddd84c` (Biome bump) | cold | 9 min 49 s |
| 31578650562 | `828c5de` | cold | 8 min 53 s |
| 31646097583 | `be8cc98` | cold | 8 min 43 s |
| 31907933049 | `e9a9331` (`retry.ts`) | warm | 2 min 18 s |
| 31742962489 | `21aaa80` | warm | 43 s |

Nothing in 23 runs approaches an hour.

### What the diff does, and does not, change

The ADR's own measurement table is untouched — those numbers are real, taken on
`src/utils`. What is replaced is the *extrapolation* built on them, and it is
replaced with the measured range plus a note on why the projection missed. Keeping
the 65 min figure visible as a warning is deliberate: bringing `src/tools/**` into
the scope is exactly what would make it real, and a future reader should meet that
trap before walking into it rather than after.

The argument the projection was serving is unchanged and still holds — the
incremental baseline is what makes a PR-time gate viable rather than a nightly
one.

### The one judgment call

`timeout-minutes: 120` → **45**. This is the only behavioural line in the diff, so
it is the one to push back on. The reasoning: 45 min is still 4–5× the worst
observed cold run, a timeout's job is detecting a hang rather than bounding a
known cost, and the scope is expected to grow (#203 brings `src/utils/formatting.ts`
back in). Tightening further would start gambling on scope stability for no real
gain. Say so and I will leave it at 120 — the documentation fix stands either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYF537T6gVgcFUp5ofpJYr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated mutation-testing cost projections with measured runtimes and the current mutation scope.
  * Clarified when the longer runtime estimate would apply.
  * Corrected wording in the functional-test exemption note.

* **Chores**
  * Reduced the full mutation baseline job timeout to 45 minutes and documented runtime expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->