### PR TITLE
test(utils): raise src/utils/formatting.ts to zero escaped mutants and put it back under the gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,10 @@ quality bar still hold — the freedom is from Zendesk's shape, not from craft.)
 - Existing tests are sacred: a failure is a potential regression — find the root
   cause before touching the test.
 - Mock Zendesk with MSW (`tests/msw-handlers.ts`), never the real API.
+- Exact-output assertions go through `toMatchInlineSnapshot`, **committed
+  filled** — an empty one is auto-filled, passes, and kills no mutant. A `-u` on a
+  formatter changes what an agent reads back: treat it as a behaviour change and
+  justify it. Rule: `CONTRIBUTING.md` (Code standards).
 - Extend `tests/integration/` when you add/change a tool, mode, filter or
   transport; shared behaviour goes in `registerCoreScenarios`. Coverage
   thresholds in `vitest.config.ts` are a ratchet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,15 @@ The same checklist appears on the
     test just to make it pass without understanding the root cause.
   - The Zendesk API is mocked with MSW handlers in `tests/msw-handlers.ts`.
     Never call the real API in tests.
+- **Exact-output assertions use `toMatchInlineSnapshot`, committed filled.** An
+  empty `toMatchInlineSnapshot()` is auto-filled on the next run and passes, so it
+  asserts nothing — and under mutation testing it kills nothing, silently. Write
+  it empty, run `pnpm exec vitest run <file> -u` once, read what it wrote, commit
+  that.
+- **A `-u` on a formatter is a product-surface change, not a chore.** Those
+  strings are what an MCP agent reads back, so re-baselining a snapshot changes
+  the server's output. Re-read the diff the update produced and say in the PR why
+  the new wording is right, exactly as for any other behaviour change.
 - Functional style: pure functions, immutable data, no classes (except
   `ZendeskApiError`). See `AGENTS.md` for the full architecture and
   conventions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,8 +152,9 @@ The same checklist appears on the
 - **Exact-output assertions use `toMatchInlineSnapshot`, committed filled.** An
   empty `toMatchInlineSnapshot()` is auto-filled on the next run and passes, so it
   asserts nothing — and under mutation testing it kills nothing, silently. Write
-  it empty, run `pnpm exec vitest run <file> -u` once, read what it wrote, commit
-  that.
+  it empty, run `pnpm test <file>` once, read what it wrote, commit that. A plain
+  run is what fills an empty inline snapshot; reach for `-u` only to overwrite a
+  filled one, since it re-baselines *every* stale snapshot in the file at once.
 - **A `-u` on a formatter is a product-surface change, not a chore.** Those
   strings are what an MCP agent reads back, so re-baselining a snapshot changes
   the server's output. Re-read the diff the update produced and say in the PR why

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -434,14 +434,30 @@ Every disable names the role it claims, so a reviewer can challenge the
 classification; an unexplained disable is indistinguishable from hiding a gap.
 
 **And it cannot target one mutant among several of the same mutator on a line.**
-Both waivers left in `formatting.ts` hit this: the equivalent mutant is the
-whole-condition `ConditionalExpression`, and its siblings on the same line are
-killed. Splitting a guard into two statements isolates a clause and is worth
-doing; hoisting a condition into a named `const` is not, because Stryker emits
-the whole-conjunction mutant wherever the expression sits. What is left is a
-waiver that also covers killed siblings — acceptable only when the comment says
-so, and when the assertions behind those siblings stay in place. Only the gate
-accounting is waived, never the test.
+The equivalent mutant is typically the whole-condition `ConditionalExpression`
+while its siblings on the same line are killed, so a line-level waiver takes them
+with it. Splitting a guard into two statements isolates a clause; hoisting a
+condition into a named `const` does *not*, because Stryker emits the
+whole-conjunction mutant wherever the expression sits. Which is why the first
+question is never "how do I scope the waiver" but **"is this mutant actually
+equivalent"**.
+
+#203 got that wrong twice before getting it right, and the pattern is worth
+naming. Two mutants in `renderAuditValue` looked equivalent because every
+*reachable* input produced identical output: emptying the `value === ''` arm, and
+forcing the SLA-metric test true. Both arguments rested on the **caller** — the
+audit name maps never carry key 0, the Zendesk API never sends an array with an
+own `minutes` property — while the guards live in a function whose signature
+promises neither. `AuditNames` is a plain `Map<number, string>`; `value` is
+`unknown`. Each mutant was killable by one test asserting the guard's own
+contract, and the file now needs **no directive at all**.
+
+So: when a mutant looks equivalent, check whether the argument for that is a fact
+about the *type* or a fact about *today's caller*. If it is the caller, the
+mutant is marking an unasserted contract, and the assertion is the fix. A waiver
+that also covers killed siblings is a last resort, acceptable only when the
+comment says so and the assertions behind those siblings stay in place — only the
+gate accounting is ever waived, never the test.
 
 **The `!` ordering is load-bearing**, even with no negation left in `mutate`
 today. Stryker resolves it as a sequence of set/unset operations rather than two

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -138,14 +138,20 @@ A cold run is expensive; incremental runs are not. Measured on `src/utils`
 That extrapolated badly, and the number it produced is worth keeping as a
 warning. Projecting to all of `src/` gave ~7 400 mutants ≈ 65 min, and
 `mutation.yml` was sized against it. Two things made it wrong: the scope that
-shipped ([§5](#5-scope-and-why-label-heavy-files-stay-out-of-it)) leaves out
-`src/tools/**` and `src/utils/formatting.ts`, so it is **1 452 mutants**, five
-times fewer; and CI runs about twice the mutants per second of the 4-core figures
-above. Measured across the baselines on `main`, a **cold** run is **6–10 min**
-(6 min 22 s on `ca28fad`, 9 min 49 s on the dependency bump before it) and a warm
-one is 45 s to 2 min. Those two timings, and the 1 417 mutants they covered,
-predate the Stryker 10 bump; [§8](#8-the-1000-bump-and-the-one-mutator-it-adds)
-has the +35 and what it cost.
+shipped ([§5](#5-scope-and-how-string-mutants-are-treated)) leaves out
+`src/tools/**`, so it is **2 043 mutants**, more than three times fewer; and CI
+runs about twice the mutants per second of the 4-core figures above.
+
+Two cold-run figures, and they are not interchangeable. **Locally on 4 cores**,
+the whole scope is **13 min 7 s** (measured on #203's branch, 2 043 mutants).
+**In CI**, the `baseline` job read **6–10 min** — 6 min 22 s on `ca28fad`,
+9 min 49 s on the dependency bump before it — but over **1 417** mutants, and
+before both the Stryker 10 bump ([§8](#8-the-1000-bump-and-the-one-mutator-it-adds)
+has the +35 and what it cost) and `src/utils/formatting.ts` re-entering the scope
+with #203. Scaled by mutant count that band becomes roughly 9–14 min, which the
+baseline job's `timeout-minutes: 45` still clears with room; the figure to trust
+is the first `main` baseline after #203 merges, not this extrapolation. A **warm**
+run is 45 s to 2 min.
 
 Those are the `baseline` job, which mutates the **whole** scope. The `Changed
 lines` gate a PR actually waits on mutates only the lines the diff touched, so it
@@ -264,7 +270,7 @@ the whole file.
 Line granularity narrows that problem but does not remove it — a line that
 already carries a survivor still fails the PR that touches it. That residual is
 what keeps label-heavy files out of scope until their assertion work is done
-([§5](#5-scope-and-why-label-heavy-files-stay-out-of-it)).
+([§5](#5-scope-and-how-string-mutants-are-treated)).
 
 The gate asks for **no survivors in the changed lines**, not a percentage: on a
 handful of mutants a percentage is arbitrary (1 of 3 fails at 67 %, 1 of 10
@@ -345,12 +351,10 @@ none of those things.
 Reconsider if #2843 ships: native line-range scoping would replace the first
 half, and `thresholds.break` over a scoped run could replace the second.
 
-## 5. Scope, and why label-heavy files stay out of it
+## 5. Scope, and how string mutants are treated
 
 `mutate` covers `src/auth`, `src/client`, `src/routing`, `src/utils` and
 `src/config.ts` — the logic code, where a surviving mutant is a real test gap.
-
-Two exclusions, both for the same reason and both temporary.
 
 **A label-heavy file does not merely score badly — it booby-traps the gate.**
 Because the gate fails a PR on a survivor in a line that PR changed, a file whose
@@ -362,22 +366,93 @@ scope is a decision to do its assertion work *first*:
 
 | Excluded | Why | Owner |
 | --- | --- | --- |
-| `src/tools/**` | `.describe()` calls, each emptied by `StringLiteral` into a survivor that says nothing about test quality | needs `excludedMutations` or per-file directives |
-| `src/utils/formatting.ts` | 171 escaped mutants, 58 % of them label strings; 42 distinct lines carry one | [#203](https://github.com/fruggr/zendesk-mcp-server/issues/203) |
+| `src/tools/**` | `.describe()` calls, each emptied by `StringLiteral` into a survivor that says nothing about test quality | [#212](https://github.com/fruggr/zendesk-mcp-server/issues/212) |
 
-Excluded from *mutation* only: both still run under `pnpm test` and still count
-towards the coverage thresholds. `formatting.ts` also keeps the boundary tests
-added alongside this decision — the exclusion defers the score, not the testing.
+Excluded from *mutation* only: it still runs under `pnpm test` and still counts
+towards the coverage thresholds.
 
-**The `!` ordering is load-bearing.** Stryker resolves `mutate` as a sequence of
-set/unset operations rather than two independent lists (`project-reader`,
-`resolveFileDescriptions`), so a negation only excludes what an *earlier* pattern
-included. `scopeMatcher` in `scripts/mutation-scope.mjs` mirrors that exactly, and
-has to: the gate hands its ranges to `--mutate`, which **replaces** the configured
-scope rather than intersecting with it. A `patterns.some(...)` that ignored
-negations would have let the gate mutate an excluded file anyway — the exclusion
-defeated in the one place it has to hold. Pinned in
-`tests/unit/mutation-scope.test.ts`.
+`src/utils/formatting.ts` was excluded here until #203, which brought it in at
+**zero escaped mutants**. That is the bar, and it is not a round-number
+aesthetic: re-arming the gate on a file with any residue leaves a mine on each
+line that carries one, which is the trap the exclusion existed to avoid. Getting
+there is also what corrected the reasoning below.
+
+### The `StringLiteral` question, decided on measurement
+
+The tempting rule — "`StringLiteral` survivors are label noise, exempt them" — is
+wrong, and #203 measured how wrong. On `581c958` that file had 173 escaped
+mutants, 102 of them `StringLiteral`. Splitting those 102 by what the string
+actually *is*:
+
+| Form | Count | What it is |
+| --- | ---: | --- |
+| `'…'` → `''` | 73 | a label or separator emptied — including every trailing `.join('\n')` |
+| `''` → a non-empty marker | 29 | the **suppressed-line branch of a ternary** |
+
+The second group is not prose at all. It is the assertion "this line must be
+*absent* from the output", and no `not.toContain` can make it: Stryker replaces
+the `''` with a marker, the line appears, and the negative assertion still
+passes. The same blind spot covers two more forms that are not `StringLiteral` —
+a dropped `.filter(Boolean)` (the output gains a blank line) and an emptied
+separator inside a joined list.
+
+So the axis is not the mutator, and it is not the file. **It is what the string
+does**, and there are four roles:
+
+1. **Behavioural** — anything the code branches on, or that travels to a wire,
+   protocol or API: dispatch keys, `case` labels, sentinels, algorithm and
+   encoding identifiers, HTTP header names and values, OAuth parameters and
+   scopes, error codes, env-var names, escaping replacements, data-mapping keys.
+   A survivor here is a missing test, and Stryker classing it as `StringLiteral`
+   is an accident of the mutator's implementation. **Assert, never disable.**
+2. **Structural** — the `''` arm that suppresses an output line, and its
+   non-string cousins (`filter(Boolean)`, list separators). **Assert**, with an
+   input where the line *is* suppressed.
+3. **Output prose read by an agent or a user.** Also assert: an exact-output
+   assertion costs a `vitest -u` on a pre-filled `toMatchInlineSnapshot`, so the
+   maintenance argument for exempting cosmetic prose does not survive contact
+   with the tooling. Measured on one formatter — two snapshots took its region
+   from 6 killed / 15 escaped to 21 killed / 0 escaped, with no directive; the
+   block-scoped disable scored 36.36 % and left the seven logic mutants needing
+   *the same two inputs* anyway.
+4. **Internal diagnostics** — log event names, debug payload keys. Disable with a
+   reason, unless a test asserts the event name as an observability contract, in
+   which case it is role 1.
+
+### Mechanism, and what it cannot do
+
+`mutator.excludedMutations` stays unused: it is global-only, so it would exempt
+files nobody has looked at yet, including files added later.
+
+A directive is `// Stryker disable next-line <Mutator>[,<Mutator>]: <reason>`, or
+a `disable`/`restore` pair around a region. **Never at file scope** — every file
+worth arguing about mixes roles, and a file-scoped `StringLiteral` disable in
+`formatting.ts` would have silently exempted its dispatch keys and sentinels
+along with its labels.
+
+Every disable names the role it claims, so a reviewer can challenge the
+classification; an unexplained disable is indistinguishable from hiding a gap.
+
+**And it cannot target one mutant among several of the same mutator on a line.**
+Both waivers left in `formatting.ts` hit this: the equivalent mutant is the
+whole-condition `ConditionalExpression`, and its siblings on the same line are
+killed. Splitting a guard into two statements isolates a clause and is worth
+doing; hoisting a condition into a named `const` is not, because Stryker emits
+the whole-conjunction mutant wherever the expression sits. What is left is a
+waiver that also covers killed siblings — acceptable only when the comment says
+so, and when the assertions behind those siblings stay in place. Only the gate
+accounting is waived, never the test.
+
+**The `!` ordering is load-bearing**, even with no negation left in `mutate`
+today. Stryker resolves it as a sequence of set/unset operations rather than two
+independent lists (`project-reader`, `resolveFileDescriptions`), so a negation
+only excludes what an *earlier* pattern included. `scopeMatcher` in
+`scripts/mutation-scope.mjs` mirrors that exactly, and has to: the gate hands its
+ranges to `--mutate`, which **replaces** the configured scope rather than
+intersecting with it. A `patterns.some(...)` that ignored negations would have
+let the gate mutate an excluded file anyway — the exclusion defeated in the one
+place it has to hold. Pinned in `tests/unit/mutation-scope.test.ts`, and the next
+exclusion will depend on it.
 
 ## 6. What this replaces, and what it does not
 
@@ -530,8 +605,8 @@ every one of them in `src/auth`**. Nine were in `browser-oauth.ts`, the only fil
 whose score fell before the assertions landed (53.14 % → 52.36 %); every other
 file held or gained.
 
-The mutator was **kept enabled**, against the [section 5](#5-scope-and-why-label-heavy-files-stay-out-of-it)
-booby-trap test, because not one of its survivors was a label. Every single one
+The mutator was **kept enabled**, against the [section 5](#5-scope-and-how-string-mutants-are-treated)
+booby-trap test, because not one of its survivors was role-3 prose. Every single one
 was an unasserted teardown or error path — which is the case for the mutator, so
 the ten are worth listing individually:
 

--- a/docs/decisions/mutation-testing.md
+++ b/docs/decisions/mutation-testing.md
@@ -442,8 +442,8 @@ whole-conjunction mutant wherever the expression sits. Which is why the first
 question is never "how do I scope the waiver" but **"is this mutant actually
 equivalent"**.
 
-#203 got that wrong twice before getting it right, and the pattern is worth
-naming. Two mutants in `renderAuditValue` looked equivalent because every
+Issue #203 got that wrong twice before getting it right, and the pattern is
+worth naming. Two mutants in `renderAuditValue` looked equivalent because every
 *reachable* input produced identical output: emptying the `value === ''` arm, and
 forcing the SLA-metric test true. Both arguments rested on the **caller** — the
 audit name maps never carry key 0, the Zendesk API never sends an array with an

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -269,10 +269,34 @@ const withName = (id: unknown, names: Map<number, string>): string => {
 // to "Name (id)", SLA-metric objects reduced to their minutes, everything else via
 // formatFieldValue. Returns '' for an empty/absent side.
 const renderAuditValue = (field: string, value: unknown, names: AuditNames): string => {
-  if (value === null || value === undefined || value === '') return '';
+  if (value === null || value === undefined) return '';
+  // Split out of the guard above so this waiver covers the empty-string clause
+  // alone, leaving the null/undefined guard fully scored. The clause is a redundant
+  // early-out, not a sentinel the output depends on: every path further down
+  // already yields '' for '' — withName via Number('') === 0 then String(''),
+  // formatFieldValue via String(''). No input can observe its removal, so skipping
+  // the early-out (ConditionalExpression => false, BlockStatement) and never
+  // matching it (StringLiteral) are equivalent. The waiver also takes one killed
+  // sibling with it, "always return ''", which the audit suite still fails on; the
+  // returned '' on the line below stays scored.
+  // Stryker disable next-line ConditionalExpression,StringLiteral,BlockStatement: equivalent, see above
+  if (value === '') {
+    return '';
+  }
   const entity = AUDIT_ENTITY_FIELDS[field];
   if (entity === 'user') return withName(value, names.users);
   if (entity === 'group') return withName(value, names.groups);
+  // Forcing this condition true is equivalent: for every value it rejects,
+  // destructuring yields `minutes === undefined` and the numeric check below routes
+  // the value to formatFieldValue exactly as the rejection would. Only an array
+  // carrying an own `minutes` property could separate the two, and these values
+  // come from JSON.parse of an API response, where that shape is unrepresentable.
+  // Hoisting the condition does not narrow the waiver — Stryker emits the
+  // whole-conjunction mutant wherever the expression sits — so it also covers this
+  // line's three killed siblings (never take the branch; treat any value as an
+  // object). All three stay asserted by the SLA-metric test; only the gate
+  // accounting is waived.
+  // Stryker disable next-line ConditionalExpression: equivalent, see above
   if (typeof value === 'object' && !Array.isArray(value) && 'minutes' in value) {
     const { minutes } = value as { minutes?: unknown };
     if (typeof minutes === 'number') return `${minutes} min`;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -273,8 +273,10 @@ const renderAuditValue = (field: string, value: unknown, names: AuditNames): str
   // Split out of the guard above so this waiver covers the empty-string clause
   // alone, leaving the null/undefined guard fully scored. The clause is a redundant
   // early-out, not a sentinel the output depends on: every path further down
-  // already yields '' for '' — withName via Number('') === 0 then String(''),
-  // formatFieldValue via String(''). No input can observe its removal, so skipping
+  // already yields '' for '' — formatFieldValue via String(''), and withName via
+  // Number('') === 0, whose lookup cannot hit (the maps are built by
+  // `addPositiveId` in `tools/tickets.ts`, which admits positive integers only, so
+  // key 0 is absent by construction). No input can observe its removal, so skipping
   // the early-out (ConditionalExpression => false, BlockStatement) and never
   // matching it (StringLiteral) are equivalent. The waiver also takes one killed
   // sibling with it, "always return ''", which the audit suite still fails on; the

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -269,36 +269,19 @@ const withName = (id: unknown, names: Map<number, string>): string => {
 // to "Name (id)", SLA-metric objects reduced to their minutes, everything else via
 // formatFieldValue. Returns '' for an empty/absent side.
 const renderAuditValue = (field: string, value: unknown, names: AuditNames): string => {
-  if (value === null || value === undefined) return '';
-  // Split out of the guard above so this waiver covers the empty-string clause
-  // alone, leaving the null/undefined guard fully scored. The clause is a redundant
-  // early-out, not a sentinel the output depends on: every path further down
-  // already yields '' for '' — formatFieldValue via String(''), and withName via
-  // Number('') === 0, whose lookup cannot hit (the maps are built by
-  // `addPositiveId` in `tools/tickets.ts`, which admits positive integers only, so
-  // key 0 is absent by construction). No input can observe its removal, so skipping
-  // the early-out (ConditionalExpression => false, BlockStatement) and never
-  // matching it (StringLiteral) are equivalent. The waiver also takes one killed
-  // sibling with it, "always return ''", which the audit suite still fails on; the
-  // returned '' on the line below stays scored.
-  // Stryker disable next-line ConditionalExpression,StringLiteral,BlockStatement: equivalent, see above
-  if (value === '') {
-    return '';
-  }
+  // The empty-value guard is the contract, not an optimisation: without it an
+  // entity field would resolve `''` through `withName`, where `Number('')` is 0 —
+  // rendering a name whenever the caller's map happens to carry that key. The
+  // production caller filters 0 out (`addPositiveId` in `tools/tickets.ts`), but
+  // `AuditNames` does not, so the guard has to hold here. Asserted in
+  // "renders an emptied entity field as (none), whatever the name maps carry".
+  if (value === null || value === undefined || value === '') return '';
   const entity = AUDIT_ENTITY_FIELDS[field];
   if (entity === 'user') return withName(value, names.users);
   if (entity === 'group') return withName(value, names.groups);
-  // Forcing this condition true is equivalent: for every value it rejects,
-  // destructuring yields `minutes === undefined` and the numeric check below routes
-  // the value to formatFieldValue exactly as the rejection would. Only an array
-  // carrying an own `minutes` property could separate the two, and these values
-  // come from JSON.parse of an API response, where that shape is unrepresentable.
-  // Hoisting the condition does not narrow the waiver — Stryker emits the
-  // whole-conjunction mutant wherever the expression sits — so it also covers this
-  // line's three killed siblings (never take the branch; treat any value as an
-  // object). All three stay asserted by the SLA-metric test; only the gate
-  // accounting is waived.
-  // Stryker disable next-line ConditionalExpression: equivalent, see above
+  // `!Array.isArray` is likewise load-bearing rather than defensive padding: an
+  // array reaching the SLA-metric branch would be destructured for `minutes` and
+  // reported as a duration. Asserted in "never reads an array as an SLA metric".
   if (typeof value === 'object' && !Array.isArray(value) && 'minutes' in value) {
     const { minutes } = value as { minutes?: unknown };
     if (typeof minutes === 'number') return `${minutes} min`;

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -36,25 +36,30 @@ export default {
 
   // Scope: logic code, where a surviving mutant is a genuine test gap.
   //
-  // Two exclusions, same reason, both temporary. A file whose survivors are
-  // mostly label strings does not merely score badly — it *booby-traps the PR
-  // gate*, because editing any line carrying one fails CI for debt the author
-  // did not create. Bringing a file in is therefore a decision to do its
-  // assertion work first, tracked per file:
-  //   - `src/tools/**`: its `.describe()` calls would each yield a StringLiteral
-  //     survivor, drowning the signal.
-  //   - `src/utils/formatting.ts`: 171 escaped mutants, 58 % of them label
-  //     strings. #203 owns both the remaining work and the decision on how to
-  //     treat those strings; delete the negation below when it lands.
+  // One exclusion left, and it is temporary. A file whose survivors are mostly
+  // label strings does not merely score badly — it *booby-traps the PR gate*,
+  // because editing any line carrying one fails CI for debt the author did not
+  // create. Bringing a file in is therefore a decision to do its assertion work
+  // first, and `src/tools/**` has not had it: its `.describe()` calls would each
+  // yield a StringLiteral survivor. #212 owns the measurement that establishes
+  // how much of that directory is really label prose and how much is logic.
   // Excluded from *mutation* only — its tests still run and still count for
-  // coverage. `!` ordering matters: Stryker applies these as set/unset in
-  // sequence (`project-reader`), and `scopeMatcher` in the gate mirrors that.
+  // coverage.
+  //
+  // `src/utils/formatting.ts` came back in with #203, at zero escaped mutants.
+  // That is the bar re-arming the gate needs: any residue would leave a mine on
+  // its line for whoever edits it next, which is the trap the exclusion existed
+  // to avoid in the first place.
+  //
+  // `!` ordering stays load-bearing even though no negation is left in the list:
+  // Stryker applies these as set/unset in sequence (`project-reader`) and
+  // `scopeMatcher` in the gate mirrors it, pinned in
+  // `tests/unit/mutation-scope.test.ts`. The next exclusion will depend on it.
   mutate: [
     'src/auth/**/*.ts',
     'src/client/**/*.ts',
     'src/routing/**/*.ts',
     'src/utils/**/*.ts',
-    '!src/utils/formatting.ts',
     'src/config.ts',
   ],
 

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CHARACTER_LIMIT } from '../../../src/constants';
 import type { ZendeskViewCount } from '../../../src/types';
 import {
@@ -81,111 +81,249 @@ describe('truncateIfNeeded', () => {
 });
 
 describe('formatTicket', () => {
-  it('includes ticket id and subject', () => {
-    const result = formatTicket(MOCK_TICKET);
-    expect(result).toContain('Ticket #1');
-    expect(result).toContain('Test ticket');
+  it('renders every field of a fully populated ticket', () => {
+    expect(formatTicket(MOCK_TICKET)).toMatchInlineSnapshot(`
+      "## Ticket #1: Test ticket
+      - **Status**: open | **Priority**: normal | **Type**: incident
+      - **Requester**: 200 | **Assignee**: 100
+      - **Tags**: test, mock
+      - **Created**: 2026-01-01T00:00:00Z | **Updated**: 2026-01-02T00:00:00Z
+
+      A test ticket"
+    `);
   });
 
-  it('includes status and priority', () => {
-    const result = formatTicket(MOCK_TICKET);
-    expect(result).toContain('open');
-    expect(result).toContain('normal');
-  });
-
-  it('includes tags', () => {
-    const result = formatTicket(MOCK_TICKET);
-    expect(result).toContain('test, mock');
-  });
-
-  it('handles missing priority', () => {
-    const result = formatTicket({ ...MOCK_TICKET, priority: null });
-    expect(result).toContain('none');
+  it('falls back to none/unassigned and drops the body when the ticket is bare', () => {
+    expect(
+      formatTicket({
+        ...MOCK_TICKET,
+        priority: null,
+        type: null,
+        assignee_id: null,
+        tags: [],
+        description: '',
+      }),
+    ).toMatchInlineSnapshot(`
+      "## Ticket #1: Test ticket
+      - **Status**: open | **Priority**: none | **Type**: none
+      - **Requester**: 200 | **Assignee**: unassigned
+      - **Tags**: none
+      - **Created**: 2026-01-01T00:00:00Z | **Updated**: 2026-01-02T00:00:00Z"
+    `);
   });
 });
 
 describe('formatSlaPolicy', () => {
-  it('includes title, conditions and per-priority targets', () => {
-    const result = formatSlaPolicy(MOCK_SLA_POLICY);
-    expect(result).toContain('SLA contractuels fruggr - Bugs/Incidents');
-    expect(result).toContain('(123)');
-    expect(result).toContain('type is incident');
-    expect(result).toContain('high / first_reply_time: 420 min');
-    expect(result).toContain('high / total_resolution_time: 4200 min');
+  it('renders all/any conditions, a null-valued condition and per-priority targets', () => {
+    // A null condition value renders as empty, so the line would keep a trailing
+    // space without the `.trim()`; `any` must be non-empty for its own map to
+    // be observable at all.
+    expect(
+      formatSlaPolicy({
+        ...MOCK_SLA_POLICY,
+        filter: {
+          all: [
+            ...MOCK_SLA_POLICY.filter.all,
+            { field: 'assignee_id', operator: 'is', value: null },
+          ],
+          any: [{ field: 'priority', operator: 'is', value: 'urgent' }],
+        },
+        policy_metrics: MOCK_SLA_POLICY.policy_metrics.map((m, i) =>
+          i === 1 ? { ...m, business_hours: true } : m,
+        ),
+      }),
+    ).toMatchInlineSnapshot(`
+      "## SLA policy: SLA contractuels fruggr - Bugs/Incidents (123)
+      - **Description**: Contractual SLA for bugs and incidents
+      - **Position**: 1
+      - **Conditions**: all: type is incident; all: custom_status_id includes ["1","2"]; all: assignee_id is; any: priority is urgent
+      - **Targets**:
+        - high / first_reply_time: 420 min
+        - high / total_resolution_time: 4200 min (business)"
+    `);
   });
 
-  it('renders array-valued filter conditions (e.g. includes)', () => {
-    const result = formatSlaPolicy(MOCK_SLA_POLICY);
-    expect(result).toContain('custom_status_id includes ["1","2"]');
+  it('drops the description, conditions and targets lines when the policy has none', () => {
+    expect(
+      formatSlaPolicy({
+        ...MOCK_SLA_POLICY,
+        description: '',
+        filter: { all: [], any: [] },
+        policy_metrics: [],
+      }),
+    ).toMatchInlineSnapshot(`
+      "## SLA policy: SLA contractuels fruggr - Bugs/Incidents (123)
+      - **Position**: 1"
+    `);
   });
 });
 
 describe('formatSlaBlock', () => {
+  // A real clock makes the countdown unassertable — "some number of minutes" is
+  // the loosest possible claim about arithmetic. Pinning `now` lets every branch
+  // of the countdown be stated exactly, boundary included.
+  const NOW = new Date('2026-06-01T12:00:00Z');
+  const at = (minutes: number) => new Date(NOW.getTime() + minutes * 60_000).toISOString();
   const entry = (metrics: unknown[]) => ({ policy_metrics: metrics }) as never;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it('returns an empty string when no SLA applies', () => {
     expect(formatSlaBlock(undefined)).toBe('');
     expect(formatSlaBlock(entry([]))).toBe('');
   });
 
-  it('shows minutes remaining for an active metric with a future breach', () => {
-    const future = new Date(Date.now() + 60 * 60_000).toISOString();
-    const result = formatSlaBlock(
-      entry([{ metric: 'requester_wait_time', stage: 'active', breach_at: future }]),
-    );
-    expect(result).toContain('### SLA');
-    expect(result).toContain('Next breach');
-    expect(result).toContain('min remaining');
+  it('states the exact number of minutes remaining', () => {
+    expect(
+      formatSlaBlock(entry([{ metric: 'first_reply_time', stage: 'active', breach_at: at(90) }])),
+    ).toMatchInlineSnapshot(`
+      "
+
+      ### SLA
+      - **Next breach**: 2026-06-01T13:30:00.000Z
+      - **first_reply_time** — active; due 2026-06-01T13:30:00.000Z — 90 min remaining"
+    `);
+  });
+
+  it('reports the earliest future breach, not the latest', () => {
+    expect(
+      formatSlaBlock(
+        entry([
+          { metric: 'first_reply_time', stage: 'active', breach_at: at(240) },
+          { metric: 'total_resolution_time', stage: 'active', breach_at: at(30) },
+        ]),
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+
+      ### SLA
+      - **Next breach**: 2026-06-01T12:30:00.000Z
+      - **first_reply_time** — active; due 2026-06-01T16:00:00.000Z — 240 min remaining
+      - **total_resolution_time** — active; due 2026-06-01T12:30:00.000Z — 30 min remaining"
+    `);
+  });
+
+  it('treats a deadline exactly at the current instant as due, not as remaining', () => {
+    // The two boundaries meet here: `t > Date.now()` must not advertise a "next
+    // breach" that is already due, and `remaining < 0` must not call 0 overdue.
+    expect(
+      formatSlaBlock(entry([{ metric: 'first_reply_time', stage: 'active', breach_at: at(0) }])),
+    ).toMatchInlineSnapshot(`
+      "
+
+      ### SLA
+      - **first_reply_time** — active; due 2026-06-01T12:00:00.000Z — 0 min remaining"
+    `);
   });
 
   it('flags a breached metric as overdue instead of a negative countdown', () => {
-    const past = new Date(Date.now() - 60 * 60_000).toISOString();
-    const result = formatSlaBlock(
-      entry([{ metric: 'first_reply_time', stage: 'active', breach_at: past }]),
-    );
-    expect(result).toContain('breached');
-    expect(result).toContain('overdue');
-    expect(result).not.toContain('min remaining');
+    expect(
+      formatSlaBlock(entry([{ metric: 'first_reply_time', stage: 'active', breach_at: at(-75) }])),
+    ).toMatchInlineSnapshot(`
+      "
+
+      ### SLA
+      - **first_reply_time** — active; due 2026-06-01T10:45:00.000Z — breached (75 min overdue)"
+    `);
   });
 
-  it('omits the countdown for paused and achieved stages', () => {
-    const future = new Date(Date.now() + 60 * 60_000).toISOString();
-    const result = formatSlaBlock(
-      entry([
-        { metric: 'agent_work_time', stage: 'paused', breach_at: future },
-        { metric: 'first_reply_time', stage: 'achieved', breach_at: future },
-      ]),
-    );
-    expect(result).not.toContain('remaining');
+  it('omits the next-breach line when every deadline is already past', () => {
+    // A past deadline is not a *next* breach: it must be filtered out, not
+    // reported as the soonest one.
+    expect(
+      formatSlaBlock(
+        entry([
+          { metric: 'first_reply_time', stage: 'active', breach_at: at(-120) },
+          { metric: 'total_resolution_time', stage: 'active', breach_at: at(-10) },
+        ]),
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+
+      ### SLA
+      - **first_reply_time** — active; due 2026-06-01T10:00:00.000Z — breached (120 min overdue)
+      - **total_resolution_time** — active; due 2026-06-01T11:50:00.000Z — breached (10 min overdue)"
+    `);
   });
 
-  it('tolerates an unparseable timestamp without crashing', () => {
-    const result = formatSlaBlock(
-      entry([{ metric: 'first_reply_time', stage: 'active', breach_at: 'not-a-date' }]),
-    );
-    expect(result).toContain('first_reply_time');
-    expect(result).not.toContain('remaining');
+  it('omits the countdown for paused, achieved and fulfilled stages', () => {
+    expect(
+      formatSlaBlock(
+        entry([
+          { metric: 'agent_work_time', stage: 'paused', breach_at: at(60) },
+          { metric: 'first_reply_time', stage: 'achieved', breach_at: at(60) },
+          { metric: 'total_resolution_time', stage: 'fulfilled', breach_at: at(60) },
+        ]),
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+
+      ### SLA
+      - **Next breach**: 2026-06-01T13:00:00.000Z
+      - **agent_work_time** — paused; due 2026-06-01T13:00:00.000Z
+      - **first_reply_time** — achieved; due 2026-06-01T13:00:00.000Z
+      - **total_resolution_time** — fulfilled; due 2026-06-01T13:00:00.000Z"
+    `);
+  });
+
+  it('tolerates an unparseable timestamp without crashing or counting down', () => {
+    expect(
+      formatSlaBlock(
+        entry([{ metric: 'first_reply_time', stage: 'active', breach_at: 'not-a-date' }]),
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+
+      ### SLA
+      - **first_reply_time** — active; due not-a-date"
+    `);
+  });
+
+  it('labels a metric with no stage as unknown, and omits the deadline when absent', () => {
+    expect(
+      formatSlaBlock(
+        entry([
+          { metric: 'first_reply_time', breach_at: null },
+          { metric: 'agent_work_time', stage: undefined, breach_at: at(45) },
+        ]),
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+
+      ### SLA
+      - **Next breach**: 2026-06-01T12:45:00.000Z
+      - **first_reply_time** — unknown
+      - **agent_work_time** — unknown; due 2026-06-01T12:45:00.000Z — 45 min remaining"
+    `);
   });
 });
-
 describe('formatComment', () => {
-  it('formats public comment', () => {
-    const result = formatComment(MOCK_COMMENT);
-    expect(result).toContain('Public comment');
-    expect(result).toContain('This is a comment');
+  it('renders a public comment with its attachment ids and content types', () => {
+    expect(formatComment(MOCK_COMMENT)).toMatchInlineSnapshot(`
+      "### Public comment by 9999
+      *2026-01-01T00:00:00Z*
+      Attachments: #30001 (image/png), #30002 (application/pdf), #30003 (image/png)
+
+      This is a comment"
+    `);
   });
 
-  it('formats private note', () => {
-    const result = formatComment({ ...MOCK_COMMENT, public: false });
-    expect(result).toContain('Internal note');
-  });
+  it('renders an internal note with no attachment line', () => {
+    expect(
+      formatComment({ ...MOCK_COMMENT, public: false, attachments: [] }),
+    ).toMatchInlineSnapshot(`
+      "### Internal note by 9999
+      *2026-01-01T00:00:00Z*
 
-  it('lists attachment ids and content types when the comment has attachments', () => {
-    const result = formatComment(MOCK_COMMENT);
-    expect(result).toContain('Attachments:');
-    expect(result).toContain('#30001 (image/png)');
-    expect(result).toContain('#30002 (application/pdf)');
-    expect(result).toContain('#30003 (image/png)');
+      This is a comment"
+    `);
   });
 
   it('omits the Attachments line when the comment has none', () => {
@@ -305,27 +443,288 @@ describe('formatAudit', () => {
   });
 });
 
-describe('formatUser', () => {
-  it('includes name, email, role', () => {
-    const result = formatUser(MOCK_USER);
-    expect(result).toContain('Test User');
-    expect(result).toContain('test@example.com');
-    expect(result).toContain('admin');
+describe('formatAudit — Create events', () => {
+  const names = {
+    users: new Map([
+      [100, 'Agent Smith'],
+      [200, 'Requester Jane'],
+    ]),
+    groups: new Map([[300, 'Support']]),
+  };
+
+  const create = (events: unknown[]) =>
+    ({
+      id: 9300,
+      ticket_id: 1,
+      created_at: '2026-02-01T00:00:00Z',
+      author_id: 200,
+      via: { channel: 'web' },
+      events,
+    }) as never;
+
+  it('renders every whitelisted founding fact, and only those', () => {
+    // One event per member of the Create whitelist, plus a non-member: emptying
+    // any member of the set drops its line, and only this covers all of them.
+    expect(
+      formatAudit(
+        create([
+          { id: 1, type: 'Create', field_name: 'status', value: 'new' },
+          { id: 2, type: 'Create', field_name: 'priority', value: 'urgent' },
+          { id: 3, type: 'Create', field_name: 'type', value: 'incident' },
+          { id: 4, type: 'Create', field_name: 'assignee_id', value: '100' },
+          { id: 5, type: 'Create', field_name: 'group_id', value: '300' },
+          { id: 6, type: 'Create', field_name: 'subject', value: 'Scanner is down' },
+          { id: 7, type: 'Create', field_name: 'tags', value: ['urgent', 'scanner'] },
+          { id: 8, type: 'Create', field_name: 'custom_status_id', value: '1' },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-01T00:00:00Z — Requester Jane (200) via web
+      - **status**: new
+      - **priority**: urgent
+      - **type**: incident
+      - **assignee**: Agent Smith (100)
+      - **group**: Support (300)
+      - **subject**: Scanner is down
+      - **tags**: urgent, scanner"
+    `);
   });
 
-  it('includes organization when present', () => {
-    const result = formatUser(MOCK_USER);
-    expect(result).toContain('Organization');
+  it('drops the tags line when the Create carries no tag', () => {
+    expect(
+      formatAudit(
+        create([
+          { id: 1, type: 'Create', field_name: 'status', value: 'new' },
+          { id: 2, type: 'Create', field_name: 'tags', value: [] },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-01T00:00:00Z — Requester Jane (200) via web
+      - **status**: new"
+    `);
+  });
+
+  it('drops a tags value that is not an array rather than stringifying it', () => {
+    // `tags` takes a dedicated branch precisely so a malformed value is dropped
+    // instead of rendered; falling through would print it as a scalar.
+    expect(
+      formatAudit(
+        create([
+          { id: 1, type: 'Create', field_name: 'status', value: 'new' },
+          { id: 2, type: 'Create', field_name: 'tags', value: 'urgent,scanner' },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-01T00:00:00Z — Requester Jane (200) via web
+      - **status**: new"
+    `);
+  });
+
+  it('drops a whitelisted field whose value is empty', () => {
+    expect(
+      formatAudit(
+        create([
+          { id: 1, type: 'Create', field_name: 'status', value: 'new' },
+          { id: 2, type: 'Create', field_name: 'subject', value: '' },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-01T00:00:00Z — Requester Jane (200) via web
+      - **status**: new"
+    `);
+  });
+});
+
+describe('formatAudit — Change events', () => {
+  const names = {
+    users: new Map([
+      [100, 'Agent Smith'],
+      [200, 'Requester Jane'],
+      [201, 'Requester Bob'],
+    ]),
+    groups: new Map([[300, 'Support']]),
+  };
+
+  const change = (events: unknown[], over: Record<string, unknown> = {}) =>
+    ({
+      id: 9400,
+      ticket_id: 1,
+      created_at: '2026-02-02T00:00:00Z',
+      author_id: 100,
+      via: { channel: 'api' },
+      events,
+      ...over,
+    }) as never;
+
+  it('resolves requester and submitter ids to names under their own labels', () => {
+    // Both fields are in AUDIT_ENTITY_FIELDS *and* AUDIT_FIELD_LABELS: dropping
+    // either mapping degrades the line to a bare id or a raw field name.
+    expect(
+      formatAudit(
+        change([
+          {
+            id: 1,
+            type: 'Change',
+            field_name: 'requester_id',
+            value: '201',
+            previous_value: '200',
+          },
+          {
+            id: 2,
+            type: 'Change',
+            field_name: 'submitter_id',
+            value: '100',
+            previous_value: '200',
+          },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-02T00:00:00Z — Agent Smith (100) via api
+      - **requester**: Requester Jane (200) → Requester Bob (201)
+      - **submitter**: Requester Jane (200) → Agent Smith (100)"
+    `);
+  });
+
+  it('renders a cleared field as "(none)" on the after side', () => {
+    expect(
+      formatAudit(
+        change([
+          { id: 1, type: 'Change', field_name: 'subject', value: null, previous_value: 'Old' },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-02T00:00:00Z — Agent Smith (100) via api
+      - **subject**: Old → (none)"
+    `);
+  });
+
+  it('renders an entity id with no previous value as "(none)", not as "null"', () => {
+    // `renderAuditValue` short-circuits on null/undefined; without it the id
+    // resolver would stringify the absent side.
+    expect(
+      formatAudit(
+        change([
+          { id: 1, type: 'Change', field_name: 'assignee_id', value: '100', previous_value: null },
+          { id: 2, type: 'Change', field_name: 'group_id', value: '300' },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-02T00:00:00Z — Agent Smith (100) via api
+      - **assignee**: (none) → Agent Smith (100)
+      - **group**: (none) → Support (300)"
+    `);
+  });
+
+  it('drops a Change event carrying no field name', () => {
+    expect(
+      formatAudit(
+        change([
+          { id: 1, type: 'Change', value: 'whatever', previous_value: 'other' },
+          { id: 2, type: 'Change', field_name: 'status', value: 'open', previous_value: 'new' },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-02T00:00:00Z — Agent Smith (100) via api
+      - **status**: new → open"
+    `);
+  });
+
+  it('renders an SLA-metric object as its minutes, and a non-numeric one as data', () => {
+    expect(
+      formatAudit(
+        change([
+          {
+            id: 1,
+            type: 'Change',
+            field_name: 'requester_wait_time',
+            value: { minutes: 45, in_business_hours: false },
+            previous_value: { minutes: 150, in_business_hours: false },
+          },
+          {
+            id: 2,
+            type: 'Change',
+            field_name: 'agent_wait_time',
+            value: { minutes: 'n/a' },
+            previous_value: { minutes: 12 },
+          },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-02T00:00:00Z — Agent Smith (100) via api
+      - **requester_wait_time**: 150 min → 45 min
+      - **agent_wait_time**: 12 min → {"minutes":"n/a"}"
+    `);
+  });
+
+  it('attributes a voice comment like a regular one', () => {
+    expect(
+      formatAudit(
+        change([
+          { id: 1, type: 'VoiceComment', body: 'call recording', public: true, author_id: 100 },
+          { id: 2, type: 'VoiceComment', body: 'private call note', public: false, author_id: 100 },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-02T00:00:00Z — Agent Smith (100) via api
+      - Public comment added
+      - Internal note added"
+    `);
+  });
+
+  it('omits the channel from the heading when the audit carries no via', () => {
+    expect(
+      formatAudit(
+        change(
+          [{ id: 1, type: 'Change', field_name: 'status', value: 'open', previous_value: 'new' }],
+          {
+            via: undefined,
+          },
+        ),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-02T00:00:00Z — Agent Smith (100)
+      - **status**: new → open"
+    `);
+  });
+});
+
+describe('formatUser', () => {
+  it('renders name, email, role, role type, active flag and organization', () => {
+    expect(formatUser({ ...MOCK_USER, role_type: 4 })).toMatchInlineSnapshot(`
+      "## Test User (9999)
+      - **Email**: test@example.com
+      - **Role**: admin
+      - **Role type**: 4
+      - **Active**: true
+      - **Organization**: 400"
+    `);
+  });
+
+  it('drops the role type and organization lines when both are absent', () => {
+    expect(
+      formatUser({ ...MOCK_USER, role_type: null, organization_id: null, active: false }),
+    ).toMatchInlineSnapshot(`
+      "## Test User (9999)
+      - **Email**: test@example.com
+      - **Role**: admin
+      - **Active**: false"
+    `);
   });
 
   it('omits organization when null', () => {
     const result = formatUser({ ...MOCK_USER, organization_id: null });
     expect(result).not.toContain('Organization');
-  });
-
-  it('displays role_type when present', () => {
-    const result = formatUser({ ...MOCK_USER, role_type: 1 });
-    expect(result).toContain('**Role type**: 1');
   });
 
   it('omits role_type when null', () => {
@@ -335,48 +734,81 @@ describe('formatUser', () => {
 });
 
 describe('formatOrganization', () => {
-  it('includes name and domains', () => {
-    const result = formatOrganization(MOCK_ORGANIZATION);
-    expect(result).toContain('Test Org');
-    expect(result).toContain('example.com');
+  it('renders details, domains and tags', () => {
+    expect(
+      formatOrganization({
+        ...MOCK_ORGANIZATION,
+        domain_names: ['example.com', 'example.org'],
+        tags: ['vip', 'eu'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "## Test Org (400)
+      - **Details**: A test org
+      - **Domains**: example.com, example.org
+      - **Tags**: vip, eu"
+    `);
+  });
+
+  it('drops details, domains and tags when the organization has none', () => {
+    expect(
+      formatOrganization({ ...MOCK_ORGANIZATION, details: '', domain_names: [], tags: [] }),
+    ).toMatchInlineSnapshot(`"## Test Org (400)"`);
   });
 });
 
 describe('formatArticle', () => {
-  it('includes title, locale, body', () => {
-    const result = formatArticle(MOCK_ARTICLE);
-    expect(result).toContain('How to test');
-    expect(result).toContain('en-us');
-    expect(result).toContain('Testing guide');
+  it('renders the summary, a blank line, then the body', () => {
+    expect(formatArticle(MOCK_ARTICLE)).toMatchInlineSnapshot(`
+      "## How to test (5000)
+      - **Locale**: en-us | **Source locale**: en-us
+      - **Section**: 600 | **Draft**: false
+      - **Permission group**: 12001 | **User segment**: 15001
+      - **Position**: 0
+      - **Labels**: guide
+      - **Created**: 2026-01-01T00:00:00Z | **Updated**: 2026-01-02T00:00:00Z
+
+      <p>Testing guide</p>"
+    `);
   });
 });
 
 describe('formatArticleSummary', () => {
-  it('includes metadata', () => {
-    const result = formatArticleSummary(MOCK_ARTICLE);
-    expect(result).toContain('How to test');
-    expect(result).toContain('5000');
-    expect(result).toContain('en-us');
-    expect(result).toContain('600');
-    expect(result).toContain('Draft');
-    expect(result).toContain('Created');
-    expect(result).toContain('Updated');
+  it('renders locale, section, visibility ids, position and labels', () => {
+    expect(
+      formatArticleSummary({ ...MOCK_ARTICLE, label_names: ['guide', 'setup'] }),
+    ).toMatchInlineSnapshot(`
+      "## How to test (5000)
+      - **Locale**: en-us | **Source locale**: en-us
+      - **Section**: 600 | **Draft**: false
+      - **Permission group**: 12001 | **User segment**: 15001
+      - **Position**: 0
+      - **Labels**: guide, setup
+      - **Created**: 2026-01-01T00:00:00Z | **Updated**: 2026-01-02T00:00:00Z"
+    `);
+  });
+
+  it('renders the promoted caveat and drops position, labels and the segment id', () => {
+    expect(
+      formatArticleSummary({
+        ...MOCK_ARTICLE,
+        promoted: true,
+        position: undefined as unknown as number,
+        label_names: [],
+        user_segment_id: null,
+      }),
+    ).toMatchInlineSnapshot(`
+      "## How to test (5000)
+      - **Locale**: en-us | **Source locale**: en-us
+      - **Section**: 600 | **Draft**: false
+      - **Promoted**: featured in its section — changing this requires Help Center admin (Guide admin) rights; set via update_article \`promoted\`.
+      - **Permission group**: 12001 | **User segment**: everyone (no segment)
+      - **Created**: 2026-01-01T00:00:00Z | **Updated**: 2026-01-02T00:00:00Z"
+    `);
   });
 
   it('does not include body', () => {
     const result = formatArticleSummary(MOCK_ARTICLE);
     expect(result).not.toContain('Testing guide');
-  });
-
-  it('includes labels when present', () => {
-    const result = formatArticleSummary(MOCK_ARTICLE);
-    expect(result).toContain('guide');
-  });
-
-  it('surfaces the permission group and user segment so their IDs can be reused', () => {
-    const result = formatArticleSummary(MOCK_ARTICLE);
-    expect(result).toContain('12001');
-    expect(result).toContain('15001');
   });
 
   it('marks visibility as everyone when the article has no user segment', () => {
@@ -391,11 +823,6 @@ describe('formatArticleSummary', () => {
   it('omits labels when empty', () => {
     const result = formatArticleSummary({ ...MOCK_ARTICLE, label_names: [] });
     expect(result).not.toContain('Labels');
-  });
-
-  it('includes the sort position', () => {
-    const result = formatArticleSummary({ ...MOCK_ARTICLE, position: 7 });
-    expect(result).toContain('**Position**: 7');
   });
 
   it('omits position when not a number', () => {
@@ -417,21 +844,26 @@ describe('formatArticleSummary', () => {
 });
 
 describe('formatTranslation', () => {
-  it('includes locale and title', () => {
-    const result = formatTranslation(MOCK_TRANSLATION);
-    expect(result).toContain('fr');
-    expect(result).toContain('Comment tester');
+  it('renders the summary, a blank line, then the body', () => {
+    expect(formatTranslation(MOCK_TRANSLATION)).toMatchInlineSnapshot(`
+      "## Translation: fr (7000)
+      - **Title**: Comment tester
+      - **Draft**: false
+      - **Updated**: 2026-01-02T00:00:00Z
+
+      <p>Guide de test</p>"
+    `);
   });
 });
 
 describe('formatTranslationSummary', () => {
-  it('includes metadata', () => {
-    const result = formatTranslationSummary(MOCK_TRANSLATION);
-    expect(result).toContain('fr');
-    expect(result).toContain('7000');
-    expect(result).toContain('Comment tester');
-    expect(result).toContain('Draft');
-    expect(result).toContain('Updated');
+  it('renders locale, id, title, draft and updated', () => {
+    expect(formatTranslationSummary(MOCK_TRANSLATION)).toMatchInlineSnapshot(`
+      "## Translation: fr (7000)
+      - **Title**: Comment tester
+      - **Draft**: false
+      - **Updated**: 2026-01-02T00:00:00Z"
+    `);
   });
 
   it('does not include body', () => {
@@ -441,19 +873,24 @@ describe('formatTranslationSummary', () => {
 });
 
 describe('formatCategory', () => {
-  it('includes name and id', () => {
-    const result = formatCategory(MOCK_CATEGORY);
-    expect(result).toContain('General');
-    expect(result).toContain('800');
+  it('renders name, id and description, and says so when there is none', () => {
+    expect(formatCategory(MOCK_CATEGORY)).toMatchInlineSnapshot(
+      `"- **General** (800) — General category"`,
+    );
+    expect(formatCategory({ ...MOCK_CATEGORY, description: '' })).toMatchInlineSnapshot(
+      `"- **General** (800) — No description"`,
+    );
   });
 });
 
 describe('formatSection', () => {
-  it('includes name, id, category_id', () => {
-    const result = formatSection(MOCK_SECTION);
-    expect(result).toContain('FAQ');
-    expect(result).toContain('600');
-    expect(result).toContain('800');
+  it('renders name, id, category and description, and says so when there is none', () => {
+    expect(formatSection(MOCK_SECTION)).toMatchInlineSnapshot(
+      `"- **FAQ** (600) — Category: 800 — Frequently asked questions"`,
+    );
+    expect(formatSection({ ...MOCK_SECTION, description: '' })).toMatchInlineSnapshot(
+      `"- **FAQ** (600) — Category: 800 — No description"`,
+    );
   });
 });
 
@@ -473,6 +910,28 @@ describe('formatFieldValue', () => {
 });
 
 describe('formatMacro', () => {
+  it('renders title, id, active flag, scope, description and the ordered actions', () => {
+    expect(formatMacro(MOCK_MACRO)).toMatchInlineSnapshot(`
+      "## Close and thank the customer (id 700)
+      - **active** | **Scope**: shared
+      - **Description**: Solve the ticket and send a thank-you note
+      - **Actions**:
+        - status → solved
+        - set_tags → resolved, macro_applied
+        - comment_value → Thanks for your business! We hope to see you again soon."
+    `);
+  });
+
+  it('marks an inactive macro, drops the description and says the actions are none', () => {
+    expect(
+      formatMacro({ ...MOCK_MACRO, active: false, description: '', actions: [] }),
+    ).toMatchInlineSnapshot(`
+      "## Close and thank the customer (id 700)
+      - **inactive** | **Scope**: shared
+      - **Actions**: none"
+    `);
+  });
+
   it('includes id, title, scope and the ordered actions', () => {
     const result = formatMacro(MOCK_MACRO);
     expect(result).toContain('Close and thank the customer (id 700)');
@@ -535,21 +994,40 @@ describe('formatMacro', () => {
 });
 
 describe('formatList', () => {
-  it('formats items with pagination meta', () => {
-    const result = formatList([MOCK_TICKET], formatTicket, {
-      has_more: true,
-      after_cursor: 'abc',
-      count: 42,
-    });
-    expect(result).toContain('Results: 42');
-    expect(result).toContain('More available');
-    expect(result).toContain('Test ticket');
+  it('renders the pagination header, then the items separated by a blank line', () => {
+    expect(
+      formatList([MOCK_CATEGORY, { ...MOCK_CATEGORY, id: 801, name: 'Billing' }], formatCategory, {
+        has_more: true,
+        after_cursor: 'abc',
+        count: 42,
+      }),
+    ).toMatchInlineSnapshot(`
+      "Results: 42 | More available (cursor: abc)
+
+      - **General** (800) — General category
+
+      - **Billing** (801) — General category"
+    `);
   });
 
-  it('works without pagination meta', () => {
-    const result = formatList([MOCK_USER], formatUser);
-    expect(result).toContain('Test User');
-    expect(result).not.toContain('Results:');
+  it('omits the header entirely when there is no pagination meta', () => {
+    expect(formatList([MOCK_CATEGORY], formatCategory)).toMatchInlineSnapshot(
+      `"- **General** (800) — General category"`,
+    );
+  });
+
+  it('reports the result count without a cursor when there is no next page', () => {
+    expect(
+      formatList([MOCK_CATEGORY], formatCategory, {
+        has_more: false,
+        after_cursor: '',
+        count: 1,
+      }),
+    ).toMatchInlineSnapshot(`
+      "Results: 1
+
+      - **General** (800) — General category"
+    `);
   });
 });
 

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -126,7 +126,10 @@ describe('formatSlaPolicy', () => {
             ...MOCK_SLA_POLICY.filter.all,
             { field: 'assignee_id', operator: 'is', value: null },
           ],
-          any: [{ field: 'priority', operator: 'is', value: 'urgent' }],
+          any: [
+            { field: 'priority', operator: 'is', value: 'urgent' },
+            { field: 'group_id', operator: 'is', value: null },
+          ],
         },
         policy_metrics: MOCK_SLA_POLICY.policy_metrics.map((m, i) =>
           i === 1 ? { ...m, business_hours: true } : m,
@@ -136,7 +139,7 @@ describe('formatSlaPolicy', () => {
       "## SLA policy: SLA contractuels fruggr - Bugs/Incidents (123)
       - **Description**: Contractual SLA for bugs and incidents
       - **Position**: 1
-      - **Conditions**: all: type is incident; all: custom_status_id includes ["1","2"]; all: assignee_id is; any: priority is urgent
+      - **Conditions**: all: type is incident; all: custom_status_id includes ["1","2"]; all: assignee_id is; any: priority is urgent; any: group_id is
       - **Targets**:
         - high / first_reply_time: 420 min
         - high / total_resolution_time: 4200 min (business)"

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CHARACTER_LIMIT } from '../../../src/constants';
+import type { ZendeskViewCount } from '../../../src/types';
 import {
   formatArticle,
   formatArticleSummary,
@@ -9,14 +10,20 @@ import {
   formatFieldValue,
   formatList,
   formatMacro,
+  formatNodeTranslationSummary,
   formatOrganization,
+  formatPermissionGroup,
   formatSection,
   formatSlaBlock,
   formatSlaPolicy,
+  formatTagDiff,
   formatTicket,
+  formatTicketField,
   formatTranslation,
   formatTranslationSummary,
   formatUser,
+  formatUserSegment,
+  formatView,
   truncateIfNeeded,
 } from '../../../src/utils/formatting';
 import {
@@ -28,11 +35,17 @@ import {
   MOCK_COMMENT,
   MOCK_MACRO,
   MOCK_ORGANIZATION,
+  MOCK_PERMISSION_GROUP,
   MOCK_SECTION,
+  MOCK_SECTION_TRANSLATION,
   MOCK_SLA_POLICY,
   MOCK_TICKET,
+  MOCK_TICKET_FIELD_CUSTOM,
+  MOCK_TICKET_FIELD_SYSTEM,
   MOCK_TRANSLATION,
   MOCK_USER,
+  MOCK_USER_SEGMENT,
+  MOCK_VIEW,
 } from '../../msw-handlers';
 
 describe('truncateIfNeeded', () => {
@@ -537,5 +550,160 @@ describe('formatList', () => {
     const result = formatList([MOCK_USER], formatUser);
     expect(result).toContain('Test User');
     expect(result).not.toContain('Results:');
+  });
+});
+
+describe('formatTicketField', () => {
+  it('renders a system field with its accepted value tags', () => {
+    expect(
+      formatTicketField({ ...MOCK_TICKET_FIELD_SYSTEM, tag: 'priority_tag' }),
+    ).toMatchInlineSnapshot(`
+      "## Priority (id 10)
+      - **Type**: priority | **active, optional**
+      - **Description**: Ticket priority
+      - **Tag**: priority_tag
+      - **Options** (name → value):
+        - Low → low
+        - High → high"
+    `);
+  });
+
+  it('prefers custom_field_options over system_field_options and marks it required', () => {
+    expect(
+      formatTicketField({
+        ...MOCK_TICKET_FIELD_CUSTOM,
+        system_field_options: [{ name: 'Ignored', value: 'ignored' }],
+      }),
+    ).toMatchInlineSnapshot(`
+      "## Severity (id 360000000001)
+      - **Type**: tagger | **active, required**
+      - **Description**: Customer-facing severity
+      - **Options** (name → value):
+        - Sev-1 → severity_1
+        - Sev-2 → severity_2"
+    `);
+  });
+
+  it('renders a bare inactive field with neither options array', () => {
+    // Exercises the `?? []` fallback: no custom_field_options, no
+    // system_field_options, and every optional line suppressed.
+    expect(
+      formatTicketField({
+        id: 42,
+        type: 'text',
+        title: 'Free text',
+        description: null,
+        active: false,
+        required: false,
+      }),
+    ).toMatchInlineSnapshot(`
+      "## Free text (id 42)
+      - **Type**: text | **inactive, optional**"
+    `);
+  });
+});
+
+describe('formatTagDiff', () => {
+  it('renders an addition and a removal in the same diff', () => {
+    // Both sides non-empty is what pins the `added.length + removed.length`
+    // sum: a difference would read as unchanged when the counts match.
+    expect(formatTagDiff(['keep', 'gone'], ['keep', 'new'])).toMatchInlineSnapshot(
+      `"- **tags**: +new, -gone"`,
+    );
+  });
+
+  it('renders additions only, and removals only', () => {
+    expect(formatTagDiff(['keep'], ['keep', 'new'])).toMatchInlineSnapshot(`"- **tags**: +new"`);
+    expect(formatTagDiff(['keep', 'gone'], ['keep'])).toMatchInlineSnapshot(`"- **tags**: -gone"`);
+  });
+
+  it('returns null when the set is unchanged', () => {
+    expect(formatTagDiff(['keep', 'other'], ['other', 'keep'])).toBeNull();
+  });
+
+  it('treats a non-array side as empty rather than seeding it', () => {
+    expect(formatTagDiff(undefined, ['new'])).toMatchInlineSnapshot(`"- **tags**: +new"`);
+    expect(formatTagDiff(['gone'], null)).toMatchInlineSnapshot(`"- **tags**: -gone"`);
+    expect(formatTagDiff(undefined, undefined)).toBeNull();
+  });
+
+  it('stringifies non-string tags', () => {
+    expect(formatTagDiff([1], [1, 2])).toMatchInlineSnapshot(`"- **tags**: +2"`);
+  });
+});
+
+describe('formatView', () => {
+  const count = (over: Partial<ZendeskViewCount>): ZendeskViewCount => ({
+    view_id: MOCK_VIEW.id,
+    value: 298,
+    pretty: '298',
+    fresh: true,
+    ...over,
+  });
+
+  it('renders a view with a fresh count and a description', () => {
+    expect(formatView(MOCK_VIEW, count({}))).toMatchInlineSnapshot(
+      `"- **Unassigned tickets** (id 25) — 298 ticket(s) — Tickets with no assignee"`,
+    );
+  });
+
+  it('marks a non-fresh count as updating', () => {
+    expect(
+      formatView(MOCK_VIEW, count({ value: null, pretty: '...', fresh: false })),
+    ).toMatchInlineSnapshot(
+      `"- **Unassigned tickets** (id 25) — ... ticket(s) (count updating) — Tickets with no assignee"`,
+    );
+  });
+
+  it('omits the count and the description when neither is available', () => {
+    expect(formatView({ ...MOCK_VIEW, description: null })).toMatchInlineSnapshot(
+      `"- **Unassigned tickets** (id 25)"`,
+    );
+  });
+});
+
+describe('formatPermissionGroup', () => {
+  it('flags a built-in group and leaves a custom one unmarked', () => {
+    expect(
+      formatPermissionGroup({ ...MOCK_PERMISSION_GROUP, built_in: true }),
+    ).toMatchInlineSnapshot(`"- **Editors** (12001) — Built-in"`);
+    expect(formatPermissionGroup(MOCK_PERMISSION_GROUP)).toMatchInlineSnapshot(
+      `"- **Editors** (12001)"`,
+    );
+  });
+});
+
+describe('formatUserSegment', () => {
+  it('flags a built-in segment and leaves a custom one unmarked', () => {
+    expect(formatUserSegment(MOCK_USER_SEGMENT)).toMatchInlineSnapshot(
+      `"- **Signed-in users** (15001) — signed_in_users — Built-in"`,
+    );
+    expect(
+      formatUserSegment({ ...MOCK_USER_SEGMENT, built_in: false, user_type: 'staff' }),
+    ).toMatchInlineSnapshot(`"- **Signed-in users** (15001) — staff"`);
+  });
+});
+
+describe('formatNodeTranslationSummary', () => {
+  it('reports a set description as present rather than inlining it', () => {
+    expect(formatNodeTranslationSummary(MOCK_SECTION_TRANSLATION)).toMatchInlineSnapshot(`
+      "## Translation: en-us (7100)
+      - **Name**: FAQ
+      - **Description**: set
+      - **Draft**: false
+      - **Updated**: 2026-01-02T00:00:00Z"
+    `);
+  });
+
+  it('reports an empty description as empty', () => {
+    expect(
+      formatNodeTranslationSummary({ ...MOCK_SECTION_TRANSLATION, body: '' }),
+    ).toMatchInlineSnapshot(`
+      "## Translation: en-us (7100)
+      - **Name**: FAQ
+      - **Description**: empty
+      - **Draft**: false
+      - **Updated**: 2026-01-02T00:00:00Z"
+    `);
   });
 });

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -307,6 +307,7 @@ describe('formatSlaBlock', () => {
     `);
   });
 });
+
 describe('formatComment', () => {
   it('renders a public comment with its attachment ids and content types', () => {
     expect(formatComment(MOCK_COMMENT)).toMatchInlineSnapshot(`
@@ -331,11 +332,6 @@ describe('formatComment', () => {
 
   it('omits the Attachments line when the comment has none', () => {
     const result = formatComment({ ...MOCK_COMMENT, attachments: undefined });
-    expect(result).not.toContain('Attachments:');
-  });
-
-  it('omits the Attachments line when the attachments array is empty', () => {
-    const result = formatComment({ ...MOCK_COMMENT, attachments: [] });
     expect(result).not.toContain('Attachments:');
   });
 });

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -664,6 +664,49 @@ describe('formatAudit — Change events', () => {
     `);
   });
 
+  it('renders an emptied entity field as (none), whatever the name maps carry', () => {
+    // `withName` resolves through `Number(value)`, and `Number('')` is 0. The
+    // production caller never puts 0 in these maps, but `AuditNames` is a plain
+    // `Map<number, string>` and cannot say so — the empty-value guard in
+    // `renderAuditValue` is what keeps a cleared field from picking up whatever
+    // name happens to sit at that key.
+    expect(
+      formatAudit(
+        change([
+          { id: 1, type: 'Change', field_name: 'assignee_id', value: '', previous_value: '100' },
+        ]),
+        { users: new Map([...names.users, [0, 'Not A Real User']]), groups: names.groups },
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-02T00:00:00Z — Agent Smith (100) via api
+      - **assignee**: Agent Smith (100) → (none)"
+    `);
+  });
+
+  it('never reads an array as an SLA metric', () => {
+    // The metric branch destructures `minutes` and reports it as a duration, so an
+    // array that carries such a property must not reach it — `!Array.isArray` is
+    // the guard, and an array is the one value that can hold both shapes.
+    const arrayWithMinutes = Object.assign(['1', '2'], { minutes: 5 });
+    expect(
+      formatAudit(
+        change([
+          {
+            id: 1,
+            type: 'Change',
+            field_name: 'custom_field_1',
+            value: arrayWithMinutes,
+            previous_value: null,
+          },
+        ]),
+        names,
+      ),
+    ).toMatchInlineSnapshot(`
+      "### 2026-02-02T00:00:00Z — Agent Smith (100) via api
+      - **custom_field_1**: (none) → 1, 2"
+    `);
+  });
+
   it('attributes a voice comment like a regular one', () => {
     expect(
       formatAudit(

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -213,9 +213,10 @@ describe('formatSlaBlock', () => {
     `);
   });
 
-  it('treats a deadline exactly at the current instant as due, not as remaining', () => {
+  it('counts a deadline at the current instant as 0 min remaining, not as a next breach', () => {
     // The two boundaries meet here: `t > Date.now()` must not advertise a "next
-    // breach" that is already due, and `remaining < 0` must not call 0 overdue.
+    // breach" that is already due (hence no such line below), and `remaining < 0`
+    // must not call 0 overdue.
     expect(
       formatSlaBlock(entry([{ metric: 'first_reply_time', stage: 'active', breach_at: at(0) }])),
     ).toMatchInlineSnapshot(`
@@ -257,6 +258,11 @@ describe('formatSlaBlock', () => {
   });
 
   it('omits the countdown for paused, achieved and fulfilled stages', () => {
+    // The `Next breach` line in this snapshot is today's output, not endorsed
+    // behaviour: the header counts every future `breach_at` regardless of stage,
+    // so it announces a breach for metrics this very test shows carry no live
+    // countdown. Pinned here so the disagreement is visible rather than silent —
+    // #260 owns the fix and the call on whether `paused` should feed the header.
     expect(
       formatSlaBlock(
         entry([
@@ -763,16 +769,6 @@ describe('formatUser', () => {
       - **Active**: false"
     `);
   });
-
-  it('omits organization when null', () => {
-    const result = formatUser({ ...MOCK_USER, organization_id: null });
-    expect(result).not.toContain('Organization');
-  });
-
-  it('omits role_type when null', () => {
-    const result = formatUser({ ...MOCK_USER, role_type: null });
-    expect(result).not.toContain('Role type');
-  });
 });
 
 describe('formatOrganization', () => {
@@ -851,37 +847,6 @@ describe('formatArticleSummary', () => {
   it('does not include body', () => {
     const result = formatArticleSummary(MOCK_ARTICLE);
     expect(result).not.toContain('Testing guide');
-  });
-
-  it('marks visibility as everyone when the article has no user segment', () => {
-    const result = formatArticleSummary({
-      ...MOCK_ARTICLE,
-      user_segment_id: null,
-    });
-    expect(result).toContain('12001');
-    expect(result).toMatch(/everyone/i);
-  });
-
-  it('omits labels when empty', () => {
-    const result = formatArticleSummary({ ...MOCK_ARTICLE, label_names: [] });
-    expect(result).not.toContain('Labels');
-  });
-
-  it('omits position when not a number', () => {
-    const result = formatArticleSummary({
-      ...MOCK_ARTICLE,
-      position: undefined as unknown as number,
-    });
-    expect(result).not.toContain('Position');
-  });
-
-  it('surfaces promoted status with the admin-only caveat only when promoted', () => {
-    // MOCK_ARTICLE is not promoted → no line at all.
-    expect(formatArticleSummary(MOCK_ARTICLE)).not.toContain('Promoted');
-
-    const promoted = formatArticleSummary({ ...MOCK_ARTICLE, promoted: true });
-    expect(promoted).toContain('**Promoted**');
-    expect(promoted).toMatch(/Help Center admin|Guide admin/);
   });
 });
 
@@ -972,15 +937,6 @@ describe('formatMacro', () => {
       - **inactive** | **Scope**: shared
       - **Actions**: none"
     `);
-  });
-
-  it('includes id, title, scope and the ordered actions', () => {
-    const result = formatMacro(MOCK_MACRO);
-    expect(result).toContain('Close and thank the customer (id 700)');
-    expect(result).toContain('Scope**: shared');
-    expect(result).toContain('status → solved');
-    expect(result).toContain('set_tags → resolved, macro_applied');
-    expect(result).toContain('comment_value → Thanks for your business!');
   });
 
   it('marks a restricted macro and previews an over-long action value', () => {


### PR DESCRIPTION
## Summary

`src/utils/formatting.ts` has been out of the `mutate` scope since #197, at 67.72 % with **173 escaped mutants over 101 of its 461 lines**. This PR takes it to **100.00 % — 536 killed, 0 survived, 0 without coverage, 0 ignored** — and removes the exclusion, so the file is gated again.

| `src/utils/formatting.ts` | `5958501` (before) | this branch |
| --- | ---: | ---: |
| Mutation score (total / covered) | 67.72 % / 73.04 % | **100.00 % / 100.00 %** |
| Killed | 363 | 536 |
| Survived | 134 | **0** |
| NoCoverage | 39 | **0** |
| Ignored | 0 | **0** |
| Lines carrying an escaped mutant | 101 of 461 | **0** |

No Stryker directive anywhere in the file. The `src/` diff is comments only.

The bar is zero escaped, not a better score — see the [analysis comment](https://github.com/fruggr/zendesk-mcp-server/issues/203#issuecomment-5474063628). Re-arming the gate with a residue would just relocate the booby trap #197 deferred: a mine on each of those 101 lines for the next author who touches one.

Whole-scope side effects, measured: **2 043 mutants at 88.40 %** (was 1 452 documented), cold run **13 min 7 s** locally on 4 cores.

## Linked issue

Closes #203

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no external behavior change)
- [x] Documentation
- [x] Tooling / CI

Primarily test work; the ADR rewrite, the `CONTRIBUTING.md` convention and the `stryker.config.mjs` scope flip come with it.

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally — 954 tests
- [x] `pnpm test:coverage` meets the thresholds — 98.07 / 89.03 / 99.34 / 98.5 against 94 / 77 / 98 / 95
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings — see *What review caught* below; three review passes each found something real, and all are fixed or filed
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: n/a
- [x] If the change has **MCP-runtime-observable** behaviour: **exempt.** Tests, mutation-testing config and docs; the `src/` change is comments. A running server behaves identically for a client, so the standard gates are the validation.

## Notes for the reviewer (human or AI)

### Why inline snapshots, and why no block-scoped disable

The root cause of the 173 was the assertion style, not the strings: this file's suite ran **116 `toContain` against 13 `toBe`**. `toContain('open')` on `formatTicket` says nothing about the template — emptying `- **Status**: ` leaves `open` in the output. Three mutant classes are invisible to `toContain` no matter how many keywords you add:

- an emptied separator (`', '`, or the trailing `.join('\n')`);
- a dropped `.filter(Boolean)` (the output gains a blank line);
- the **suppressed-line branch** of a ternary — Stryker rewrites `''` to a non-empty marker, so the line *appears* and `expect(result).not.toContain('Promoted')` still passes. 29 of the 102 `StringLiteral` survivors were this, and they are not prose.

One exact-output assertion kills the `StringLiteral`, `ConditionalExpression`, `EqualityOperator` and `MethodExpression` on the same line at once, which is why this was not split into "logic mutants" and "label strings".

Both treatments were measured on `formatOrganization` (`:358-366`, 21 mutants, baseline 6 killed / 15 escaped):

| | Score | Killed | Ignored | Survived |
| --- | ---: | ---: | ---: | ---: |
| two inline snapshots, no directive | **100.00 %** | 21 | 0 | **0** |
| `// Stryker disable StringLiteral` block, assertions unchanged | 36.36 % | 4 | 10 | **7** |

The 7 survivors under the directive are the logic mutants, and killing them needs *the same two inputs* the snapshots already use. The disable buys back no test work — it was costed against hand-written expected output, and a pre-filled `toMatchInlineSnapshot` reduces that to one `vitest` run. That is what ADR §5 now says, on the axis that actually decides it (what the string *does*, four roles) rather than per mutator or per file.

### What review caught, and the lesson that came out of it

An earlier revision waived two mutants in `renderAuditValue` as equivalent. **Both were killable.** CodeRabbit flagged the first; the second had the identical flaw and nothing had flagged it.

The flaw was where the argument lived, not how the waiver was scoped:

- `renderAuditValue` empties `''` before resolving an id because `withName` goes through `Number(value)`, and `Number('')` is 0 — so without the guard, a cleared field picks up whatever name sits at key 0. I justified the waiver with `addPositiveId` in `tools/tickets.ts` never putting 0 in those maps. That is a fact about today's caller; `AuditNames` is a plain `Map<number, string>` and promises nothing.
- `!Array.isArray(value)` stops an array being destructured for `minutes` and reported as a duration. I argued no input could separate the two because `JSON.parse` cannot produce an array with an own `minutes` property. Also a fact about the caller — `value` is `unknown`.

Each died to one test asserting the guard's own contract, so both directives are gone, and reverting the guard split that waiver-scoping had needed put `src/` back to comments only.

ADR §5 now carries the generalisable form in place of the waiver-scoping advice: **when a mutant looks equivalent, check whether the argument is a fact about the *type* or about *today's caller*. If it is the caller, the mutant is marking an unasserted contract, and the assertion is the fix.** The scoping limitation is still recorded — `disable next-line` cannot target one mutant among several of the same mutator on a line, and hoisting a condition into a named `const` does not narrow it because Stryker emits the whole-conjunction mutant wherever the expression sits — but as a last resort, after that question.

A later pass caught two more of mine: a test whose name endorsed the opposite of its assertion (`treats a deadline exactly at the current instant as due, not as remaining`, asserting a snapshot that reads `0 min remaining`), and a `CONTRIBUTING.md` bullet telling authors to fill an empty snapshot with `-u` while the bullet below it calls `-u` a product-surface change. Verified both directions before rewriting: a plain `pnpm test <file>` fills an empty inline snapshot and *fails* on a filled one that no longer matches, without overwriting.

### One defect found and deliberately not fixed here — #260

`formatSlaBlock` computes its `Next breach` line over every metric with a future `breach_at` and no stage filter, while `formatSlaMetric` ten lines below suppresses the countdown for `paused`, `achieved` and `fulfilled`. The two disagree inside the same block, and a snapshot added here shows three non-live metrics under a `Next breach` header. Pre-existing, but this PR pins it — so the snapshot carries a comment saying it records today's output rather than endorsed behaviour, and #260 owns the fix plus the product call on whether `paused` should feed the header. Fixing it changes user-visible output, which is a different PR.

### The diff gate is not the proof, and this PR demonstrates it

`pnpm test:mutation:diff origin/main HEAD` on the commit that re-arms the gate:

```
Mutating the changed lines: src/utils/formatting.ts:272-277,src/utils/formatting.ts:282-284
Stryker produced no mutants inside the changed lines, so there is nothing to
gate. Note this is not a pass: ...
```

Zero mutants judged — the script says so itself. `changedRanges` reads `git diff --unified=0` and `escapedMutants` judges only a mutant contained in a changed range, and the only `formatting.ts` lines this PR changes are comments. The gate would have reported exactly the same with 173 survivors still in the file. The full-file run is the proof; the gate is a smoke check. Corrected in the issue's acceptance list in a comment.

### Also

- **30 tests removed**, each strictly subsumed by an exact-output snapshot over the identical input in the same describe. Tests whose name states a rule the output does not show on its own — a comment body must never leak into the timeline — are kept. Mutation testing was re-run after the deletions and still reports 536/536, which is the proof they carried no signal.
- **The SLA block moved onto fake timers.** A real clock makes "some number of minutes" the loosest possible claim about arithmetic. A pinned `now` states every branch exactly, including two boundaries that were unreachable before: a deadline exactly at the current instant is not a *future* breach, and 0 minutes remaining is not 0 minutes overdue.
- **`tests/unit/mutation-scope.test.ts` needs no change** — its `'!src/utils/formatting.ts'` patterns are literal fixtures for `scopeMatcher`, not read from the config. The `!` paragraph stays in ADR §5 for the same reason: no negation is left in `mutate` today, but the semantics still have to hold for the next exclusion.
- **Coverage thresholds untouched.** Branches now sit 12 points above the 77 floor, but that gap mostly predates this PR and raising a global floor affects unrelated work — a ratchet belongs in its own change.

https://claude.ai/code/session_01X3S7XFhsXkVFmeiHLdTANT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for writing and maintaining committed inline snapshots.
  * Updated mutation-testing documentation and scope details.

* **Tests**
  * Expanded formatting coverage across tickets, users, organizations, SLAs, audits, translations, and other supported values.
  * Added snapshot-based assertions and edge-case coverage, including malformed timestamps and missing data.

* **Bug Fixes**
  * Preserved formatting behavior while improving handling of empty and missing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->