### PR TITLE
feat: exit when the client disconnects instead of leaking a process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
       - name: Verify tarball runs on Node 20
         run: |
           set -euo pipefail
-          OUT=$(env LOG_LEVEL=info timeout 5 zendesk-mcp-server smoke-test 2>&1 || true)
+          # `sleep` holds stdin open for the whole run. A step's stdin is
+          # /dev/null, which reaches EOF immediately, and EOF now shuts the
+          # stdio server down — without this the job would silently stop
+          # testing that the tarball *runs* and start testing that it exits.
+          # The EOF path itself is asserted in scripts/smoke-test.mjs.
+          OUT=$(sleep 6 | env LOG_LEVEL=info timeout 5 zendesk-mcp-server smoke-test 2>&1 || true)
           echo "$OUT"
           echo "$OUT" | grep -q "stdio_transport_ready"

--- a/docs/decisions/lifecycle-shutdown.md
+++ b/docs/decisions/lifecycle-shutdown.md
@@ -55,32 +55,48 @@ bug being fixed.
 
 The watchdog is what keeps that from happening: it is armed *before* cleanup
 runs, so a cleanup that never settles is still bounded. It is `unref()`'d, so
-having a grace period does not mean waiting one out. `SHUTDOWN_GRACE_MS` is 3s —
-under the 10s that systemd and Docker allow between their own `SIGTERM` and
-`SIGKILL`, because being killed by the supervisor is the unclean exit this is
-meant to avoid.
+having a grace period does not mean waiting one out. `SHUTDOWN_GRACE_MS` is 3s,
+inside the tightest common supervisor grace — `docker stop` allows 10s and
+Kubernetes 30s before their own `SIGKILL` (systemd is far laxer, 90s by default)
+— because being killed by the supervisor is the unclean exit this is meant to
+avoid.
 
-### `/dev/null` stdin reaches EOF immediately
+### EOF only exists in flowing mode
 
-A daemonised HTTP server is routinely handed `/dev/null` on stdin, which is at
-EOF from the first read. A stdin listener registered in HTTP mode would shut the
-server down at boot — in production, and in CI, where a GitHub Actions step's
-stdin is likewise `/dev/null`.
+`'end'` fires when a readable stream is *read* to exhaustion. Attaching an
+`'end'` listener does not by itself resume a paused stream, and Node leaves stdin
+paused until something attaches `'data'`. Measured:
 
-So the trigger set is per transport, and `watchStdin` is a required option rather
-than a default: stdio watches stdin, HTTP does not. The unit suite asserts the
-*absence* of the listener in HTTP mode, which is the assertion that would catch a
-regression here before it reaches an operator.
+| stdin | `'data'` listener | `'end'` |
+| --- | --- | --- |
+| `/dev/null` | yes | fires immediately |
+| `/dev/null` | no | never fires |
+| closed pipe | no | never fires |
 
-Two consequences worth naming:
+Two consequences, and they pull in opposite directions.
 
-- In stdio mode, `zendesk-mcp-server < /dev/null` now exits immediately. This is
-  intended — there is no client on the other end — and is documented as a
-  symptom in `troubleshooting.md`.
-- `scripts/smoke-test.mjs` had to stop spawning with `stdio: ['ignore', …]`, and
-  the Node 20 tarball job in `ci.yml` had to hold stdin open, or both would have
-  quietly stopped testing that the server *runs* and started testing that it
-  exits.
+**In stdio mode the SDK attaches `'data'`, so EOF is genuinely live** — including
+at startup. `zendesk-mcp-server < /dev/null` now exits immediately, which is
+intended (there is no client on the other end) and is documented as a symptom in
+`troubleshooting.md`. It is also why `scripts/smoke-test.mjs` had to stop
+spawning with `stdio: ['ignore', …]` and the Node 20 tarball job in `ci.yml` had
+to hold stdin open: otherwise both would have quietly stopped testing that the
+server *runs* and started testing that it exits.
+
+**In HTTP mode nothing reads stdin**, so the stream stays paused and would never
+report EOF even on `/dev/null`. `watchStdin: false` there is therefore not
+averting a live failure — it is refusing to depend on that.  Nothing states that
+stdin must stay unread in the HTTP process; the day a library, a debugger or a
+future feature attaches a `'data'` listener, a server carrying an EOF handler
+would start exiting as soon as its supervisor handed it `/dev/null`. Making
+`watchStdin` a required option rather than a default keeps the choice at each
+call site instead of resting on that invariant.
+
+The unit suite asserts the *absence* of the stdin listener in HTTP mode, because
+that is the only place the distinction is observable. The smoke check that closes
+stdin against a running HTTP server pins the user-visible contract, but cannot
+tell the flag apart from the paused stream and would keep passing if only one of
+the two survived.
 
 ## Why the runtime is injected
 

--- a/docs/decisions/lifecycle-shutdown.md
+++ b/docs/decisions/lifecycle-shutdown.md
@@ -55,7 +55,18 @@ bug being fixed.
 
 The watchdog is what keeps that from happening: it is armed *before* cleanup
 runs, so a cleanup that never settles is still bounded. It is `unref()`'d, so
-having a grace period does not mean waiting one out. `SHUTDOWN_GRACE_MS` is 3s,
+having a grace period does not mean waiting one out.
+
+`unref()` does not defeat it, though that is easy to assume. An unref'd timer
+still fires while the loop is running; it only declines to keep the loop alive by
+itself. The two cases therefore both terminate:
+
+- something still holds the loop (an in-flight request, a socket) — the loop is
+  running, so the watchdog fires and forces the exit;
+- nothing holds it — the loop empties and Node exits on its own, before the
+  watchdog was ever needed.
+
+`SHUTDOWN_GRACE_MS` is 3s,
 inside the tightest common supervisor grace — `docker stop` allows 10s and
 Kubernetes 30s before their own `SIGKILL` (systemd is far laxer, 90s by default)
 — because being killed by the supervisor is the unclean exit this is meant to

--- a/docs/decisions/lifecycle-shutdown.md
+++ b/docs/decisions/lifecycle-shutdown.md
@@ -1,0 +1,106 @@
+# Process lifecycle: why the server owns its exit
+
+> **Build documentation, not user documentation.** This records why
+> `src/utils/shutdown.ts` exists and why its triggers differ per transport.
+> Client-facing symptoms are in [`docs/troubleshooting.md`](../troubleshooting.md);
+> operator concerns in [`docs/http-deployment.md`](../http-deployment.md).
+
+| | |
+| --- | --- |
+| **Status** | Decided and applied |
+| **Date** | 2026-08-22 |
+| **Applied in** | [#249](https://github.com/fruggr/zendesk-mcp-server/pull/249) ([#246](https://github.com/fruggr/zendesk-mcp-server/issues/246)) |
+| **Question** | How should the server learn that it is done, and what must it guarantee once it does? |
+| **Answer** | One idempotent shutdown path, triggered by `SIGINT`/`SIGTERM` on both transports and additionally by stdin EOF on stdio only, always ending in an explicit `exit(0)` bounded by a watchdog. |
+
+## Why EOF at all
+
+Behind `npx`, the `npm exec` and `sh -c` links in the chain do not relay signals,
+so a stdio server never receives `SIGTERM` when its client goes away. The only
+remaining evidence is EOF on stdin — and the SDK does not read it.
+`StdioServerTransport` attaches exactly two listeners:
+
+```js
+this._stdin.on('data',  this._ondata);
+this._stdin.on('error', this._onerror);
+```
+
+Never `'end'`, never `'close'`. `transport.onclose` fires only when *we* call
+`close()`. So EOF was observed by nobody.
+
+## Why it was not already broken
+
+Before this change the process still exited, because nothing kept the event loop
+alive. That was mostly discipline rather than luck — every timer is deliberately
+`unref()`'d, and says so at its declaration (`auth/token-store.ts`,
+`transports/http.ts`).
+
+But the discipline had a hole, and it was not hypothetical. The OAuth callback
+server in `auth/browser-oauth.ts` is a listening `http.Server` that is **not**
+`unref()`'d; only its `authTimeout` is. A client that disappeared mid-auth left
+the process alive for up to `AUTH_TIMEOUT_MS` — five minutes — on 2.18.0.
+
+That hole is also why the shutdown ends in an explicit `exit(0)` rather than
+letting the loop drain: draining would wait out that same five minutes.
+
+## Two constraints that shaped the design
+
+### Registering a signal handler removes a guarantee
+
+Without a handler, `SIGTERM` terminates the process by Node's default. Adding
+`process.on('SIGTERM', …)` **replaces** that default and makes the exit our
+responsibility. A cleanup that stalls on an in-flight Zendesk request would
+therefore produce a process that `SIGTERM` cannot kill — a worse version of the
+bug being fixed.
+
+The watchdog is what keeps that from happening: it is armed *before* cleanup
+runs, so a cleanup that never settles is still bounded. It is `unref()`'d, so
+having a grace period does not mean waiting one out. `SHUTDOWN_GRACE_MS` is 3s —
+under the 10s that systemd and Docker allow between their own `SIGTERM` and
+`SIGKILL`, because being killed by the supervisor is the unclean exit this is
+meant to avoid.
+
+### `/dev/null` stdin reaches EOF immediately
+
+A daemonised HTTP server is routinely handed `/dev/null` on stdin, which is at
+EOF from the first read. A stdin listener registered in HTTP mode would shut the
+server down at boot — in production, and in CI, where a GitHub Actions step's
+stdin is likewise `/dev/null`.
+
+So the trigger set is per transport, and `watchStdin` is a required option rather
+than a default: stdio watches stdin, HTTP does not. The unit suite asserts the
+*absence* of the listener in HTTP mode, which is the assertion that would catch a
+regression here before it reaches an operator.
+
+Two consequences worth naming:
+
+- In stdio mode, `zendesk-mcp-server < /dev/null` now exits immediately. This is
+  intended — there is no client on the other end — and is documented as a
+  symptom in `troubleshooting.md`.
+- `scripts/smoke-test.mjs` had to stop spawning with `stdio: ['ignore', …]`, and
+  the Node 20 tarball job in `ci.yml` had to hold stdin open, or both would have
+  quietly stopped testing that the server *runs* and started testing that it
+  exits.
+
+## Why the runtime is injected
+
+`installShutdown` takes its `process` access through a `ShutdownRuntime`, and
+`createRuntime(process)` is what adapts the real one. Not ceremony: `index.ts`
+and `transports/stdio.ts` are excluded from coverage as thin bootstraps
+(`vitest.config.ts`), so logic placed there is invisible to both the coverage
+ratchet and Stryker. Putting the module in `src/utils/` instead — where
+`logger.ts` already sets the precedent for cross-cutting infrastructure — brings
+it inside Stryker's `mutate` scope, and injecting the process is what lets the
+adapter itself be tested rather than `v8 ignore`d. The riskiest lines in the
+module would otherwise have been the only ones no test could reach.
+
+## What was not done
+
+- **No configurable grace period.** A knob here would be a support burden with no
+  demonstrated use; 3s is derived from the supervisor budget above, and tests
+  override it by argument.
+- **No `unref()` on the OAuth callback server.** It would paper over the orphan
+  without giving the process a shutdown path, and a half-finished auth flow
+  should end deliberately, not by the loop happening to empty.
+- **Exit code is always 0.** A signal-triggered stop is a clean stop; `128+signum`
+  would make supervisors report a normal shutdown as a failure.

--- a/docs/http-deployment.md
+++ b/docs/http-deployment.md
@@ -164,13 +164,12 @@ This server provides the MCP transport and the OAuth discovery metadata. The ope
 
 `SIGINT` and `SIGTERM` drain the live sessions, close the listening socket and
 exit `0`. A shutdown that cannot finish within a few seconds is forced rather
-than left hanging, so the server always exits well inside the 10s that systemd
-and Docker allow before their own `SIGKILL`.
+than left hanging, so the server always exits well inside the grace its
+supervisor allows before `SIGKILL` — 10s for `docker stop`, 30s for Kubernetes.
 
-Stdin is deliberately *not* watched in HTTP mode: a supervised process is usually
-handed `/dev/null`, which is at EOF immediately, and watching it would stop the
-server at boot. Why the stdio transport does the opposite:
-[Process lifecycle](decisions/lifecycle-shutdown.md).
+Stdin is ignored in HTTP mode: closing it does nothing, and the server has no
+client there to lose. Only signals stop it. The stdio transport deliberately does
+the opposite — see [Process lifecycle](decisions/lifecycle-shutdown.md).
 
 See also [Configuration](configuration.md) for the full CLI and environment-variable reference.
 

--- a/docs/http-deployment.md
+++ b/docs/http-deployment.md
@@ -160,6 +160,18 @@ This server provides the MCP transport and the OAuth discovery metadata. The ope
 - Network exposure and firewalling. The server binds `0.0.0.0` by default, so choose carefully.
 - Process supervision (systemd, Docker, fly.io, your hosting provider's runner). None is shipped here.
 
+## Stopping the server
+
+`SIGINT` and `SIGTERM` drain the live sessions, close the listening socket and
+exit `0`. A shutdown that cannot finish within a few seconds is forced rather
+than left hanging, so the server always exits well inside the 10s that systemd
+and Docker allow before their own `SIGKILL`.
+
+Stdin is deliberately *not* watched in HTTP mode: a supervised process is usually
+handed `/dev/null`, which is at EOF immediately, and watching it would stop the
+server at boot. Why the stdio transport does the opposite:
+[Process lifecycle](decisions/lifecycle-shutdown.md).
+
 See also [Configuration](configuration.md) for the full CLI and environment-variable reference.
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,6 +111,23 @@ those rights, read an existing article with `get_article` and reuse the IDs it
 reports; omitting `user_segment_id` on create/update keeps the default visibility
 (everyone).
 
+## The server exits straight away in stdio mode
+
+It logs `stdio_transport_ready`, then `shutdown_started reason=stdin_eof`, and
+stops. Stdin reached end-of-file, which the server reads as "the client is gone"
+— behind `npx` that is the only notice it ever gets, because the `npm exec` and
+`sh -c` links in the chain do not relay signals.
+
+An MCP client keeps stdin open for the life of the session, so this normally
+means the server was started without one:
+
+- `zendesk-mcp-server < /dev/null`, or any launcher that closes stdin. Give it a
+  pipe or a terminal instead.
+- A wrapper script that reads stdin itself before handing over.
+
+Running it bare in a terminal is fine — stdin stays open until you press
+`Ctrl-D`. In HTTP mode stdin is ignored entirely, so this cannot happen there.
+
 ## A tool call fails with `Network error on GET https://…`
 
 The request never got an HTTP response — DNS, a refused or reset connection, a

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -77,6 +77,13 @@ const runCheck = (args, marker) =>
 // distinguishes "shut down deliberately" from "fell over by luck" — the whole
 // point of the issue.
 const SHUTDOWN_MARKER = 'shutdown_started reason=stdin_eof';
+// The clean *end* of that same path. `shutdown_started` alone is not enough:
+// a cleanup that hangs is cut short by the server's own watchdog, which logs
+// `shutdown_forced`, exits 0 too, and does so at the 3s grace — inside this
+// check's deadline. Requiring the completion marker, and refusing the forced
+// one, is what keeps "shut down cleanly" distinct from "was cut short".
+const SHUTDOWN_DONE_MARKER = 'shutdown_complete reason=stdin_eof';
+const SHUTDOWN_FORCED_MARKER = 'shutdown_forced';
 
 /**
  * The assertion for #246: behind `npx` the client's exit is invisible except as
@@ -144,6 +151,12 @@ const runStdinEofCheck = (args, marker) =>
       if (!output.includes(SHUTDOWN_MARKER)) {
         return fail(`exited without "${SHUTDOWN_MARKER}" — no deliberate shutdown ran`);
       }
+      if (output.includes(SHUTDOWN_FORCED_MARKER)) {
+        return fail(`logged "${SHUTDOWN_FORCED_MARKER}" — the watchdog cut the cleanup short`);
+      }
+      if (!output.includes(SHUTDOWN_DONE_MARKER)) {
+        return fail(`exited without "${SHUTDOWN_DONE_MARKER}" — the shutdown never finished`);
+      }
 
       console.log('[smoke] ok (shut down deliberately on stdin EOF)');
       resolve();
@@ -168,8 +181,17 @@ const runStdinIgnoredCheck = (args, marker) =>
     let output = '';
     let ready = false;
     let settled = false;
+    let hadToKill = false;
     let readyTimer;
     let aliveTimer;
+    let killTimer;
+
+    const fail = (message) => {
+      console.error(`[smoke] fail: ${message}`);
+      console.error('--- captured output ---');
+      console.error(output || '(empty)');
+      reject(new Error(message));
+    };
 
     const onData = (chunk) => {
       output += chunk.toString();
@@ -181,6 +203,13 @@ const runStdinIgnoredCheck = (args, marker) =>
         aliveTimer = setTimeout(() => {
           settled = true;
           proc.kill('SIGTERM');
+          // A server that does not honour SIGTERM must *fail* this check, not
+          // hang it: without the escalation the promise would never settle and
+          // CI would sit until its job timeout with no diagnosis.
+          killTimer = setTimeout(() => {
+            hadToKill = true;
+            proc.kill('SIGKILL');
+          }, EXIT_TIMEOUT_MS);
         }, SURVIVE_MS);
       }
     };
@@ -195,6 +224,7 @@ const runStdinIgnoredCheck = (args, marker) =>
     proc.on('error', (err) => {
       clearTimeout(readyTimer);
       clearTimeout(aliveTimer);
+      clearTimeout(killTimer);
       console.error(`[smoke] spawn error: ${err.message}`);
       reject(err);
     });
@@ -202,19 +232,14 @@ const runStdinIgnoredCheck = (args, marker) =>
     proc.on('close', () => {
       clearTimeout(readyTimer);
       clearTimeout(aliveTimer);
+      clearTimeout(killTimer);
 
-      if (!ready) {
-        console.error(`[smoke] fail: marker "${marker}" not seen in ${TIMEOUT_MS}ms`);
-        console.error('--- captured output ---');
-        console.error(output || '(empty)');
-        return reject(new Error(`marker not found: ${marker}`));
-      }
+      if (!ready) return fail(`marker "${marker}" not seen in ${TIMEOUT_MS}ms`);
       if (!settled) {
-        const message = `HTTP server exited within ${SURVIVE_MS}ms of stdin EOF; it must ignore stdin`;
-        console.error(`[smoke] fail: ${message}`);
-        console.error('--- captured output ---');
-        console.error(output || '(empty)');
-        return reject(new Error(message));
+        return fail(`HTTP server exited within ${SURVIVE_MS}ms of stdin EOF; it must ignore stdin`);
+      }
+      if (hadToKill) {
+        return fail(`still running ${EXIT_TIMEOUT_MS}ms after SIGTERM (had to SIGKILL)`);
       }
 
       console.log('[smoke] ok (survived stdin EOF in http mode)');

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -5,6 +5,8 @@ const KILL_GRACE_MS = 1000;
 // Budget for the EOF check: the server's own shutdown grace is 3s, and the
 // watchdog forces the exit at that point, so 5s leaves room without hanging CI.
 const EXIT_TIMEOUT_MS = 5000;
+// How long the HTTP server must keep running after its stdin reaches EOF.
+const SURVIVE_MS = 1000;
 
 // Markers are structured logger events. Force LOG_LEVEL=info so an inherited
 // LOG_LEVEL=warn/error can't suppress the marker and false-fail the smoke test.
@@ -69,12 +71,20 @@ const runCheck = (args, marker) =>
     });
   });
 
+// Proof that the *designed* path ran. A clean exit alone is not evidence: before
+// #246 the process also exited on EOF, just circumstantially, because nothing
+// happened to be holding the event loop open. Requiring this marker is what
+// distinguishes "shut down deliberately" from "fell over by luck" — the whole
+// point of the issue.
+const SHUTDOWN_MARKER = 'shutdown_started reason=stdin_eof';
+
 /**
  * The assertion for #246: behind `npx` the client's exit is invisible except as
  * EOF on stdin, so once the server is ready we close stdin and nothing else.
- * **No signal is sent** — an exit here can only have come from the EOF handler.
- * A process still alive at the deadline is SIGKILLed and fails the check, as is
- * one that exits non-zero or dies on a signal.
+ * **No signal is sent.** The server must then log that it is shutting down
+ * because of EOF, and exit 0 of its own accord. A process still alive at the
+ * deadline is SIGKILLed and fails the check, as is one that exits non-zero,
+ * dies on a signal, or exits without having taken the shutdown path.
  */
 const runStdinEofCheck = (args, marker) =>
   new Promise((resolve, reject) => {
@@ -131,16 +141,94 @@ const runStdinEofCheck = (args, marker) =>
       }
       if (signal) return fail(`exited on ${signal} rather than by itself`);
       if (code !== 0) return fail(`exited with code ${code}, expected 0`);
+      if (!output.includes(SHUTDOWN_MARKER)) {
+        return fail(`exited without "${SHUTDOWN_MARKER}" — no deliberate shutdown ran`);
+      }
 
-      console.log('[smoke] ok (exited cleanly on stdin EOF)');
+      console.log('[smoke] ok (shut down deliberately on stdin EOF)');
       resolve();
     });
   });
 
+/**
+ * The inverse contract: closing stdin must not stop an HTTP server, however it
+ * is supervised.
+ *
+ * Two independent things currently guarantee that — `watchStdin: false` in
+ * `src/index.ts`, and the fact that nothing reads stdin in HTTP mode, so the
+ * stream stays paused and never reports EOF. This check cannot tell them apart
+ * and will keep passing if only one survives. It is here to pin the observable
+ * behaviour, not to police the flag; `installShutdown`'s unit suite is what
+ * asserts that no stdin listener is registered.
+ */
+const runStdinIgnoredCheck = (args, marker) =>
+  new Promise((resolve, reject) => {
+    const proc = spawnServer(args);
+
+    let output = '';
+    let ready = false;
+    let settled = false;
+    let readyTimer;
+    let aliveTimer;
+
+    const onData = (chunk) => {
+      output += chunk.toString();
+      if (!ready && output.includes(marker)) {
+        ready = true;
+        clearTimeout(readyTimer);
+        proc.stdin.end();
+        // Survive the EOF, then stop the server the way a supervisor would.
+        aliveTimer = setTimeout(() => {
+          settled = true;
+          proc.kill('SIGTERM');
+        }, SURVIVE_MS);
+      }
+    };
+
+    proc.stdout.on('data', onData);
+    proc.stderr.on('data', onData);
+
+    readyTimer = setTimeout(() => {
+      if (!ready) proc.kill('SIGKILL');
+    }, TIMEOUT_MS);
+
+    proc.on('error', (err) => {
+      clearTimeout(readyTimer);
+      clearTimeout(aliveTimer);
+      console.error(`[smoke] spawn error: ${err.message}`);
+      reject(err);
+    });
+
+    proc.on('close', () => {
+      clearTimeout(readyTimer);
+      clearTimeout(aliveTimer);
+
+      if (!ready) {
+        console.error(`[smoke] fail: marker "${marker}" not seen in ${TIMEOUT_MS}ms`);
+        console.error('--- captured output ---');
+        console.error(output || '(empty)');
+        return reject(new Error(`marker not found: ${marker}`));
+      }
+      if (!settled) {
+        const message = `HTTP server exited within ${SURVIVE_MS}ms of stdin EOF; it must ignore stdin`;
+        console.error(`[smoke] fail: ${message}`);
+        console.error('--- captured output ---');
+        console.error(output || '(empty)');
+        return reject(new Error(message));
+      }
+
+      console.log('[smoke] ok (survived stdin EOF in http mode)');
+      resolve();
+    });
+  });
+
+const HTTP_ARGS = ['smoke-test', '--transport', 'http', '--port', '0'];
+
 try {
   await runCheck(['smoke-test'], 'stdio_transport_ready');
-  await runCheck(['smoke-test', '--transport', 'http', '--port', '0'], 'http_transport_ready');
+  await runCheck(HTTP_ARGS, 'http_transport_ready');
   await runStdinEofCheck(['smoke-test'], 'stdio_transport_ready');
+  await runStdinIgnoredCheck(HTTP_ARGS, 'http_transport_ready');
   process.exit(0);
 } catch {
   process.exit(1);

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -2,15 +2,25 @@ import { spawn } from 'node:child_process';
 
 const TIMEOUT_MS = 5000;
 const KILL_GRACE_MS = 1000;
+// Budget for the EOF check: the server's own shutdown grace is 3s, and the
+// watchdog forces the exit at that point, so 5s leaves room without hanging CI.
+const EXIT_TIMEOUT_MS = 5000;
 
 // Markers are structured logger events. Force LOG_LEVEL=info so an inherited
 // LOG_LEVEL=warn/error can't suppress the marker and false-fail the smoke test.
+//
+// stdin is a real pipe rather than `'ignore'`: `'ignore'` maps to `/dev/null`,
+// which reaches EOF immediately, and EOF is now a shutdown trigger in stdio
+// mode. A pipe also mirrors how a client actually launches the server.
+const spawnServer = (args) =>
+  spawn('node', ['dist/index.js', ...args], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, LOG_LEVEL: 'info' },
+  });
+
 const runCheck = (args, marker) =>
   new Promise((resolve, reject) => {
-    const proc = spawn('node', ['dist/index.js', ...args], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, LOG_LEVEL: 'info' },
-    });
+    const proc = spawnServer(args);
 
     let output = '';
     let found = false;
@@ -59,9 +69,78 @@ const runCheck = (args, marker) =>
     });
   });
 
+/**
+ * The assertion for #246: behind `npx` the client's exit is invisible except as
+ * EOF on stdin, so once the server is ready we close stdin and nothing else.
+ * **No signal is sent** — an exit here can only have come from the EOF handler.
+ * A process still alive at the deadline is SIGKILLed and fails the check, as is
+ * one that exits non-zero or dies on a signal.
+ */
+const runStdinEofCheck = (args, marker) =>
+  new Promise((resolve, reject) => {
+    const proc = spawnServer(args);
+
+    let output = '';
+    let ready = false;
+    let timedOut = false;
+    let readyTimer;
+    let exitTimer;
+
+    const fail = (message) => {
+      console.error(`[smoke] fail: ${message}`);
+      console.error('--- captured output ---');
+      console.error(output || '(empty)');
+      reject(new Error(message));
+    };
+
+    const onData = (chunk) => {
+      output += chunk.toString();
+      if (!ready && output.includes(marker)) {
+        ready = true;
+        clearTimeout(readyTimer);
+        // The whole point: EOF only, no signal.
+        proc.stdin.end();
+        exitTimer = setTimeout(() => {
+          timedOut = true;
+          proc.kill('SIGKILL');
+        }, EXIT_TIMEOUT_MS);
+      }
+    };
+
+    proc.stdout.on('data', onData);
+    proc.stderr.on('data', onData);
+
+    readyTimer = setTimeout(() => {
+      if (!ready) proc.kill('SIGKILL');
+    }, TIMEOUT_MS);
+
+    proc.on('error', (err) => {
+      clearTimeout(readyTimer);
+      clearTimeout(exitTimer);
+      console.error(`[smoke] spawn error: ${err.message}`);
+      reject(err);
+    });
+
+    proc.on('close', (code, signal) => {
+      clearTimeout(readyTimer);
+      clearTimeout(exitTimer);
+
+      if (!ready) return fail(`marker "${marker}" not seen in ${TIMEOUT_MS}ms`);
+      if (timedOut) {
+        return fail(`still running ${EXIT_TIMEOUT_MS}ms after stdin closed (had to SIGKILL)`);
+      }
+      if (signal) return fail(`exited on ${signal} rather than by itself`);
+      if (code !== 0) return fail(`exited with code ${code}, expected 0`);
+
+      console.log('[smoke] ok (exited cleanly on stdin EOF)');
+      resolve();
+    });
+  });
+
 try {
   await runCheck(['smoke-test'], 'stdio_transport_ready');
   await runCheck(['smoke-test', '--transport', 'http', '--port', '0'], 'http_transport_ready');
+  await runStdinEofCheck(['smoke-test'], 'stdio_transport_ready');
   process.exit(0);
 } catch {
   process.exit(1);

--- a/src/dev/reload.ts
+++ b/src/dev/reload.ts
@@ -175,6 +175,10 @@ export const registerReloadTool = (
  * `reload_tools` tool that hot-reloads edited tool code on demand. stdio only —
  * HTTP builds a per-session server per request, so there is no long-lived
  * server to hot-swap.
+ *
+ * Returns the running server so the caller can close it on shutdown: dev mode
+ * runs over the same stdio transport as normal mode and must exit the same way
+ * when the client disconnects.
  */
 /* v8 ignore start -- runtime bootstrap: binds the reload tool to a real stdio
    transport; the reload machinery it wires up is covered by dev-reload.test.ts */
@@ -183,10 +187,11 @@ export const startDevServer = async (
   getToken: () => string | Promise<string>,
   logger: Logger = silentLogger,
   onUnauthorized?: () => void,
-): Promise<void> => {
+): Promise<McpServer> => {
   const { server, reload } = createReloadableServer(config, getToken, logger, onUnauthorized);
   registerReloadTool(server, reload, logger);
   await startStdioTransport(server, logger);
   logger.info('dev_mode_enabled');
+  return server;
 };
 /* v8 ignore stop */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createTokenStore } from './auth/token-store';
 import type { Config } from './config';
 import { loadConfig } from './config';
@@ -6,6 +7,7 @@ import { createMcpServer } from './server';
 import { startHttpTransport } from './transports/http';
 import { startStdioTransport } from './transports/stdio';
 import { createLogger, type Logger } from './utils/logger';
+import { installShutdown } from './utils/shutdown';
 
 // OAuth mode — browser-based auth on first tool call. `invalidate` drops the
 // dead access token on a 401 so the next call refreshes/re-authenticates.
@@ -19,18 +21,40 @@ const buildStdioTokenStore = (config: Config, logger: Logger) =>
     logger,
   );
 
+// Both stdio paths end with a server already connected to its transport; dev
+// mode wires `reload_tools` and connects on its own. Returning the server is
+// what lets the caller close it on shutdown.
+const connectStdio = async (
+  config: Config,
+  tokenStore: ReturnType<typeof buildStdioTokenStore>,
+  logger: Logger,
+): Promise<McpServer> => {
+  if (config.dev) {
+    return startDevServer(config, tokenStore.getToken, logger, tokenStore.invalidate);
+  }
+  const server = createMcpServer(config, tokenStore.getToken, logger, tokenStore.invalidate);
+  await startStdioTransport(server, logger);
+  return server;
+};
+
 const main = async (): Promise<void> => {
   const config = loadConfig();
   const logger = createLogger(config.logLevel);
 
   if (config.transport === 'stdio') {
     const tokenStore = buildStdioTokenStore(config, logger);
-    if (config.dev) {
-      await startDevServer(config, tokenStore.getToken, logger, tokenStore.invalidate);
-      return;
-    }
-    const server = createMcpServer(config, tokenStore.getToken, logger, tokenStore.invalidate);
-    await startStdioTransport(server, logger);
+    const server = await connectStdio(config, tokenStore, logger);
+
+    // Installed *after* the transport is connected: the SDK's stdin `data`
+    // listener is what puts stdin in flowing mode, and `end` only fires there.
+    installShutdown({
+      watchStdin: true,
+      logger,
+      cleanup: async () => {
+        await server.close();
+        tokenStore.dispose();
+      },
+    });
     return;
   }
 
@@ -42,7 +66,12 @@ const main = async (): Promise<void> => {
 
   // HTTP mode: the HTTP transport creates a per-session McpServer with the
   // request's bearer captured in its tools' closure — no shared state.
-  await startHttpTransport(config, logger);
+  const http = await startHttpTransport(config, logger);
+
+  // Signals only. A daemonised HTTP server is routinely handed `/dev/null` on
+  // stdin, which reaches EOF immediately — watching it here would shut the
+  // server down at boot.
+  installShutdown({ watchStdin: false, logger, cleanup: http.close });
 };
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,9 +68,9 @@ const main = async (): Promise<void> => {
   // request's bearer captured in its tools' closure — no shared state.
   const http = await startHttpTransport(config, logger);
 
-  // Signals only. A daemonised HTTP server is routinely handed `/dev/null` on
-  // stdin, which reaches EOF immediately — watching it here would shut the
-  // server down at boot.
+  // Signals only: an HTTP server has no client on stdin to lose. Nothing reads
+  // stdin here, so it stays paused and never reports EOF anyway — but saying so
+  // explicitly keeps that from becoming load-bearing.
   installShutdown({ watchStdin: false, logger, cleanup: http.close });
 };
 

--- a/src/utils/shutdown.ts
+++ b/src/utils/shutdown.ts
@@ -4,9 +4,9 @@ import type { Logger } from './logger';
  * How long a shutdown may take before the watchdog forces the exit.
  *
  * Generous enough for `server.close()` and an HTTP session drain, short enough
- * that a supervisor's own SIGTERM→SIGKILL grace (10s under systemd and Docker)
- * never expires first — a process killed by the supervisor is exactly the
- * unclean exit this module removes.
+ * to stay inside the tightest common supervisor grace — `docker stop` allows 10s
+ * and Kubernetes 30s before their own SIGKILL (systemd is far laxer at 90s). A
+ * process killed by its supervisor is exactly the unclean exit this removes.
  */
 export const SHUTDOWN_GRACE_MS = 3000;
 
@@ -35,9 +35,15 @@ export interface ShutdownOptions {
    * Watch stdin for EOF. **stdio transport only.**
    *
    * Behind `npx`, the `npm exec` / `sh -c` chain does not relay signals, so EOF
-   * on stdin is the only sign the client is gone. But a daemonised HTTP server
-   * is routinely handed `/dev/null` on stdin, which reaches EOF immediately —
-   * watching it there would shut the server down at boot.
+   * on stdin is the only sign the client is gone.
+   *
+   * HTTP passes `false`. Not because the listener would misfire today — `end`
+   * only fires once something reads stdin, and in HTTP mode nothing does, so a
+   * paused stream never reaches EOF even on `/dev/null` — but because relying
+   * on that would be a trap: the day anything in the process starts reading
+   * stdin, a server with this on would begin exiting the moment its supervisor
+   * handed it `/dev/null`. Required rather than defaulted so the choice is
+   * made at each call site.
    */
   watchStdin: boolean;
   graceMs?: number;

--- a/src/utils/shutdown.ts
+++ b/src/utils/shutdown.ts
@@ -71,7 +71,7 @@ export const createRuntime = (proc: ProcessLike): ShutdownRuntime => ({
   },
   setTimer: (fn, ms) => {
     const timer = setTimeout(fn, ms);
-    return { unref: () => void timer.unref?.(), clear: () => clearTimeout(timer) };
+    return { unref: () => void timer.unref(), clear: () => clearTimeout(timer) };
   },
 });
 

--- a/src/utils/shutdown.ts
+++ b/src/utils/shutdown.ts
@@ -1,0 +1,140 @@
+import type { Logger } from './logger';
+
+/**
+ * How long a shutdown may take before the watchdog forces the exit.
+ *
+ * Generous enough for `server.close()` and an HTTP session drain, short enough
+ * that a supervisor's own SIGTERM→SIGKILL grace (10s under systemd and Docker)
+ * never expires first — a process killed by the supervisor is exactly the
+ * unclean exit this module removes.
+ */
+export const SHUTDOWN_GRACE_MS = 3000;
+
+/** A timer the shutdown owns: armed once, kept off the loop, cancelled on success. */
+export interface ShutdownTimer {
+  unref: () => void;
+  clear: () => void;
+}
+
+/**
+ * The slice of `process` this module touches, injected so tests never register
+ * a listener on the real process or race a real clock.
+ */
+export interface ShutdownRuntime {
+  on: (event: 'SIGINT' | 'SIGTERM', listener: () => void) => void;
+  stdin: { on: (event: 'end', listener: () => void) => void };
+  exit: (code: number) => void;
+  setTimer: (fn: () => void, ms: number) => ShutdownTimer;
+}
+
+export interface ShutdownOptions {
+  /** Releases what the transport holds: the MCP server, the token store, HTTP sessions. */
+  cleanup: () => Promise<void> | void;
+  logger: Logger;
+  /**
+   * Watch stdin for EOF. **stdio transport only.**
+   *
+   * Behind `npx`, the `npm exec` / `sh -c` chain does not relay signals, so EOF
+   * on stdin is the only sign the client is gone. But a daemonised HTTP server
+   * is routinely handed `/dev/null` on stdin, which reaches EOF immediately —
+   * watching it there would shut the server down at boot.
+   */
+  watchStdin: boolean;
+  graceMs?: number;
+  runtime?: ShutdownRuntime;
+}
+
+/** The process API `createRuntime` adapts — narrowed to what is actually used. */
+export interface ProcessLike {
+  on: (event: string, listener: () => void) => unknown;
+  stdin: { on: (event: string, listener: () => void) => unknown };
+  exit: (code: number) => unknown;
+}
+
+/**
+ * Adapt a `process` to a {@link ShutdownRuntime}. Takes the process as an
+ * argument rather than closing over the global so the adapter itself is
+ * testable — otherwise the one part of this module that touches the real
+ * process would be the one part no test can reach.
+ */
+export const createRuntime = (proc: ProcessLike): ShutdownRuntime => ({
+  on: (event, listener) => {
+    proc.on(event, listener);
+  },
+  stdin: {
+    on: (event, listener) => {
+      proc.stdin.on(event, listener);
+    },
+  },
+  exit: (code) => {
+    proc.exit(code);
+  },
+  setTimer: (fn, ms) => {
+    const timer = setTimeout(fn, ms);
+    return { unref: () => void timer.unref?.(), clear: () => clearTimeout(timer) };
+  },
+});
+
+const defaultRuntime: ShutdownRuntime = createRuntime(process);
+
+/**
+ * Install the process's one shutdown path and return its trigger.
+ *
+ * Registering a `SIGTERM` handler *removes* Node's default terminate, which
+ * makes the exit our responsibility: a cleanup that stalls on an in-flight
+ * request would otherwise leave a process SIGTERM cannot kill — the very
+ * symptom this exists to remove. Hence the watchdog, which is load-bearing
+ * rather than defensive, and the unconditional `exit` on every path.
+ *
+ * The exit is explicit rather than a drained event loop because the OAuth
+ * callback server (`auth/browser-oauth.ts`) is a listening socket that is not
+ * `unref()`'d: letting the loop drain would keep a disconnected session alive
+ * for up to the 5-minute auth timeout.
+ */
+export const installShutdown = (options: ShutdownOptions): ((reason: string) => Promise<void>) => {
+  const { cleanup, logger, watchStdin, graceMs = SHUTDOWN_GRACE_MS } = options;
+  const runtime = options.runtime ?? defaultRuntime;
+
+  // SIGTERM and stdin EOF genuinely both fire for a single client disconnect.
+  let started = false;
+  let exited = false;
+
+  const exitOnce = (code: number): void => {
+    if (exited) return;
+    exited = true;
+    runtime.exit(code);
+  };
+
+  const shutdown = async (reason: string): Promise<void> => {
+    if (started) return;
+    started = true;
+    logger.info('shutdown_started', { reason });
+
+    // Armed before cleanup so a cleanup that hangs is still bounded, and
+    // unref'd so it never keeps the process alive for the full grace period
+    // once cleanup has already finished.
+    const watchdog = runtime.setTimer(() => {
+      logger.warn('shutdown_forced', { graceMs });
+      exitOnce(0);
+    }, graceMs);
+    watchdog.unref();
+
+    try {
+      await cleanup();
+      logger.info('shutdown_complete', { reason });
+    } catch (err) {
+      logger.warn('shutdown_cleanup_failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      watchdog.clear();
+      exitOnce(0);
+    }
+  };
+
+  runtime.on('SIGINT', () => void shutdown('SIGINT'));
+  runtime.on('SIGTERM', () => void shutdown('SIGTERM'));
+  if (watchStdin) runtime.stdin.on('end', () => void shutdown('stdin_eof'));
+
+  return shutdown;
+};

--- a/tests/unit/utils/shutdown.test.ts
+++ b/tests/unit/utils/shutdown.test.ts
@@ -1,0 +1,512 @@
+import { describe, expect, it, vi } from 'vitest';
+import { silentLogger } from '../../../src/utils/logger';
+import {
+  createRuntime,
+  installShutdown,
+  SHUTDOWN_GRACE_MS,
+  type ShutdownRuntime,
+  type ShutdownTimer,
+} from '../../../src/utils/shutdown';
+
+/**
+ * A fake `process` plus a fake timer, so no test ever registers a listener on
+ * the real process or races a real clock.
+ *
+ * `listeners` records every registration by event name, which is what lets the
+ * `watchStdin: false` test assert the *absence* of a stdin listener — the one
+ * mistake in this module that would take the HTTP server down at boot.
+ */
+const fakeRuntime = () => {
+  const listeners = new Map<string, Array<() => void>>();
+  const record = (event: string, listener: () => void) => {
+    const existing = listeners.get(event);
+    if (existing) existing.push(listener);
+    else listeners.set(event, [listener]);
+  };
+
+  const exit = vi.fn<(code: number) => void>();
+  const timers: Array<{ fn: () => void; ms: number; unrefs: number; cleared: number }> = [];
+
+  const setTimer = vi.fn((fn: () => void, ms: number): ShutdownTimer => {
+    const entry = { fn, ms, unrefs: 0, cleared: 0 };
+    timers.push(entry);
+    return {
+      unref: () => {
+        entry.unrefs += 1;
+      },
+      clear: () => {
+        entry.cleared += 1;
+      },
+    };
+  });
+
+  const runtime: ShutdownRuntime = {
+    on: record,
+    stdin: { on: (event, listener) => record(`stdin:${event}`, listener) },
+    exit,
+    setTimer,
+  };
+
+  return {
+    runtime,
+    exit,
+    timers,
+    events: () => [...listeners.keys()],
+    /** Fire a registered listener, e.g. `fire('SIGTERM')` or `fire('stdin:end')`. */
+    fire: (event: string) => {
+      const found = listeners.get(event);
+      if (!found) throw new Error(`no listener registered for ${event}`);
+      for (const listener of found) listener();
+    },
+  };
+};
+
+// Lets a test hold `cleanup` open, then release it, without any real timers.
+const deferred = () => {
+  let resolve!: () => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('installShutdown', () => {
+  describe('trigger registration', () => {
+    it('watches stdin EOF only when asked to', () => {
+      const stdio = fakeRuntime();
+      installShutdown({
+        cleanup: async () => {},
+        logger: silentLogger,
+        watchStdin: true,
+        runtime: stdio.runtime,
+      });
+      expect(stdio.events()).toContain('stdin:end');
+    });
+
+    // The regression guard for the whole module. A daemonised HTTP server is
+    // routinely handed `/dev/null` on stdin, which emits EOF immediately, so a
+    // stdin listener registered in HTTP mode would shut the server down at boot.
+    it('registers no stdin listener when watchStdin is false', () => {
+      const http = fakeRuntime();
+      installShutdown({
+        cleanup: async () => {},
+        logger: silentLogger,
+        watchStdin: false,
+        runtime: http.runtime,
+      });
+
+      expect(http.events()).not.toContain('stdin:end');
+      expect(http.events()).toStrictEqual(['SIGINT', 'SIGTERM']);
+    });
+
+    it.each(['SIGINT', 'SIGTERM'] as const)('shuts down on %s', async (signal) => {
+      const rt = fakeRuntime();
+      const cleanup = vi.fn(async () => {});
+      installShutdown({
+        cleanup,
+        logger: silentLogger,
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire(signal);
+      await flush();
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(rt.exit).toHaveBeenCalledWith(0);
+    });
+
+    it('shuts down on stdin EOF', async () => {
+      const rt = fakeRuntime();
+      const cleanup = vi.fn(async () => {});
+      installShutdown({
+        cleanup,
+        logger: silentLogger,
+        watchStdin: true,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('stdin:end');
+      await flush();
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(rt.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('idempotence', () => {
+    // SIGTERM and stdin EOF genuinely can both fire for one client disconnect.
+    it('runs cleanup once when several triggers fire', async () => {
+      const rt = fakeRuntime();
+      const cleanup = vi.fn(async () => {});
+      installShutdown({
+        cleanup,
+        logger: silentLogger,
+        watchStdin: true,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      rt.fire('stdin:end');
+      rt.fire('SIGINT');
+      await flush();
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(rt.exit).toHaveBeenCalledTimes(1);
+    });
+
+    it('arms only one watchdog across repeated triggers', async () => {
+      const rt = fakeRuntime();
+      installShutdown({
+        cleanup: async () => {},
+        logger: silentLogger,
+        watchStdin: true,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      rt.fire('stdin:end');
+      await flush();
+
+      expect(rt.timers).toHaveLength(1);
+    });
+  });
+
+  describe('the watchdog', () => {
+    it('arms an unref-ed timer at the grace period', () => {
+      const rt = fakeRuntime();
+      installShutdown({
+        cleanup: () => deferred().promise,
+        logger: silentLogger,
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+
+      expect(rt.timers).toHaveLength(1);
+      // Pinned exactly: the default is a contract, and an arbitrary delay would
+      // still pass a `toBeGreaterThan`-style assertion.
+      expect(rt.timers[0]?.ms).toBe(SHUTDOWN_GRACE_MS);
+      // unref() is what stops the watchdog from *itself* holding the loop open
+      // for the whole grace period once cleanup has finished early.
+      expect(rt.timers[0]?.unrefs).toBe(1);
+    });
+
+    it('honours an overridden grace period', () => {
+      const rt = fakeRuntime();
+      installShutdown({
+        cleanup: () => deferred().promise,
+        logger: silentLogger,
+        watchStdin: false,
+        graceMs: 250,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      expect(rt.timers[0]?.ms).toBe(250);
+    });
+
+    // Registering a SIGTERM handler removes Node's default terminate, so a
+    // cleanup that never settles would leave a process that SIGTERM cannot kill
+    // — the exact symptom this module exists to remove.
+    it('forces the exit when cleanup never settles', async () => {
+      const rt = fakeRuntime();
+      const stuck = deferred();
+      installShutdown({
+        cleanup: () => stuck.promise,
+        logger: silentLogger,
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      await flush();
+      expect(rt.exit).not.toHaveBeenCalled();
+
+      rt.timers[0]?.fn();
+      expect(rt.exit).toHaveBeenCalledWith(0);
+    });
+
+    it('clears the watchdog once cleanup completes', async () => {
+      const rt = fakeRuntime();
+      installShutdown({
+        cleanup: async () => {},
+        logger: silentLogger,
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      await flush();
+
+      expect(rt.timers[0]?.cleared).toBe(1);
+    });
+
+    it('exits once when the watchdog fires after a completed cleanup', async () => {
+      const rt = fakeRuntime();
+      installShutdown({
+        cleanup: async () => {},
+        logger: silentLogger,
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      await flush();
+      rt.timers[0]?.fn();
+
+      expect(rt.exit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cleanup failure', () => {
+    it('still exits when cleanup rejects', async () => {
+      const rt = fakeRuntime();
+      installShutdown({
+        cleanup: async () => {
+          throw new Error('close failed');
+        },
+        logger: silentLogger,
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      await flush();
+
+      expect(rt.exit).toHaveBeenCalledWith(0);
+    });
+
+    it('logs the failure reason', async () => {
+      const rt = fakeRuntime();
+      const warn = vi.fn();
+      installShutdown({
+        cleanup: async () => {
+          throw new Error('close failed');
+        },
+        logger: { ...silentLogger, warn },
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      await flush();
+
+      expect(warn).toHaveBeenCalledWith('shutdown_cleanup_failed', { error: 'close failed' });
+    });
+
+    it('stringifies a non-Error rejection', async () => {
+      const rt = fakeRuntime();
+      const warn = vi.fn();
+      installShutdown({
+        // A rejected promise rather than `throw`: Biome forbids throwing a
+        // non-Error, but a library can still reject with one, which is exactly
+        // the case `String(err)` exists for.
+        cleanup: () => Promise.reject('plain string'),
+        logger: { ...silentLogger, warn },
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      await flush();
+
+      expect(warn).toHaveBeenCalledWith('shutdown_cleanup_failed', { error: 'plain string' });
+      expect(rt.exit).toHaveBeenCalledWith(0);
+    });
+
+    it('still exits when cleanup throws synchronously', async () => {
+      const rt = fakeRuntime();
+      installShutdown({
+        cleanup: () => {
+          throw new Error('sync boom');
+        },
+        logger: silentLogger,
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      await flush();
+
+      expect(rt.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('logging', () => {
+    it('names the trigger that started the shutdown', async () => {
+      const rt = fakeRuntime();
+      const info = vi.fn();
+      installShutdown({
+        cleanup: async () => {},
+        logger: { ...silentLogger, info },
+        watchStdin: true,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('stdin:end');
+      await flush();
+
+      expect(info).toHaveBeenCalledWith('shutdown_started', { reason: 'stdin_eof' });
+      expect(info).toHaveBeenCalledWith('shutdown_complete', { reason: 'stdin_eof' });
+    });
+
+    it('reports the signal name as the reason', async () => {
+      const rt = fakeRuntime();
+      const info = vi.fn();
+      installShutdown({
+        cleanup: async () => {},
+        logger: { ...silentLogger, info },
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGINT');
+      await flush();
+
+      expect(info).toHaveBeenCalledWith('shutdown_started', { reason: 'SIGINT' });
+    });
+
+    it('warns when the watchdog has to force the exit', () => {
+      const rt = fakeRuntime();
+      const warn = vi.fn();
+      installShutdown({
+        cleanup: () => deferred().promise,
+        logger: { ...silentLogger, warn },
+        watchStdin: false,
+        graceMs: 250,
+        runtime: rt.runtime,
+      });
+
+      rt.fire('SIGTERM');
+      rt.timers[0]?.fn();
+
+      expect(warn).toHaveBeenCalledWith('shutdown_forced', { graceMs: 250 });
+    });
+  });
+
+  // The adapter is the only part that touches a real `process`, which is
+  // exactly why it takes one as an argument: closing over the global would make
+  // the riskiest lines in the module the ones no test can reach.
+  describe('createRuntime', () => {
+    const fakeProcess = () => {
+      const on = vi.fn();
+      const stdinOn = vi.fn();
+      const exit = vi.fn();
+      return { proc: { on, stdin: { on: stdinOn }, exit }, on, stdinOn, exit };
+    };
+
+    it('registers signal listeners on the process', () => {
+      const fake = fakeProcess();
+      const listener = () => {};
+      createRuntime(fake.proc).on('SIGTERM', listener);
+      expect(fake.on).toHaveBeenCalledWith('SIGTERM', listener);
+    });
+
+    it('registers stdin listeners on process.stdin', () => {
+      const fake = fakeProcess();
+      const listener = () => {};
+      createRuntime(fake.proc).stdin.on('end', listener);
+      expect(fake.stdinOn).toHaveBeenCalledWith('end', listener);
+      // Never on the process itself: `end` there would mean nothing.
+      expect(fake.on).not.toHaveBeenCalled();
+    });
+
+    it('forwards the exit code to process.exit', () => {
+      const fake = fakeProcess();
+      createRuntime(fake.proc).exit(0);
+      expect(fake.exit).toHaveBeenCalledWith(0);
+    });
+
+    it('schedules the watchdog at the requested delay', () => {
+      vi.useFakeTimers();
+      try {
+        const fn = vi.fn();
+        createRuntime(fakeProcess().proc).setTimer(fn, 250);
+
+        vi.advanceTimersByTime(249);
+        expect(fn).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(fn).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('cancels a cleared watchdog', () => {
+      vi.useFakeTimers();
+      try {
+        const fn = vi.fn();
+        const timer = createRuntime(fakeProcess().proc).setTimer(fn, 250);
+        timer.clear();
+
+        vi.advanceTimersByTime(1000);
+        expect(fn).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('unrefs the watchdog so it cannot hold the loop open', () => {
+      vi.useFakeTimers();
+      try {
+        const timer = createRuntime(fakeProcess().proc).setTimer(() => {}, 250);
+        const handle = vi.getTimerCount() > 0;
+        expect(handle).toBe(true);
+        // `unref` must reach the real timer handle, not be swallowed.
+        expect(() => timer.unref()).not.toThrow();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('the default runtime', () => {
+    // Exercises the `options.runtime ?? defaultRuntime` fallback that every
+    // production call takes. The listeners are located precisely and removed
+    // again: one left behind could exit the test runner on a later signal.
+    it('registers on the real process when no runtime is injected', () => {
+      const before = {
+        SIGINT: new Set(process.listeners('SIGINT')),
+        SIGTERM: new Set(process.listeners('SIGTERM')),
+      };
+
+      installShutdown({ cleanup: async () => {}, logger: silentLogger, watchStdin: false });
+
+      const added = {
+        SIGINT: process.listeners('SIGINT').filter((l) => !before.SIGINT.has(l)),
+        SIGTERM: process.listeners('SIGTERM').filter((l) => !before.SIGTERM.has(l)),
+      };
+      try {
+        expect(added.SIGINT).toHaveLength(1);
+        expect(added.SIGTERM).toHaveLength(1);
+      } finally {
+        for (const l of added.SIGINT) process.off('SIGINT', l);
+        for (const l of added.SIGTERM) process.off('SIGTERM', l);
+      }
+    });
+  });
+
+  describe('the returned trigger', () => {
+    it('shuts down when called directly and resolves after cleanup', async () => {
+      const rt = fakeRuntime();
+      const cleanup = vi.fn(async () => {});
+      const shutdown = installShutdown({
+        cleanup,
+        logger: silentLogger,
+        watchStdin: false,
+        runtime: rt.runtime,
+      });
+
+      await shutdown('manual');
+
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(rt.exit).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/tests/unit/utils/shutdown.test.ts
+++ b/tests/unit/utils/shutdown.test.ts
@@ -356,7 +356,9 @@ describe('installShutdown', () => {
       expect(info).toHaveBeenCalledWith('shutdown_complete', { reason: 'stdin_eof' });
     });
 
-    it('reports the signal name as the reason', async () => {
+    // Both signals, because each carries its own reason literal: covering only
+    // one leaves the other free to report an empty reason.
+    it.each(['SIGINT', 'SIGTERM'] as const)('reports %s as the reason', async (signal) => {
       const rt = fakeRuntime();
       const info = vi.fn();
       installShutdown({
@@ -366,10 +368,11 @@ describe('installShutdown', () => {
         runtime: rt.runtime,
       });
 
-      rt.fire('SIGINT');
+      rt.fire(signal);
       await flush();
 
-      expect(info).toHaveBeenCalledWith('shutdown_started', { reason: 'SIGINT' });
+      expect(info).toHaveBeenCalledWith('shutdown_started', { reason: signal });
+      expect(info).toHaveBeenCalledWith('shutdown_complete', { reason: signal });
     });
 
     it('warns when the watchdog has to force the exit', () => {
@@ -452,16 +455,35 @@ describe('installShutdown', () => {
       }
     });
 
-    it('unrefs the watchdog so it cannot hold the loop open', () => {
-      vi.useFakeTimers();
+    // Asserting `unref()` reaches the real handle, not merely that it does not
+    // throw: a no-op `unref` would leave the watchdog holding the event loop
+    // open for the whole grace period on every clean shutdown.
+    it('unrefs the underlying timer handle', () => {
+      const realSetTimeout = globalThis.setTimeout;
+      let handleUnref: ReturnType<typeof vi.fn> | undefined;
+
+      const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+        fn: () => void,
+        ms: number,
+      ) => {
+        const handle = realSetTimeout(fn, ms);
+        // Bind the original *before* overwriting, or the spy calls itself.
+        const original = handle.unref.bind(handle);
+        handleUnref = vi.fn(() => original());
+        handle.unref = handleUnref as unknown as typeof handle.unref;
+        return handle;
+      }) as unknown as typeof globalThis.setTimeout);
+
       try {
-        const timer = createRuntime(fakeProcess().proc).setTimer(() => {}, 250);
-        const handle = vi.getTimerCount() > 0;
-        expect(handle).toBe(true);
-        // `unref` must reach the real timer handle, not be swallowed.
-        expect(() => timer.unref()).not.toThrow();
+        const timer = createRuntime(fakeProcess().proc).setTimer(() => {}, 60_000);
+        expect(handleUnref).not.toHaveBeenCalled();
+
+        timer.unref();
+        expect(handleUnref).toHaveBeenCalledTimes(1);
+
+        timer.clear();
       } finally {
-        vi.useRealTimers();
+        spy.mockRestore();
       }
     });
   });

--- a/tests/unit/utils/shutdown.test.ts
+++ b/tests/unit/utils/shutdown.test.ts
@@ -476,12 +476,18 @@ describe('installShutdown', () => {
 
       try {
         const timer = createRuntime(fakeProcess().proc).setTimer(() => {}, 60_000);
-        expect(handleUnref).not.toHaveBeenCalled();
+        // Cleared in `finally`: this is a real 60s timer, and it is still ref'd
+        // until `unref()` below runs. A failure on the first assertion would
+        // otherwise leave it armed and holding the worker open for a minute —
+        // turning a failing test into a stalled one.
+        try {
+          expect(handleUnref).not.toHaveBeenCalled();
 
-        timer.unref();
-        expect(handleUnref).toHaveBeenCalledTimes(1);
-
-        timer.clear();
+          timer.unref();
+          expect(handleUnref).toHaveBeenCalledTimes(1);
+        } finally {
+          timer.clear();
+        }
       } finally {
         spy.mockRestore();
       }


### PR DESCRIPTION
## Summary

Behind `npx`, a stdio server never sees `SIGTERM` when its client goes away — the only notice is EOF on stdin, and nobody read it. This gives the server an explicit shutdown path and triggers it from that EOF, so an abandoned session releases its process instead of being left behind.

**The failure mode is observed, not theoretical.** `@bytebase/dbhub` exits cleanly on EOF. `mongodb-lens`, which handles signals only and holds a MongoDB connection with no timeout, accumulates orphans instead: **79 live instances** were counted on one workstation after 7 days of uptime. That machine had 64 GB of RAM and absorbed it; a 16 GB laptop at 180 days of uptime would not. The Mongo connection is exactly the "something long-lived holds the event loop" case.

**Where this server stands — and why the gap matters more than the number.** The same audit found **2** live instances of this server, not 79. That is the honest figure, and it is small for a specific reason: nothing here holds the loop open, so an abandoned process usually falls over on its own. The one retention path that does exist — the OAuth callback server in `auth/browser-oauth.ts`, a listening socket nobody `unref()`'d — is bounded by the 5-minute auth timeout. At ~127 MB resident per process (measured on this branch, default `namespace` mode, 52 tools), 2 instances is a few hundred megabytes, not gigabytes.

So the distance between 2 and 79 is not a property of this codebase's discipline. It is the absence of a long-lived handle, and nothing states that absence as a rule. Add one — an HTTP keep-alive agent, a refresh timer, a persistent cache, a database connection like the one above — and this server's number starts moving toward the other one, while nothing in the diff that introduced it would have looked like it touched process lifecycle. That is what this closes off, at the source rather than at the symptom.

## Linked issue

Closes #246

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` — n/a, no tool change
- [x] If the change has **MCP-runtime-observable** behaviour: this PR carries a `## Functional validation plan` below — **executed by an independent validator against `5ecb20f`, all nine scenarios OK ([report](https://github.com/fruggr/zendesk-mcp-server/pull/249#issuecomment-5381671127), [rerun addendum](https://github.com/fruggr/zendesk-mcp-server/pull/249#issuecomment-5381806744)).**

## What the issue got right, and what it missed

The diagnosis is exact: `StdioServerTransport` attaches `'data'` and `'error'` listeners on stdin and nothing else, so `transport.onclose` fires only when we close it ourselves. EOF was read by nobody.

Two things widened the fix.

**There were no existing signal handlers to sit beside.** `grep -rn "SIGINT\|SIGTERM\|process.on(" src/` returned nothing on `main`. `tokenStore.dispose()`, `server.close()` and the HTTP transport's `close()` were all unreachable from the entrypoint.

**The orphan already existed.** The `unref()` discipline elsewhere is deliberate, but the OAuth callback server is a listening `http.Server` that is not `unref()`'d — the five-minute window described above, and the likeliest explanation for the 2 instances that were found. That is also why shutdown ends in an explicit `exit(0)` rather than a drained loop: draining would wait out that same five minutes.

## Design notes for the reviewer

**The watchdog is load-bearing, not defensive.** Registering `process.on('SIGTERM')` *removes* Node's default terminate and makes the exit our responsibility. A cleanup stalled on an in-flight Zendesk request would otherwise produce a process `SIGTERM` cannot kill — a worse version of the bug. It is armed before cleanup and `unref()`'d, bounding shutdown at 3s, inside `docker stop`'s 10s and Kubernetes' 30s.

`unref()` does not defeat it, though that is easy to assume: an unref'd timer still fires while the loop runs and only declines to hold the loop open by itself. So a hung cleanup that holds something (a socket, an in-flight request) is forced out at the grace, and one that holds nothing lets the loop empty and Node exit before the watchdog was ever needed. Both terminate.

**Handlers are installed after the transport connects**, because the SDK's stdin `'data'` listener is what puts stdin in flowing mode and `'end'` only fires there. That leaves a startup window — ~0.3s on normal hardware, up to 27s on a loaded slow one — where a signal takes Node's default action instead. That is deliberate and harmless: in that window there is no connected server to close and the token store's only handle is an `unref()`'d timer, so there is nothing a graceful path would do differently. Validation surfaced it as `exit=130`; the plan now polls for readiness rather than assuming a delay.

**A correction worth reading, because it reverses a claim made earlier in this branch.** I initially justified `watchStdin: false` for HTTP by asserting that `/dev/null` stdin would shut a daemonised server down at boot. That is false, and the third commit corrects it. `'end'` fires only once a stream is actually *read*; attaching an `'end'` listener does not resume a paused stream. Measured:

| stdin | `'data'` listener | `'end'` |
| --- | --- | --- |
| `/dev/null` | yes | fires immediately |
| `/dev/null` | no | never fires |
| closed pipe | no | never fires |

In HTTP mode nothing reads stdin, so EOF never arrives regardless. `watchStdin: false` is therefore not averting a live failure — it refuses to depend on an invariant nothing states, since the day anything in the process reads stdin a server carrying an EOF handler would start exiting as soon as its supervisor handed it `/dev/null`. The stdio half is unaffected: the SDK *does* attach `'data'`, so EOF there is genuinely live, which is why `scripts/smoke-test.mjs` had to stop spawning with `stdio: ['ignore', …]` and the Node 20 tarball job had to hold stdin open.

**Every new smoke check was verified against an injected regression rather than assumed.** This took three passes, and the failures are worth knowing about because they were all the same shape — a check reporting success on a broken server:

1. The EOF check initially passed even with the feature removed, because the old accidental exit produced the same observable — precisely the distinction the issue draws. Fixed by requiring `shutdown_started reason=stdin_eof`.
2. That still accepted a *forced* shutdown: a cleanup that hangs is cut short by the watchdog, which also exits 0, at 3s, inside the check's 5s deadline. The fourth commit adds `shutdown_complete reason=stdin_eof` and rejects any run logging `shutdown_forced`. Both rejections were confirmed reachable by hanging a cleanup with and without something holding the event loop.
3. The HTTP check sent SIGTERM with no SIGKILL escalation, so a server that stopped honouring SIGTERM — the regression it exists to catch — would have hung the run until the CI job timeout instead of failing. It now escalates and fails on `hadToKill`.

The HTTP check is documented as *unable* to tell `watchStdin: false` apart from the paused stream; the unit suite is what asserts the listener's absence.

**Placement.** `src/index.ts` and `src/transports/stdio.ts` are excluded from coverage as thin bootstraps, so logic there is invisible to both the coverage ratchet and Stryker. The module lives in `src/utils/` (inside Stryker's `mutate` scope) and takes its `process` access through an injected runtime so the adapter is tested rather than `v8 ignore`d.

Rationale in full: `docs/decisions/lifecycle-shutdown.md`.

## Gates

`pnpm typecheck`, `pnpm check`, `pnpm test` (932), `pnpm test:coverage` (97.85 / 85.80 / 98.91 / 98.36 — up on all four axes), `pnpm test:smoke` (4 checks), `pnpm test:mutation:diff origin/main HEAD` → **53/53 mutants killed, 0 escaped**. CI green on `5ecb20f`.

---

## Functional validation plan

✅ **Executed against `5ecb20f` — all nine scenarios OK** ([report](https://github.com/fruggr/zendesk-mcp-server/pull/249#issuecomment-5381671127), [rerun addendum](https://github.com/fruggr/zendesk-mcp-server/pull/249#issuecomment-5381806744)). No code change came out of it: every finding was against this plan's own timing assumptions, and they are fixed below.

**For an independent validator.** Please report as a PR comment in English.

### ⚠️ Read this first — this plan deviates from the usual shape

This change is observable at the **process lifecycle** level, not through the MCP tool surface. The tool surface is unchanged, so calling `mcp__zendesk__*` tools cannot exercise it. Two consequences:

1. **Do not close the stdin of your own running server** — in stdio mode that is now a shutdown trigger and you would end your own session. All lifecycle scenarios spawn **separate, short-lived** server processes.
2. You will need a runnable build. `dist/` is normally already built at session start; if it is stale, run `pnpm build` once. This is the one setup step the plan asks for, and it is unavoidable here.

Capture the SHA you tested: `git rev-parse HEAD` (expected `5ecb20f` or later).

All commands below run from the repo root. `LOG_LEVEL=info` is required — the markers are logger events. The positional `smoke-test` is consumed as the Zendesk subdomain, so no credentials are needed: every scenario asserts lifecycle only and never reaches Zendesk.

**No scenario below uses a fixed delay to wait for the server.** Boot was measured at ~0.3s on a workstation, 1.9–2.2s warm on a slow one, and 21–27s on that same machine under load. Every wait polls for the readiness marker instead, so the plan adapts rather than needing constants retuned per machine.

### Scenarios

Every command below was run on this branch before being written here, so the expected output is observed, not predicted. Use `LOG_LEVEL=info` and **redirect to a file** rather than piping to `grep`.

Set `SP=$(mktemp -d)` once for the log files.

**V1 — normal operation is not broken.** Call any read-only tool in your live session, e.g. `mcp__zendesk__get_current_user`. It must succeed as before, and your session must stay up: the shutdown wiring must never fire during normal use.

**V2 — the core of #246: stdio shuts down *deliberately* on EOF, no signal sent.**
```bash
LOG_LEVEL=info node dist/index.js smoke-test < /dev/null > $SP/v2.log 2>&1; echo "exit=$?"
grep -E 'shutdown_started|shutdown_complete' $SP/v2.log
```
Expect `exit=0` with `shutdown_started reason=stdin_eof` **and** `shutdown_complete reason=stdin_eof`. The markers are the point — a bare `exit=0` also happened before this change, which is exactly the "circumstantial, not by design" distinction the issue draws.

**V3 — EOF does not truncate in-flight work.**
```bash
printf '%s\n%s\n' \
  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"v","version":"0"}}}' \
  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
  | LOG_LEVEL=info node dist/index.js smoke-test 2>/dev/null | grep -o '"id":[0-9]*' | sort -u
```
Expect both `"id":1` and `"id":2` — the server answers every queued request before EOF stops it.

**V4 / V5 — HTTP ignores stdin, and drains on SIGTERM.** Polls for readiness rather than racing a fixed `timeout`, and asserts the two things separately: that the server survived an EOF it received at startup, and that SIGTERM then drained it.
```bash
LOG_LEVEL=info node dist/index.js smoke-test --transport http --port 0 \
  < /dev/null > $SP/v4.log 2>&1 & PID=$!
for i in $(seq 1 120); do grep -q 'http_transport_ready' $SP/v4.log && break; sleep 0.5; done
sleep 2
kill -0 $PID 2>/dev/null && echo "alive: yes"
kill -TERM $PID; wait $PID; echo "exit=$?"
grep -E 'http_transport_ready|shutdown_|stdin_eof' $SP/v4.log
```
Expect `alive: yes` — its stdin was at EOF from the very first read, and it is still running. Then `exit=0` with `shutdown_started reason=SIGTERM` and `shutdown_complete reason=SIGTERM`, and **no `stdin_eof` anywhere**. A process already gone before the `kill -0`, or any `stdin_eof`, is a FAIL.

**V6 — SIGINT works on stdio.** stdin is held open by a fifo the shell keeps on a spare descriptor. Wait for the readiness marker rather than a fixed delay: handlers are installed only once the transport is connected, so a signal sent during boot takes Node's default action and you get `exit=130` with an empty log — a timing artefact, not a failure of the change.

A fifo rather than `sleep N |` on purpose: a holding `sleep` keeps the shell busy for its full duration after the server is already gone, which cost one validator up to 90s per scenario. Closing the descriptor releases immediately, so the poll can be generous for free — measured at 1s total here.
```bash
mkfifo $SP/hold6; exec 9<>$SP/hold6
LOG_LEVEL=info node dist/index.js smoke-test < $SP/hold6 > $SP/v6.log 2>&1 & PID=$!
for i in $(seq 1 120); do grep -q 'stdio_transport_ready' $SP/v6.log && break; sleep 0.5; done
kill -INT $PID 2>/dev/null; wait $PID; echo "exit=$?"
exec 9>&-
grep -E 'shutdown_started|shutdown_complete' $SP/v6.log
```
Expect `exit=0` with `reason=SIGINT` on both markers.

**V7 — dev mode behaves like stdio.**
```bash
LOG_LEVEL=info node dist/index.js smoke-test --dev < /dev/null > $SP/v7.log 2>&1; echo "exit=$?"
grep -E 'dev_mode_enabled|shutdown_started' $SP/v7.log
```
Expect `dev_mode_enabled`, then `shutdown_started reason=stdin_eof`, `exit=0`.

**V8 — idempotence: one shutdown, not two.** Same fifo and readiness poll as V6, for the same reasons.
```bash
mkfifo $SP/hold8; exec 8<>$SP/hold8
LOG_LEVEL=info node dist/index.js smoke-test < $SP/hold8 > $SP/v8.log 2>&1 & PID=$!
for i in $(seq 1 120); do grep -q 'stdio_transport_ready' $SP/v8.log && break; sleep 0.5; done
kill -TERM $PID 2>/dev/null; kill -TERM $PID 2>/dev/null; wait $PID; echo "exit=$?"
exec 8>&-
grep -c 'info. shutdown_started' $SP/v8.log
```
Expect `exit=0` and a count of exactly **1**.

**V9 — the committed harness agrees.** `pnpm test:smoke` — all four checks print `ok`, including `shut down deliberately on stdin EOF` and `survived stdin EOF in http mode`.

### Long-running behaviour — do not wait it out

The 3s watchdog that bounds a stalled cleanup is **already covered by unit tests** with an injected runtime and fake timer (`tests/unit/utils/shutdown.test.ts` → "forces the exit when cleanup never settles", "arms an unref-ed timer at the grace period"). Please do not try to reproduce a hung cleanup from outside the process. The only thing worth confirming externally is the negative: **no scenario above should ever print `shutdown_forced`** — if one does, a normal shutdown is hitting the watchdog and that is a FAIL.

### Priorities

Do **V2**, **V4**, **V3** first — they are the issue's actual claim, the regression it must not cause, and the correctness risk of shutting down too eagerly. **V1** is the cheap "nothing is broken" check. **V5–V9** round out the surface.

### Reporting

Post one PR comment with a per-id verdict (`OK` / `FAIL` / `BLOCKED`) plus the evidence you observed — the exit code and the relevant log lines, not just an assertion that it passed. Finish with an overall green/failing summary and the SHA you tested. If anything is `BLOCKED` on environment rather than code, say so explicitly.