### PR TITLE
feat(requests): serve end users their own tickets

### DIFF
--- a/.claude/missions/issue-48-end-user-api-probe.md
+++ b/.claude/missions/issue-48-end-user-api-probe.md
@@ -1,0 +1,215 @@
+# Mission: probe the Zendesk end-user API surface (issue #48)
+
+**For:** an agent running with authenticated access to a real Zendesk instance.
+**Why:** issue #48 ("End-user mode") is being planned. Several facts cannot be
+settled from the public documentation, and guessing them would put the wrong
+tool surface in the plan. This mission establishes them empirically.
+
+**Deliverable:** a report posted as a comment on the pull request for
+`claude/issue-48-analysis-czaqzt` (or, if that PR is gone, on issue #48).
+Answer every question below by its identifier (B1…B11), each with:
+
+- the exact request made (method, path, query string, body shape — redact values),
+- the HTTP status,
+- the relevant part of the response (redact personal data: names, emails,
+  subjects, ticket bodies — the *shape* is what matters, not the content),
+- a one-line verdict: **confirmed / refuted / inconclusive**.
+
+Mark a question **inconclusive** rather than inferring. An inconclusive answer
+is a useful result; a plausible-sounding guess is not.
+
+## Ground rules
+
+- **Do not modify this repository.** No commits, no branch pushes. Your output
+  is the report comment only.
+- **Read-only wherever possible.** Where a write is unavoidable (B6, B8, B9,
+  B10) use an obviously disposable test request — subject prefixed
+  `[MCP probe #48]` — and note its request id in the report so it can be
+  cleaned up. Do not touch any pre-existing ticket.
+- Prefer a **sandbox** instance. If only production is available, restrict
+  yourself to the read-only questions and mark the write ones
+  *not attempted (production)*.
+- Raw HTTP (curl or equivalent) against `https://<subdomain>.zendesk.com` is
+  the right tool here — this probes the Zendesk API, not this MCP server.
+
+## Accounts needed
+
+Two tokens, if you can get them:
+
+- **EU** — a token for a user whose `role` is `end-user`.
+- **AG** — a token for an agent or admin.
+
+Most questions need EU. If you cannot obtain an end-user token at all, that
+outcome *is* the answer to B1, and it is the single most important result of
+this mission — report it and continue with AG where the question still makes
+sense (noted per question).
+
+## Questions
+
+### B1 — Can an end user complete the OAuth flow? (blocking)
+
+No Zendesk documentation states whether the authorization-code flow is
+available to a user whose role is `end-user`; the endpoints and the
+`requests:read` / `requests:write` scopes suggest yes, but nothing confirms it.
+
+1. Sign in as an end user and open
+   `https://<subdomain>.zendesk.com/oauth/authorizations/new?response_type=code&client_id=<id>&redirect_uri=<uri>&scope=read+write&code_challenge=<c>&code_challenge_method=S256`
+2. Does the consent screen render, or does Zendesk reject/redirect (to a sign-in
+   page, an agent-only interstitial, an error)? Report exactly what appears.
+3. If it renders: complete it and exchange the code at `/oauth/tokens`. Report
+   whether an access token comes back and whether a refresh token comes with it.
+4. Repeat step 1 with `scope=requests:read+requests:write` and report any
+   difference (consent screen wording, acceptance, rejection).
+
+Report the OAuth client's configuration that made this work (redirect URL,
+scopes registered) — the end-user onboarding guide in #48 has to document it.
+
+### B2 — Exact role string
+
+`GET /api/v2/users/me` with EU. Report the literal value of `role` (is it
+`end-user`, `end_user`, something else?) and whether `role_type` is present.
+Then the same with AG, for comparison. This drives the role-mismatch check.
+
+### B3 — Ticket forms readable by an end user
+
+With EU: `GET /api/v2/ticket_forms?active=true&end_user_visible=true&fallback_to_default=true`
+
+- Status? If 403, that alone reshapes the plan — say so plainly.
+- How many forms come back, and does each carry `id`, `name`, `display_name`,
+  `ticket_field_ids`, `end_user_visible`, `end_user_conditions`, `position`,
+  `default`?
+- Is `display_name` populated, or empty/absent (falling back to `name`)?
+- Repeat **without** `fallback_to_default`: on this instance, does the
+  parameter change the result? (It is the proposed graceful-degradation path
+  for single-form plans.)
+- What does this instance's plan actually allow — one form or several?
+
+### B4 — Ticket fields readable by an end user
+
+With EU: `GET /api/v2/ticket_fields`
+
+- Status?
+- Are `visible_in_portal`, `required_in_portal`, `editable_in_portal` and
+  `title_in_portal` present on the returned objects? List which are missing.
+- Does the response include fields that are **not** portal-visible (i.e. must
+  we filter client-side), or does Zendesk already filter for an end user?
+- Do `custom_field_options` come back with `name` / `value` / `raw_name`?
+- Is the endpoint paginated here, and with which shape (`page`/`per_page`
+  offset, or `page[size]` cursor)?
+
+### B5 — Listing and reading own requests
+
+With EU:
+
+- `GET /api/v2/requests` — status; pagination shape (offset `page`/`per_page`,
+  or cursor `page[size]`/`links.next`); which attributes are populated.
+- `GET /api/v2/requests?sort_by=updated_at&sort_order=desc` — honoured?
+- `GET /api/v2/requests?status=open,pending` — does the `status` filter work on
+  **List** Requests, or only on Search Requests? (The documentation lists it
+  under Search; confirm or refute for List.)
+- `GET /api/v2/requests/{id}` — is `can_be_solved_by_me` present, and what is
+  its value on a request that is unassigned vs assigned to an agent?
+- `GET /api/v2/requests/{id}/comments` — do comments carry `attachments` with
+  `content_url`, and are `author_id` / `created_at` present? Are agent replies
+  and the requester's own comments distinguishable?
+- `GET /api/v2/requests/search?query=<word>` — status, and does it search only
+  the caller's own requests?
+
+### B6 — Submitting a request, and what the API validates
+
+With EU. Subject prefixed `[MCP probe #48]`.
+
+1. `POST /api/v2/requests` with a minimal body (`subject` + `comment.body`) and
+   **no** `ticket_form_id`. Status? Which form does the created request land on?
+2. Same, **with** `ticket_form_id` set to a form from B3. Does the response echo
+   `ticket_form_id`?
+3. **The key question:** pick a form having a field with
+   `required_in_portal: true`, and POST **omitting** that field. Does Zendesk
+   return 422, or does it accept the request? Quote the 422 body verbatim if
+   there is one — its shape decides whether we can surface a usable message.
+4. Same with a field that is required only through `end_user_conditions`
+   (conditionally required). Does the API enforce the condition, or is it
+   enforced only by the web widget? If this instance has no conditional form,
+   say so and mark inconclusive.
+5. Does `POST /requests` accept `custom_fields` as `[{ id, value }]`? Report
+   whether `fields` is also accepted as an alias.
+6. Are `priority` / `type` actually settable by an end user, or silently ignored?
+
+### B7 — What an end user may read on their own request
+
+With EU, on a request that has at least one agent internal note (ask an agent to
+add one, or use an existing test request):
+
+- Does `GET /requests/{id}/comments` hide the internal note? Confirm that
+  nothing agent-private leaks through this path.
+- Does `GET /api/v2/tickets/{id}` (the **agent** path, for the same ticket)
+  return 403/404 for EU? This is what justifies not exposing the agent ticket
+  tools to end users.
+- Does `GET /api/v2/search?query=...` return 403 for EU?
+
+### B8 — Commenting on own request
+
+With EU: `PUT /api/v2/requests/{id}` with `{ "request": { "comment": { "body": "..." } } }`
+
+- Status, and is the comment public (end users cannot post private ones)?
+- On a **closed** request, what happens? Quote the error.
+
+### B9 — Marking a request solved
+
+With EU:
+
+- On a request where `can_be_solved_by_me` is **true**:
+  `PUT /requests/{id}` with `{ "request": { "solved": true } }` — status, and
+  resulting `status` value.
+- On one where it is **false**: what error comes back? Quote it. (We want to
+  pre-empt this client-side with a clear message rather than surface a raw error.)
+- Can `solved` and `comment` be sent in the **same** PUT?
+
+### B10 — Attachments
+
+With EU:
+
+1. `POST /api/v2/uploads.json?filename=probe.txt` with a small text body and
+   `Content-Type: application/octet-stream`. Status? Is `upload.token` returned?
+2. Chain a second file by passing `token=<first token>`. Does the token
+   aggregate both files, as the documentation says?
+3. Use that token in `POST /requests` as `comment.uploads: [token]`. Is the file
+   attached to the created request?
+4. Same via `PUT /requests/{id}` on a follow-up comment.
+5. Is there an enforced size limit, and what error does exceeding it produce?
+
+### B11 — Agents on the end-user path
+
+The documentation says "admins and agents are treated as end users when using
+the Requests endpoint". With AG:
+
+- `GET /api/v2/requests` — does it return the agent's *own* requests (those
+  where they are the requester), and does it return 200?
+- `POST /api/v2/requests` — accepted for an agent?
+
+This decides whether the end-user toolset is usable by an agent too (which
+would make a role-mismatch warning informational rather than an error).
+
+## Report template
+
+```
+## Mission report — issue #48 end-user API probe
+
+Instance: <sandbox | production>, plan: <plan name if known>
+Tokens used: EU = <obtained | not obtained>, AG = <obtained | not obtained>
+
+### B1 — OAuth for an end user: CONFIRMED | REFUTED | INCONCLUSIVE
+<request / status / response shape / verdict>
+
+… one block per question, B1 through B11 …
+
+### Surprises
+Anything encountered that none of the questions asked about but that
+would change the design.
+
+### Cleanup
+Request ids created by this probe: #…
+```
+
+Do not skip the **Surprises** section — an undocumented behaviour found in
+passing is often worth more than a confirmed expectation.

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,22 @@
   "mcpServers": {
     "zendesk-local": {
       "command": "pnpm",
-      "args": ["exec", "tsx", "src/index.ts", "--mode", "all", "--dev"],
+      "args": [
+        "exec",
+        "tsx",
+        "src/index.ts",
+        "--mode",
+        "all",
+        "--dev",
+        "--namespace",
+        "tickets",
+        "--namespace",
+        "help_center",
+        "--namespace",
+        "users",
+        "--namespace",
+        "requests"
+      ],
       "env": {
         "ZENDESK_SUBDOMAIN": "fruggr"
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,10 +58,36 @@ browser PKCE via `token-store.ts`. HTTP: per-session bearer captured from
 credential — insufficiently secure, doesn't scale to multi-user/remote); the
 rationale lives in `README.md` ("What this server does *not* do").
 
-Local setup and auth flows live in `README.md`; CLI flags and env vars in
+Local setup and auth flows live in `README.md`; the customer-facing walkthrough
+in `docs/end-user-onboarding.md`; CLI flags and env vars in
 `docs/configuration.md`; remote HTTP deployment in `docs/http-deployment.md`;
 troubleshooting in `docs/troubleshooting.md`; manual tool testing in
 `docs/live-testing.md`.
+
+## Two audiences
+
+The server serves **agents** and **end users**, and they are different products
+sharing a codebase. The agent surface speaks `/api/v2/tickets`; the end-user
+surface speaks `/api/v2/requests`, which is the path Zendesk reserves for
+requesters and the only one an end-user token can reach. `requests` is a
+namespace excluded from `DEFAULT_NAMESPACES` (`config.ts`), so it ships opt-in.
+
+Changing the agent ticket surface? Ask whether the end-user side needs the
+equivalent — and when it doesn't, say why in the PR rather than leaving the
+asymmetry unexplained. They are not mirrors: a customer cannot set priority or
+type (Zendesk drops both), cannot post an internal note, and cannot solve a
+ticket no agent has picked up.
+
+The trap is testing an end-user tool with an agent token. Several operations
+behave differently: `solved: true` is a silent no-op for an agent, a form's
+`required_in_portal` validation is not applied to them, and `priority`/`type`
+are stored rather than dropped. An agent-token check will pass where a
+customer's real call fails. Rationale and the rejected `--profile` alternative:
+`docs/decisions/end-user-namespace.md`.
+
+Being opt-in is not a lower bar. Glama scores the flat surface, and the server
+score is `60% mean + 40% min`, so a thin definition behind a flag drags the
+whole thing down exactly as much as one in the default set.
 
 ## Design principle — usage-first, not API-shaped
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,19 @@
 [![Node.js](https://img.shields.io/node/v/@fruggr/zendesk-mcp-server?logo=nodedotjs&logoColor=white&color=339933)](https://nodejs.org)
 
 A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that
-puts Zendesk inside your AI assistant. It finds answers in the Help Center;
-drafts, updates and translates articles while keeping the languages in sync; and
-handles Support tickets end to end, comments, triage and image attachments
-included. It all happens in plain language, without switching apps.
+puts Zendesk inside your AI assistant, for **both sides of the conversation**.
+
+**For agents**: it finds answers in the Help Center; drafts, updates and
+translates articles while keeping the languages in sync; and handles Support
+tickets end to end, comments, triage and image attachments included.
+
+**For your customers**: it opens the same door the Help Center's "Submit a
+request" form does. They pick the kind of request, get walked through the
+questions that form actually asks, attach a screenshot, then follow the
+ticket — read the replies, answer back, close it when it's resolved. See
+[End-user mode](#end-user-mode).
+
+It all happens in plain language, without switching apps.
 
 It does roughly what the
 [Zendesk agent for Microsoft 365 Copilot](https://support.zendesk.com/hc/en-us/articles/9958331458458-Using-the-Zendesk-agent-in-Microsoft-365-Copilot)
@@ -39,6 +48,9 @@ then calls the right tools on your behalf.
 - Draft and maintain knowledge-base articles. You can write a new one, or revise
   a large one a single section at a time, so the whole HTML body never has to
   round-trip through the model.
+- Submit and follow a request as a customer, not an agent. Choose between the
+  kinds of request the vendor offers, answer only the questions that form asks,
+  and then track it: what was replied, what you replied, and whether it's done.
 
 ## Why this server
 
@@ -51,6 +63,10 @@ differently.
   touches exactly what that person is allowed to, the same scoping you get by
   signing into Zendesk directly. Static API tokens are deliberately not
   supported ([why](#what-this-server-does-not-do)).
+- Two audiences, one server. Because auth is per-user rather than a shared admin
+  key, the same install serves your agents and your customers — the end-user
+  surface is a namespace you switch on, speaking the API path Zendesk reserves
+  for requesters. Most Zendesk MCP servers are agent-only by construction.
 - Section-based article editing. For large Help Center articles, read and
   rewrite one section at a time (parsed by `h1`/`h2`/`h3` headings) instead of
   shuffling the full HTML body through the assistant. On a targeted edit that
@@ -197,9 +213,10 @@ job: **[docs/http-deployment.md](docs/http-deployment.md)**.
 
 ## Tool surface
 
-Tools are grouped into four namespaces: **Tickets**, **Help Center**, **Users &
-Organizations** and **Search**. The server registers them in one of three modes,
-so you can trade granularity against context budget:
+Tools are grouped into namespaces: **Tickets**, **Help Center**, **Users &
+Organizations**, **Search**, and **Requests** — the end-user surface, which is
+opt-in and covered under [End-user mode](#end-user-mode). The server registers
+them in one of three modes, so you can trade granularity against context budget:
 
 - **`all`**: every operation as its own tool, for clients with good tool selection;
 - **`namespace`** (default): one proxy tool per namespace, a balanced middle ground;
@@ -210,9 +227,96 @@ Proxies take `{ "operation": "<tool_name>", "params": { … } }` and validate
 filter tools *before* the proxies are built, so each proxy describes only the
 operations that survive.
 
+There's one way to pick the inventory (`--namespace` / `--tool`), `--mode`
+packages it, and `--read-only` narrows it. When the combination isn't obvious,
+don't guess — ask the server, which needs no credentials to answer:
+
+```bash
+zendesk-mcp-server mycompany --print-tools --namespace requests --mode single
+```
+
 Every tool with its description and its `read`/`write` mode:
 **[docs/mcp-tools-reference.md](docs/mcp-tools-reference.md)**. The flags and
 worked examples: **[docs/configuration.md](docs/configuration.md)**.
+
+## End-user mode
+
+The audience for everything above is a Zendesk **agent**. This section is about
+the other one: your **customers**.
+
+On the web, a customer opens a ticket through the Help Center's "Submit a
+request" form — they pick a kind of request, fill in the fields that kind asks
+for, attach a file, and later come back to read the replies. End-user mode is
+that same journey, in their assistant.
+
+### Who it's for
+
+A vendor pointing their customers at an MCP server, so support happens where
+those customers already work. They install it themselves, sign in with their
+own Help Center account, and never see anything that isn't theirs.
+
+### Turning it on
+
+The end-user tools live in the `requests` namespace, which is **opt-in**:
+
+```bash
+zendesk-mcp-server mycompany --namespace requests --namespace help_center
+```
+
+`help_center` is worth adding — a customer who can search the knowledge base
+often doesn't need to open a ticket at all.
+
+Two things to know about the shape of that command. `--namespace` **replaces**
+the default set rather than adding to it, so this exposes the end-user surface
+only, not the agent tools as well. And `requests` is deliberately absent from
+the default: an agent install shouldn't inherit tools built for someone else,
+and one of them (marking a request solved) doesn't work under an agent token —
+Zendesk accepts it and silently does nothing. `--print-tools` shows you exactly
+what any combination of flags produces.
+
+`--read-only` composes with it, if you want customers to follow their tickets
+without opening new ones.
+
+### The journey it supports
+
+- **See what kinds of request are available.** The forms the vendor offers, by
+  their customer-facing names.
+- **Learn what one of them asks.** The questions on that form, which are
+  required, and for dropdowns the exact choices — so the assistant can gather
+  them in conversation instead of guessing at a payload.
+- **Submit it**, with attachments.
+- **Follow it.** List their requests, read one with its whole conversation
+  (each reply attributed, and support agents marked as such), reply back, and
+  mark it solved when it is.
+
+### Zendesk prerequisites
+
+- An **OAuth client** on the Zendesk account, with the local callback URL
+  registered. Same client the agent side uses; nothing extra.
+- The customer needs a **Help Center account** they can sign into. Signing in
+  with a Google account is enough where the Help Center allows it — Zendesk
+  provisions the user on first sign-in, with no admin action.
+- At least one ticket form **visible to end users**. Accounts with several get
+  a real choice; accounts with one get that one.
+
+Sign-in is interactive, through a browser, by design — there's no scripted or
+headless path to an end-user token. The step-by-step walkthrough, written for
+someone who doesn't work in a terminal:
+**[docs/end-user-onboarding.md](docs/end-user-onboarding.md)**.
+
+### What a customer can't do — and shouldn't
+
+A customer can do less than an agent. That's the point, not a gap:
+
+- **Only their own tickets.** Enforced by Zendesk, not by us.
+- **No internal notes**, in either direction. Agent-only notes never appear in
+  what this surface returns — Zendesk filters them out of the requester's view
+  of a ticket entirely.
+- **No priority or type.** Zendesk drops both when a customer sets them;
+  triage stays with the agents.
+- **Closing a ticket only once an agent has picked it up.** Until then Zendesk
+  won't let the requester solve it, so the tool says so rather than pretending.
+- **No search across the ticket base**, no user lookups, no views, no macros.
 
 ## Help Center context
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,7 +163,8 @@ Three deliberate exceptions:
   the value the server actually uses.
 - The **numeric tuning caps** — `ZENDESK_CHARACTER_LIMIT`,
   `ZENDESK_MAX_ATTACHMENT_BYTES`, `ZENDESK_MAX_EMBEDDED_IMAGES`,
-  `ZENDESK_MAX_COMMENT_PAGES`, `ZENDESK_REORDER_CONFIRM_THRESHOLD` and
+  `ZENDESK_MAX_COMMENT_PAGES`, `ZENDESK_REORDER_CONFIRM_THRESHOLD`,
+  `ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES` and
   `ZENDESK_ARTICLE_RESOURCES_SCAN_MAX_PAGES` — read through a shared parser that
   treats an empty value as unset and falls back to the default, along with any
   value that is not a positive safe integer. They bound response sizes and scan
@@ -262,6 +263,18 @@ Maximum number of images embedded as native image content in a single tool call.
 **Required:** no · **Default:** `10`
 
 Hard cap on the number of comment pages fetched when collecting a ticket's attachments (raise it for tickets with very long comment threads).
+
+### `ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES`
+**Required:** no · **Default:** `10`
+
+Hard cap on the number of `/ticket_fields` pages scanned when `get_request_form`
+joins a request form to its field definitions. The scan exists because
+`GET /ticket_fields/{id}` answers 403 for an end user, so the list is the only
+way to a field's label and accepted values. Hitting the cap **fails the call**
+rather than returning a partial list: a field missing from the join would leave
+a required question unasked, and the submitter would meet an opaque Zendesk 422
+instead. Raise it for an account with more portal fields than the default scan
+covers.
 
 ### `ZENDESK_REORDER_CONFIRM_THRESHOLD`
 **Required:** no · **Default:** `20`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,10 @@ zendesk-mcp-server <subdomain> [options]
 
 Options:
   --mode <mode>           single | namespace (default) | all
-  --namespace <ns>        Filter by namespace (repeatable): tickets, help_center, users
+  --namespace <ns>        Filter by namespace (repeatable): tickets, help_center,
+                          users, requests. Defaults to tickets + help_center +
+                          users; `requests` (the end-user surface) is opt-in and
+                          only ever exposed when asked for by name
   --tool <name>           Filter by tool name (repeatable, forces --mode all)
   --read-only             Only expose read operations
   --no-topology           Disable the Help Center structural context
@@ -44,9 +47,25 @@ Options:
   --dev                   Dev-only: expose a reload_tools tool that hot-reloads
                           edited tool code on demand (stdio only; see "Dev mode"
                           below)
+  --print-tools           Print the tool surface these flags resolve to, then
+                          exit. No server, no Zendesk credential, no network
+                          call. Use it to check what a combination of --mode /
+                          --namespace / --tool / --read-only actually exposes
 ```
 
 `--namespace` and `--read-only` are applied before the proxies are registered, so they narrow the surface in every mode. In the default `namespace` mode, `--namespace help_center` registers a single proxy (`zendesk_help_center`) instead of the full set of namespace proxies.
+
+Passing `--namespace` **replaces** the default set rather than adding to it, so
+`--namespace requests` exposes the end-user surface *only*. To serve customers
+the knowledge base as well, name both: `--namespace requests --namespace help_center`.
+
+There is one way to pick the inventory (`--namespace` / `--tool`), `--mode`
+packages it, and `--read-only` narrows it. When the combination is hard to
+predict, don't guess — ask the server:
+
+```bash
+zendesk-mcp-server mycompany --print-tools --namespace requests --mode single
+```
 
 ### A malformed invocation fails at startup
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,14 +267,16 @@ Hard cap on the number of comment pages fetched when collecting a ticket's attac
 ### `ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES`
 **Required:** no · **Default:** `10`
 
-Hard cap on the number of `/ticket_fields` pages scanned when `get_request_form`
-joins a request form to its field definitions. The scan exists because
-`GET /ticket_fields/{id}` answers 403 for an end user, so the list is the only
-way to a field's label and accepted values. Hitting the cap **fails the call**
-rather than returning a partial list: a field missing from the join would leave
-a required question unasked, and the submitter would meet an opaque Zendesk 422
-instead. Raise it for an account with more portal fields than the default scan
-covers.
+Hard cap on the number of pages scanned when the end-user tools walk a listing
+that cannot say when it is done: the `/ticket_fields` scan `get_request_form`
+and `create_request` use to join a request form to its field definitions, and
+the `/ticket_forms` listing behind `list_request_forms`. The field scan exists
+because `GET /ticket_fields/{id}` answers 403 for an end user, so the list is
+the only way to a field's label and accepted values. Hitting the cap **fails the
+call** rather than returning a partial list: a field missing from the join would
+leave a required question unasked, and the submitter would meet an opaque
+Zendesk 422 instead. Raise it for an account with more portal fields, or more
+end-user forms, than the default scan covers.
 
 ### `ZENDESK_REORDER_CONFIRM_THRESHOLD`
 **Required:** no · **Default:** `20`

--- a/docs/decisions/end-user-namespace.md
+++ b/docs/decisions/end-user-namespace.md
@@ -1,0 +1,117 @@
+# The end-user surface is an opt-in namespace, not a profile
+
+**Status**: accepted (issue #48, PR #264)
+
+## Context
+
+The server was built for Zendesk agents. Its per-user OAuth means it can equally
+serve **end users** — the customers who, on the web, open a ticket through the
+Help Center's "Submit a request" form. Issue #48 made that a first-class
+audience.
+
+An end user cannot use the agent ticket tools: `/api/v2/tickets` answers 403 for
+them, because `/api/v2/requests` is the path Zendesk reserves for requesters.
+So the end-user journey needs its own tools, and the question was how an
+operator selects them.
+
+The issue proposed a **profile** chosen at startup — `--profile end-user` —
+which would replace the agent ticket surface with the end-user one.
+
+## Decision
+
+No new configuration axis. The tools land in a **`requests` namespace**, absent
+from `DEFAULT_NAMESPACES`, selected with the existing `--namespace requests`.
+"End-user mode" survives as an *audience* in the README, not as a flag.
+
+Alongside it, a `--print-tools` flag prints the surface a given set of flags
+resolves to and exits.
+
+## Why not a profile
+
+**It would have been a third axis over the same thing.** `--namespace` and
+`--tool` already pick the inventory, `--mode` packages it, `--read-only`
+narrows it. A profile picks the inventory too, so it overlaps `--namespace`
+rather than composing with it — and the immediate question, put by the
+maintainer, was what `--profile end-user --namespace tickets --mode all` is
+supposed to mean. Additive? Forbidden? Whichever answer you pick, you have
+added a rule an operator must learn, to express something `--namespace` already
+expressed.
+
+**The ecosystem calls this a toolset, and puts it on one axis.** The [GitHub MCP
+server](https://docs.github.com/en/copilot/how-tos/provide-context/use-mcp-in-your-ide/configure-toolsets)
+groups tools into `toolsets`, with `default` and `all` keywords *inside* that
+axis rather than beside it. There is no "profile" convention in MCP to align
+with. Our `--namespace` is the same axis; adding to it was the conventional
+move.
+
+**The real question the profile was answering was legibility**, not capability:
+"what do I get if I combine these flags?" That is better answered by the server
+than by a flag whose interaction rules you then have to document —
+hence `--print-tools`, which answers it for every axis at once, needs no
+credential, and makes no network call.
+
+The cost is discoverability: "run it for your customers" is now
+`--namespace requests --namespace help_center`, which reads as plumbing rather
+than as choosing an audience. The README's End-user mode section carries that
+weight instead.
+
+## Why opt-in rather than on by default
+
+Adding `requests` to the enum without touching the default set would have been
+less code. It was rejected on evidence, not taste.
+
+A probe of the live API found that under an **agent** token, part of the
+Requests surface silently misbehaves rather than failing:
+
+- `PUT /requests/{id}` with `solved: true` returns **200 and changes nothing**.
+- A form's `required_in_portal` validation is **not applied** to agents: a
+  submission missing a portal-required field returns 201 with an empty subject.
+- `priority` and `type` are **stored** for an agent and **dropped** for an end
+  user.
+
+So shipping these tools to every agent install would ship an operation that
+reports success on a no-op. Secondarily, an agent install keeps its tool list
+and context budget unchanged.
+
+Note what this does **not** buy: Glama scores the flat surface, so the seven
+end-user tools are evaluated like any other, and the server score's `40% min`
+term means one thin definition drags everything down whether or not it sits
+behind a flag. Opt-in is a correctness decision, not a quality exemption.
+
+## Consequences
+
+- **The default namespace set is now explicit**, and no longer "every member of
+  the enum". That asymmetry is the one non-obvious rule this decision
+  introduces, and it is stated in `docs/configuration.md`.
+- **The default lives in `ConfigSchema`, not in `loadConfig`.** The integration
+  harness builds its config through `ConfigSchema.parse` and never calls
+  `loadConfig`, so a default applied there would not reach the tests — the
+  end-user tools would have been visible to every integration scenario while
+  absent in production.
+- **`namespaces` rejects an empty array** (`.min(1)`). `filterTools` reads `[]`
+  as "no filter at all", so an empty list would have exposed the opt-in
+  namespace by accident. `parseArgs` cannot produce `[]`, so refusing it costs
+  nothing.
+- **`--namespace` replaces the default set** rather than adding to it. That was
+  already true; it becomes load-bearing here, because `--namespace requests`
+  has to mean *only* the end-user surface for a customer-facing deployment.
+- **`NAMESPACE_LABELS` is typed `Record<Namespace, …>`** and moved to
+  `routing/registry.ts`. Its consumer skips a namespace whose label is missing,
+  so an incomplete map would have silently exposed no proxy for a whole
+  namespace with every test still green. It is now a compile error.
+- **The existing functional baselines needed no edit.** Scenarios 01, 02, 04
+  and 05 assert the default surface, and it did not change — which is itself
+  evidence the gate works.
+
+## Revisit if
+
+- **Zendesk ships its own end-user MCP server.** `GET /api/v2/account/settings`
+  already returns an undocumented `end_user_mcp` block (per-brand enablement,
+  OAuth or JWT auth, a request-update polling delay), disabled at the time of
+  writing, next to an `agent_mcp` one. Zendesk's published documentation covers
+  only the MCP *client*. If a first-party end-user server arrives with an
+  adequate scope, this surface becomes a compatibility layer at best.
+- **A third audience appears.** Two namespaces on one axis is comfortable;
+  several audiences each wanting a bundle of namespaces would be the point at
+  which a preset keyword (à la `--toolsets default,all`) earns its place —
+  inside the `--namespace` axis, still not beside it.

--- a/docs/end-user-onboarding.md
+++ b/docs/end-user-onboarding.md
@@ -1,0 +1,219 @@
+# Getting started as a customer
+
+This guide is for **customers** of a company that uses Zendesk — people who
+would normally open a support ticket through that company's help site. It lets
+you do the same thing from your AI assistant instead: describe the problem in
+conversation, attach a screenshot, then follow the ticket without going back to
+a web form.
+
+It assumes no programming. You will type a few commands, and you will be told
+what each one is for.
+
+If you are a **support agent** looking to work your queue from your assistant,
+you want the [README](../README.md) instead — that's the other half of this
+server.
+
+---
+
+## What you need first
+
+**1. An account on the company's help site.**
+
+Their help site looks like `https://<company>.zendesk.com/hc` — for example
+`https://acme.zendesk.com/hc`. Open it and sign in. If you have ever emailed
+their support, you probably already have an account; otherwise sign up, or use
+the "Sign in with Google" button if it's offered.
+
+Do this before anything else. If you can't sign in there, nothing below will
+work, and that's the company's help site to fix, not this tool.
+
+**2. The company's Zendesk name.**
+
+The `<company>` part of that address. In `https://acme.zendesk.com` it is
+`acme`. You'll need it in a moment. It is often, but not always, the company's
+own name — read it off the address bar rather than guessing.
+
+**3. Node.js 20 or later**, on your computer.
+
+Check what you have by opening a terminal and typing:
+
+```bash
+node --version
+```
+
+If that prints something like `v20.11.0` or higher, you're set. If it says the
+command isn't found, install it from [nodejs.org](https://nodejs.org) — the
+version they offer by default is fine.
+
+**4. One thing to ask the company for.**
+
+The server signs you in using something Zendesk calls an **OAuth client**, and
+only the company can create it. Ask their support or IT:
+
+> Could you set up a Zendesk OAuth client for the MCP server, and tell me its
+> client identifier? It needs `http://localhost:27439/callback` registered as a
+> redirect URL, and it should be a *public* client (no secret).
+
+They may already have one, in which case they'll just send you the identifier.
+It looks like a short word, e.g. `acme_zendesk`.
+
+> **Why you have to ask.** This is the one step you cannot do yourself, and it
+> is deliberate on Zendesk's side: it's what lets the company decide which
+> applications may act on their customers' behalf.
+
+---
+
+## Connecting it to your assistant
+
+You tell your assistant about the server by adding a few lines to its
+configuration file. Where that file lives depends on which assistant you use —
+the [MCP client wiring](../README.md#mcp-client-wiring) section of the README
+lists the paths.
+
+The lines to add:
+
+```json
+{
+  "mcpServers": {
+    "zendesk": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@fruggr/zendesk-mcp-server",
+        "acme",
+        "--namespace",
+        "requests",
+        "--namespace",
+        "help_center"
+      ],
+      "env": {
+        "ZENDESK_OAUTH_CLIENT_ID": "acme_zendesk"
+      }
+    }
+  }
+}
+```
+
+Replace **`acme`** with the company's Zendesk name and **`acme_zendesk`** with
+the client identifier they gave you. Leave everything else as it is.
+
+What those two `--namespace` lines mean: `requests` is the customer surface —
+submitting and following your own tickets. `help_center` lets the assistant
+search the company's help articles, which often answers the question without a
+ticket at all. Drop that second one if you'd rather it didn't.
+
+Then restart your assistant so it picks up the change.
+
+### Checking it before you start
+
+If you want to confirm the setup produces what you expect before signing in,
+run this in a terminal. It asks the server what tools it would offer and then
+exits — no sign-in, no connection to Zendesk:
+
+```bash
+npx -y @fruggr/zendesk-mcp-server acme --print-tools \
+  --namespace requests --namespace help_center
+```
+
+You should see `zendesk_requests` listed with seven operations under it.
+
+---
+
+## Signing in
+
+You don't sign in up front. The first time you actually ask your assistant to
+do something with Zendesk, a browser window opens on the company's sign-in
+page. Sign in there, and approve the request for access.
+
+That's it. The permission is remembered on your computer, so you won't be asked
+again for a while.
+
+**If the browser doesn't open**, the terminal prints a web address — copy it
+into your browser yourself.
+
+The sign-in has to happen in a real browser; there is no way to script it. That
+is Zendesk's design, and it's the same protection that stops anyone else from
+signing in as you.
+
+---
+
+## Using it
+
+Just describe what you need. Some examples:
+
+> *"I want to report a bug with Acme."*
+
+The assistant will look up what kinds of request Acme accepts, tell you what
+the bug form asks for, and ask you those questions — rather than making you
+fill in a form. Then it submits it.
+
+> *"Attach this screenshot to that."*
+
+Files go on the request when you submit it, or on any later reply.
+
+> *"What's the status of my tickets?"*
+
+Your requests, with what state each one is in.
+
+> *"Read me the latest on ticket 4312."*
+
+The whole conversation, with each reply attributed — you'll see which messages
+came from Acme's support team.
+
+> *"Tell them it's fixed and close it."*
+
+A reply, then the ticket marked solved.
+
+### Two behaviours worth knowing
+
+**Replying to a solved ticket reopens it.** If Acme marked your ticket solved
+and you reply, it goes back to open. That's usually what you want, but it is
+worth knowing that your message did that.
+
+**You can't always close a ticket yourself.** Zendesk only allows it once
+someone at Acme has picked the ticket up. Before that, the assistant will tell
+you so instead of pretending it worked — if you want to withdraw a request
+nobody has looked at yet, reply saying so and they'll close it.
+
+---
+
+## What you cannot do
+
+By design, and enforced by Zendesk rather than by this tool:
+
+- **See anyone else's tickets.** Only your own, ever.
+- **See internal notes.** Support agents write private notes to each other on
+  tickets; those never reach you, here or anywhere else.
+- **Set priority or urgency.** Say it's urgent in the message — a human reads
+  it. Zendesk ignores a priority a customer sets.
+- **Search across all tickets, or look up other people.** Those are agent
+  tools.
+
+---
+
+## When something goes wrong
+
+**"Permission denied", or the server says the token was refused.**
+Your account can reach the company's Zendesk, but not the customer surface.
+Usually the help site is closed to self-service. Check that you can sign in at
+`https://<company>.zendesk.com/hc` and open a request there by hand; if you
+can't, that's the thing to report to them.
+
+**"No request form is available to you."**
+The company hasn't published a form for customers. They need to make at least
+one ticket form visible to end users. Nothing to fix on your side.
+
+**The browser opens but the sign-in fails, or it loops.**
+The OAuth client's redirect URL probably doesn't match. Ask the company to
+confirm `http://localhost:27439/callback` is registered on it, exactly, and
+that the client is public rather than confidential.
+
+**It worked yesterday and now it asks me to sign in again.**
+Normal. Access expires and gets renewed; occasionally you sign in afresh.
+
+The fuller, more technical list:
+**[docs/troubleshooting.md](troubleshooting.md)**.
+
+---
+
+← Back to the [README](../README.md).

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -11,6 +11,17 @@ Two complementary ways to drive a running instance of this server against the
 Both boot the same `createMcpServer` the production entry point uses
 (`src/index.ts`), so what you test is the actual server, not a stub.
 
+## Why `.mcp.json` names every namespace
+
+The committed `.mcp.json` passes `--mode all` **and** lists all four namespaces
+explicitly. That is not redundant: `requests` (the end-user surface) is excluded
+from the default namespace set, so a bare `--mode all` would expose everything
+*except* those seven tools and live-testing them would be impossible. Listing
+the namespaces makes the rig show the whole surface.
+
+Add a namespace here when you add one to the enum, or it will be invisible to
+live testing.
+
 ## Auth note (important)
 
 This server is **OAuth 2.1 PKCE only**; there is no API-token mode. The PKCE

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -85,6 +85,27 @@ out every `write` tool before the proxies are built.
 </details>
 
 <details>
+<summary><strong>Requests</strong> (end-user surface, opt-in)</summary>
+
+The customer-facing half of the server: submitting and following one's *own*
+tickets, through the API path Zendesk reserves for requesters. Exposed only
+when asked for by name (`--namespace requests`) — see
+[End-user mode](../README.md#end-user-mode) for why, and for what a customer
+deliberately cannot do.
+
+| Tool | Description | Mode |
+|------|-------------|------|
+| `list_request_forms` | List the kinds of request a customer can submit (the Help Center's forms), with each one's customer-facing name and whether it is the account default | read |
+| `get_request_form` | Read what one form asks for: its fields in portal order, which are required, the exact values dropdowns accept, and any conditional rules — joins the form definition with the field definitions | read |
+| `list_requests` | List the caller's own requests with status and solvability; pass `query` to search them instead of listing all | read |
+| `get_request` | Read one of the caller's own requests, optionally with the full public conversation, each reply attributed and support agents marked | read |
+| `create_request` | Submit a new request on a chosen form, with attachments; refuses an unknown form id or a missing portal-required field rather than letting Zendesk substitute or accept silently | write |
+| `add_request_comment` | Reply on the caller's own request, optionally with attachments; reports the resulting status, since replying to a solved request reopens it | write |
+| `mark_request_solved` | Close the caller's own request, refusing when Zendesk would accept the update and change nothing (it only allows it once an agent is assigned) | write |
+
+</details>
+
+<details>
 <summary><strong>Search</strong></summary>
 
 | Tool | Description | Mode |

--- a/scripts/probe-request-shapes.ts
+++ b/scripts/probe-request-shapes.ts
@@ -33,11 +33,15 @@ if (!subdomain) {
   process.exit(1);
 }
 
+// `accessToken`, not `access_token`: the key is the one `PersistedToken` in
+// src/auth/token-persistence.ts writes, not the one Zendesk's OAuth response
+// uses. Reading the wrong one made this script claim "No token found" on a
+// machine that had signed in, and send whoever ran it hunting for a token.
 const readCachedToken = (): string | undefined => {
   try {
     const raw = readFileSync(resolveTokenPath(subdomain), 'utf8');
-    const parsed = JSON.parse(raw) as { access_token?: string };
-    return parsed.access_token;
+    const parsed = JSON.parse(raw) as { accessToken?: string };
+    return parsed.accessToken;
   } catch {
     return undefined;
   }

--- a/scripts/probe-request-shapes.ts
+++ b/scripts/probe-request-shapes.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env tsx
+/**
+ * READ-ONLY ground-truth capture for the end-user Requests surface (issue #48).
+ *
+ * Why this exists. `src/types.ts` declares `ZendeskTicketForm`,
+ * `ZendeskFormCondition` and `ZendeskRequestCommentAuthor` from a written API
+ * probe report rather than from payloads the implementer saw. The MCP tools
+ * cannot close that gap: they return *rendered* text, never the raw upstream
+ * JSON, so a field we named wrongly would render as a silently missing line
+ * rather than as an error. This prints the raw keys so the types can be
+ * checked against reality.
+ *
+ * It is strictly read-only: three GETs, no writes, no ticket created. It reuses
+ * the token the running server already uses -- either ZENDESK_OAUTH_TOKEN, or
+ * the cached token file for the subdomain.
+ *
+ * Usage:
+ *   pnpm tsx scripts/probe-request-shapes.ts
+ *
+ * Output is deliberately keys-and-types, not values: no subject, no body, no
+ * name, no email is printed, so it is safe to paste into a public PR comment.
+ * The one exception is `end_user_conditions`, printed in full because its shape
+ * is what we are least sure of and it contains only field ids and option
+ * values.
+ */
+import { readFileSync } from 'node:fs';
+import { resolveTokenPath } from '../src/auth/token-persistence';
+import { zendeskGet } from '../src/client/zendesk-api';
+
+const subdomain = process.env['ZENDESK_SUBDOMAIN'];
+if (!subdomain) {
+  console.error('Set ZENDESK_SUBDOMAIN (the same one the running server uses).');
+  process.exit(1);
+}
+
+const readCachedToken = (): string | undefined => {
+  try {
+    const raw = readFileSync(resolveTokenPath(subdomain), 'utf8');
+    const parsed = JSON.parse(raw) as { access_token?: string };
+    return parsed.access_token;
+  } catch {
+    return undefined;
+  }
+};
+
+const token = process.env['ZENDESK_OAUTH_TOKEN'] ?? readCachedToken();
+if (!token) {
+  console.error(
+    'No token found. Export ZENDESK_OAUTH_TOKEN, or sign in once through the ' +
+      'running server so the token file is written. This script never starts an OAuth flow.',
+  );
+  process.exit(1);
+}
+
+const describeValue = (val: unknown): string => {
+  if (val === null) return 'null';
+  if (Array.isArray(val)) return `array[${val.length}]`;
+  return typeof val;
+};
+
+/** Key → runtime type, so a missing or misnamed field is obvious. */
+const shapeOf = (value: unknown): Record<string, string> => {
+  if (value === null || typeof value !== 'object') return {};
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, val]) => [key, describeValue(val)]),
+  );
+};
+
+const section = (title: string): void => {
+  console.log(`\n${'='.repeat(72)}\n${title}\n${'='.repeat(72)}`);
+};
+
+const main = async (): Promise<void> => {
+  section('1. GET /ticket_forms?active=true&end_user_visible=true&fallback_to_default=true');
+  const forms = await zendeskGet<{ ticket_forms?: Record<string, unknown>[] }>(
+    subdomain,
+    token,
+    '/ticket_forms',
+    { active: 'true', end_user_visible: 'true', fallback_to_default: 'true' },
+  );
+  const formList = forms.ticket_forms ?? [];
+  console.log(`forms returned: ${formList.length}`);
+  console.log('keys on the first form:', shapeOf(formList[0]));
+  // The one place we print values: ids and option values only, and it is the
+  // shape src/types.ts is least sure of.
+  for (const form of formList) {
+    const conditions = form['end_user_conditions'];
+    console.log(`form ${String(form['id'])}: end_user_conditions =`, JSON.stringify(conditions));
+  }
+
+  section('2. GET /ticket_fields (first page) — the portal flags');
+  const fields = await zendeskGet<{
+    ticket_fields?: Record<string, unknown>[];
+    count?: number;
+    next_page?: string | null;
+  }>(subdomain, token, '/ticket_fields', { per_page: '100' });
+  const fieldList = fields.ticket_fields ?? [];
+  console.log(
+    `fields returned: ${fieldList.length} | count says: ${String(fields.count)} | next_page: ${
+      fields.next_page ? 'present' : 'null'
+    }`,
+  );
+  console.log('keys on the first field:', shapeOf(fieldList[0]));
+  const portalKeys = [
+    'visible_in_portal',
+    'required_in_portal',
+    'editable_in_portal',
+    'title_in_portal',
+  ];
+  for (const key of portalKeys) {
+    const present = fieldList.filter((f) => key in f).length;
+    console.log(`  ${key}: present on ${present}/${fieldList.length}`);
+  }
+
+  section('3. GET /requests/{id}/comments — the users sideload');
+  const requests = await zendeskGet<{ requests?: Record<string, unknown>[] }>(
+    subdomain,
+    token,
+    '/requests',
+    { per_page: '1' },
+  );
+  const first = (requests.requests ?? [])[0];
+  if (!first) {
+    console.log('No request is visible to this token, so the sideload cannot be captured here.');
+    console.log('Report this as a partial result rather than a failure.');
+    return;
+  }
+  console.log('keys on a request:', shapeOf(first));
+  const comments = await zendeskGet<{
+    comments?: Record<string, unknown>[];
+    users?: Record<string, unknown>[];
+  }>(subdomain, token, `/requests/${String(first['id'])}/comments`);
+  console.log(`comments: ${(comments.comments ?? []).length}`);
+  console.log('keys on a comment:', shapeOf((comments.comments ?? [])[0]));
+  console.log(
+    'users sideload present:',
+    comments.users !== undefined,
+    '| keys on a sideloaded user:',
+    shapeOf((comments.users ?? [])[0]),
+  );
+};
+
+main().catch((error: unknown) => {
+  console.error('Probe failed:', error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -395,6 +395,15 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
 
   const mode = cli.tools?.length ? 'all' : (cli.mode ?? 'namespace');
 
+  // `--tool` is an inventory picker in its own right: before the namespace
+  // default existed it could name ANY tool, because no namespace filter was
+  // applied. `filterTools` ANDs the two filters, so leaving the default in
+  // place would make `--tool list_requests` resolve to nothing at all -- the
+  // tool exists, but its namespace is not in the default set. So an explicit
+  // `--tool` without an explicit `--namespace` opens the namespace filter to
+  // everything and lets `--tool` do the narrowing.
+  const namespaces = cli.namespaces ?? (cli.tools?.length ? [...Namespace.options] : undefined);
+
   const callbackPort =
     cli.callbackPort ??
     parsePortEnv(requireNonEmptyEnv('ZENDESK_OAUTH_CALLBACK_PORT'), 'ZENDESK_OAUTH_CALLBACK_PORT');
@@ -409,7 +418,7 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
     logLevel: cli.logLevel ?? requireNonEmptyEnv('LOG_LEVEL') ?? 'info',
     mode,
     readOnly: cli.readOnly ?? false,
-    namespaces: cli.namespaces,
+    namespaces,
     tools: cli.tools,
     topology: cli.topology ?? true,
     promotedArticles: cli.promotedArticles ?? true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,8 +7,28 @@ export type ToolMode = z.infer<typeof ToolMode>;
 export const LogLevel = z.enum(['debug', 'info', 'warn', 'error']);
 export type LogLevel = z.infer<typeof LogLevel>;
 
-export const Namespace = z.enum(['tickets', 'help_center', 'users']);
+export const Namespace = z.enum(['tickets', 'help_center', 'users', 'requests']);
 export type Namespace = z.infer<typeof Namespace>;
+
+/**
+ * Namespaces exposed when the operator passes no `--namespace` flag.
+ *
+ * Deliberately NOT every member of the enum: `requests` is the end-user
+ * surface (issue #48) and is opt-in. Two reasons, in order of weight.
+ *
+ * 1. Under an agent token, part of that surface silently misbehaves rather
+ *    than failing: `PUT /requests/{id}` with `solved: true` returns 200 and
+ *    changes nothing, and Zendesk does not apply a form's `required_in_portal`
+ *    validation to agents. Registering those tools for every agent install
+ *    would ship an operation that reports success on a no-op.
+ * 2. An agent install keeps its tool list and context budget unchanged.
+ *
+ * A deployment serving customers opts in with `--namespace requests`
+ * (typically alongside `--namespace help_center`, so they can read the
+ * knowledge base before opening a ticket). `--print-tools` shows the resulting
+ * surface without starting a server.
+ */
+export const DEFAULT_NAMESPACES: readonly Namespace[] = ['tickets', 'help_center', 'users'];
 
 export const Transport = z.enum(['stdio', 'http']);
 export type Transport = z.infer<typeof Transport>;
@@ -19,7 +39,26 @@ export const ConfigSchema = z.object({
   logLevel: LogLevel,
   mode: ToolMode,
   readOnly: z.boolean(),
-  namespaces: z.array(Namespace).optional(),
+  /**
+   * Active namespaces. Defaults to DEFAULT_NAMESPACES (which excludes the
+   * opt-in `requests` surface) rather than to "everything".
+   *
+   * The default lives HERE and not in `loadConfig` on purpose: the integration
+   * harness builds its Config through `ConfigSchema.parse` and never calls
+   * `loadConfig`, so a default applied there would not reach the tests — the
+   * `requests` tools would be visible to every integration scenario while
+   * absent in production.
+   *
+   * `.min(1)` rejects an explicit empty array. `filterTools` treats `[]` as
+   * "no filter at all" (it guards on `?.length`), so an empty list would quietly
+   * expose every namespace including the opt-in one. `parseArgs` cannot produce
+   * `[]` — a repeatable flag left out is `undefined` — so refusing it costs
+   * nothing and keeps the invariant explicit.
+   */
+  namespaces: z
+    .array(Namespace)
+    .min(1)
+    .default([...DEFAULT_NAMESPACES]),
   tools: z.array(z.string()).optional(),
   /**
    * Whether to expose the Help Center structural context (the `instructions`
@@ -88,6 +127,14 @@ export const ConfigSchema = z.object({
    * the "Dev mode" section of docs/configuration.md.
    */
   dev: z.boolean().default(false),
+  /**
+   * Print the tool surface the current flags resolve to, then exit without
+   * starting a server or touching the network. `--print-tools` exists because
+   * the surface is shaped by three independent knobs (`--namespace` / `--tool`
+   * pick the inventory, `--mode` packages it, `--read-only` narrows it) and
+   * their combination is easier to read off a listing than to predict.
+   */
+  printTools: z.boolean().default(false),
   transport: Transport,
   host: z.string().min(1),
   port: z.number().int().min(0).max(65535),
@@ -132,6 +179,7 @@ interface CliResult {
   promotedArticles?: boolean;
   hcResourceScheme?: string;
   dev?: boolean;
+  printTools?: boolean;
   logLevel?: string;
   transport?: string;
   host?: string;
@@ -208,6 +256,7 @@ const CLI_OPTIONS = {
   'no-topology': { type: 'boolean' },
   'no-promoted-articles': { type: 'boolean' },
   dev: { type: 'boolean' },
+  'print-tools': { type: 'boolean' },
 } as const satisfies ParseArgsConfig['options'];
 
 // The value-taking subset, spelled as they appear on the command line. Exported
@@ -241,6 +290,7 @@ const STANDALONE_EFFECTS = new Map<string, Partial<CliResult>>([
   ['no-topology', { topology: false }],
   ['no-promoted-articles', { promotedArticles: false }],
   ['dev', { dev: true }],
+  ['print-tools', { printTools: true }],
 ]);
 
 const parseCliArgs = (args: string[]): CliResult => {
@@ -365,6 +415,7 @@ export const loadConfig = (argv: string[] = process.argv.slice(2)): Config => {
     promotedArticles: cli.promotedArticles ?? true,
     hcResourceScheme,
     dev: cli.dev ?? false,
+    printTools: cli.printTools ?? false,
     callbackPort,
     ...resolveTransportSettings(cli),
   });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,6 +67,18 @@ export const MAX_EMBEDDED_IMAGE_COUNT = positiveIntEnv('ZENDESK_MAX_EMBEDDED_IMA
 // Overridable via ZENDESK_MAX_COMMENT_PAGES for tickets with many comments.
 export const MAX_COMMENT_PAGES = positiveIntEnv('ZENDESK_MAX_COMMENT_PAGES', 10);
 
+// Max /ticket_fields pages scanned when resolving a request form's fields. That
+// endpoint cannot be trusted to say when it is done: under an end-user token its
+// `count` is the UNFILTERED total (27 while returning 8 rows with
+// `next_page: null`), and in cursor mode `page[size]` is applied before the
+// visibility filter, so a short page is not the last page. We therefore follow
+// `next_page` alone and bound the walk here. Override via
+// ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES.
+export const TICKET_FIELD_SCAN_MAX_PAGES = positiveIntEnv(
+  'ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES',
+  10,
+);
+
 // Blast-radius guard for reorder_article. Reordering an article can require
 // rewriting the `position` of several neighbours (to break ties or shift a run);
 // if that write set exceeds this many articles the tool refuses unless the caller

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import { createTokenStore } from './auth/token-store';
 import type { Config } from './config';
 import { loadConfig } from './config';
 import { startDevServer } from './dev/reload';
+import { renderToolSurface } from './routing/print';
 import { createMcpServer } from './server';
+import { createAllTools } from './tools/index';
 import { startHttpTransport } from './transports/http';
 import { startStdioTransport } from './transports/stdio';
 import { createLogger, type Logger } from './utils/logger';
@@ -39,6 +41,17 @@ const connectStdio = async (
 
 const main = async (): Promise<void> => {
   const config = loadConfig();
+
+  // Diagnostic short-circuit: print the surface these flags resolve to and
+  // exit. Before the token store is built, and before any transport, because
+  // tool definitions are pure — auth only fires inside a handler — so this
+  // never needs a credential or a network call.
+  if (config.printTools) {
+    const tools = createAllTools({ subdomain: config.subdomain, getToken: () => '' });
+    console.log(renderToolSurface(config, tools));
+    return;
+  }
+
   const logger = createLogger(config.logLevel);
 
   if (config.transport === 'stdio') {

--- a/src/routing/print.ts
+++ b/src/routing/print.ts
@@ -20,10 +20,7 @@ const renderAllMode = (tools: ToolDefinition[]): string[] => [
   ...tools.map((tool) => toolLine(tool, '  ')),
 ];
 
-// `prefix` carries the `[RO]` marker the proxy descriptions themselves use in
-// read-only mode, so the listing matches what a client that ignores annotations
-// actually reads.
-const renderNamespaceMode = (tools: ToolDefinition[], prefix: string): string[] => {
+const renderNamespaceMode = (tools: ToolDefinition[]): string[] => {
   const grouped = groupByNamespace(tools);
   const lines = [`${grouped.size} proxy tool(s) exposed:`];
   for (const [namespace, nsTools] of grouped) {
@@ -31,27 +28,26 @@ const renderNamespaceMode = (tools: ToolDefinition[], prefix: string): string[] 
     // Record<Namespace, ...>, so this lookup cannot miss -- an incomplete map is a
     // compile error. The `?.` exists only to satisfy noUncheckedIndexedAccess,
     // which makes the fallback unreachable and untestable.
-    lines.push(`  ${prefix}${NAMESPACE_LABELS[namespace]?.toolName ?? namespace}`);
+    lines.push(`  ${NAMESPACE_LABELS[namespace]?.toolName ?? namespace}`);
     lines.push(...nsTools.map((tool) => toolLine(tool, '    - ')));
   }
   return lines;
 };
 
-const renderSingleMode = (tools: ToolDefinition[], prefix: string): string[] => [
+const renderSingleMode = (tools: ToolDefinition[]): string[] => [
   `1 proxy tool exposed, wrapping ${tools.length} operation(s):`,
-  `  ${prefix}zendesk`,
+  '  zendesk',
   ...tools.map((tool) => toolLine(tool, '    - ')),
 ];
 
 const renderBody = (config: Config, tools: ToolDefinition[]): string[] => {
-  const prefix = config.readOnly ? '[RO] ' : '';
   switch (config.mode) {
     case 'all':
       return renderAllMode(tools);
     case 'namespace':
-      return renderNamespaceMode(tools, prefix);
+      return renderNamespaceMode(tools);
     case 'single':
-      return renderSingleMode(tools, prefix);
+      return renderSingleMode(tools);
     default: {
       // Closed union; the guard is for a mode fed in by a hand-edited config.
       const unhandled: never = config.mode;
@@ -74,12 +70,20 @@ const renderBody = (config: Config, tools: ToolDefinition[]): string[] => {
  * would drag in a transport. The duplication is three branches wide and is
  * pinned by tests asserting this output against the names the integration
  * harness sees over the wire.
+ *
+ * Every name printed is a name a client would actually see. Read-only mode is
+ * stated in the header rather than as a `[RO]` prefix on the names: the server
+ * puts that marker in a proxy's *description*, never in its name, and printing
+ * `[RO] zendesk_tickets` here would name a tool that does not exist.
  */
 export const renderToolSurface = (config: Config, tools: ToolDefinition[]): string => {
+  // Same call `registerToolset` makes, flag for flag: the point of this output
+  // is that it matches the running server, so it must not filter differently.
   const filtered = filterTools(tools, {
     readOnly: config.readOnly,
     namespaces: config.namespaces,
     tools: config.tools,
+    promotedArticles: config.promotedArticles,
   });
 
   const header = renderHeader(config);

--- a/src/routing/print.ts
+++ b/src/routing/print.ts
@@ -1,0 +1,90 @@
+import type { Config } from '../config';
+import type { ToolDefinition } from '../tools/definitions';
+import { filterTools, groupByNamespace, NAMESPACE_LABELS } from './registry';
+
+/** `name (write)` for a write tool, bare `name` for a read one. */
+const toolLine = (tool: ToolDefinition, indent: string): string =>
+  `${indent}${tool.name}${tool.readOnly ? '' : ' (write)'}`;
+
+/** The knobs in force, on one line, so the listing below is self-explaining. */
+const renderHeader = (config: Config): string =>
+  [
+    `Mode: ${config.mode}`,
+    `Namespaces: ${config.namespaces.join(', ')}`,
+    `Read-only: ${config.readOnly ? 'yes' : 'no'}`,
+    ...(config.tools?.length ? [`Tool filter: ${config.tools.join(', ')}`] : []),
+  ].join(' | ');
+
+const renderAllMode = (tools: ToolDefinition[]): string[] => [
+  `${tools.length} tool(s) exposed individually:`,
+  ...tools.map((tool) => toolLine(tool, '  ')),
+];
+
+// `prefix` carries the `[RO]` marker the proxy descriptions themselves use in
+// read-only mode, so the listing matches what a client that ignores annotations
+// actually reads.
+const renderNamespaceMode = (tools: ToolDefinition[], prefix: string): string[] => {
+  const grouped = groupByNamespace(tools);
+  const lines = [`${grouped.size} proxy tool(s) exposed:`];
+  for (const [namespace, nsTools] of grouped) {
+    // Stryker disable next-line OptionalChaining: NAMESPACE_LABELS is typed
+    // Record<Namespace, ...>, so this lookup cannot miss -- an incomplete map is a
+    // compile error. The `?.` exists only to satisfy noUncheckedIndexedAccess,
+    // which makes the fallback unreachable and untestable.
+    lines.push(`  ${prefix}${NAMESPACE_LABELS[namespace]?.toolName ?? namespace}`);
+    lines.push(...nsTools.map((tool) => toolLine(tool, '    - ')));
+  }
+  return lines;
+};
+
+const renderSingleMode = (tools: ToolDefinition[], prefix: string): string[] => [
+  `1 proxy tool exposed, wrapping ${tools.length} operation(s):`,
+  `  ${prefix}zendesk`,
+  ...tools.map((tool) => toolLine(tool, '    - ')),
+];
+
+const renderBody = (config: Config, tools: ToolDefinition[]): string[] => {
+  const prefix = config.readOnly ? '[RO] ' : '';
+  switch (config.mode) {
+    case 'all':
+      return renderAllMode(tools);
+    case 'namespace':
+      return renderNamespaceMode(tools, prefix);
+    case 'single':
+      return renderSingleMode(tools, prefix);
+    default: {
+      // Closed union; the guard is for a mode fed in by a hand-edited config.
+      const unhandled: never = config.mode;
+      throw new Error(`Unsupported tool mode: ${String(unhandled)}`);
+    }
+  }
+};
+
+/**
+ * Render the tool surface `config` resolves to, as `registerToolset` would
+ * expose it, without starting a server or issuing a single request.
+ *
+ * The surface is shaped by three independent knobs — `--namespace` / `--tool`
+ * pick the inventory, `--mode` packages it, `--read-only` narrows it — and their
+ * combination is far easier to read off a listing than to predict. This is what
+ * `--print-tools` prints.
+ *
+ * It mirrors the `switch (config.mode)` in `registerToolset` rather than
+ * calling it: registration needs a live `McpServer`, and building one here
+ * would drag in a transport. The duplication is three branches wide and is
+ * pinned by tests asserting this output against the names the integration
+ * harness sees over the wire.
+ */
+export const renderToolSurface = (config: Config, tools: ToolDefinition[]): string => {
+  const filtered = filterTools(tools, {
+    readOnly: config.readOnly,
+    namespaces: config.namespaces,
+    tools: config.tools,
+  });
+
+  const header = renderHeader(config);
+  if (filtered.length === 0) {
+    return `${header}\n\nNo tools exposed. Check --namespace / --tool / --read-only.`;
+  }
+  return [header, '', ...renderBody(config, filtered)].join('\n');
+};

--- a/src/routing/registry.ts
+++ b/src/routing/registry.ts
@@ -15,12 +15,29 @@ export const filterTools = (allTools: ToolDefinition[], options: FilterOptions):
     return true;
   });
 
-export const groupByNamespace = (tools: ToolDefinition[]): Map<string, ToolDefinition[]> => {
-  const grouped = new Map<string, ToolDefinition[]>();
+export const groupByNamespace = (tools: ToolDefinition[]): Map<Namespace, ToolDefinition[]> => {
+  const grouped = new Map<Namespace, ToolDefinition[]>();
   for (const tool of tools) {
     const existing = grouped.get(tool.namespace) ?? [];
     existing.push(tool);
     grouped.set(tool.namespace, existing);
   }
   return grouped;
+};
+
+/**
+ * Proxy tool name and title per namespace, used by `namespace` mode.
+ *
+ * Typed `Record<Namespace, …>` rather than `Record<string, …>` so the compiler
+ * rejects this literal outright when a namespace is added to the enum without
+ * a label here. That matters because the consumer looks the label up and skips
+ * the namespace when it is missing: an incomplete map would silently expose no
+ * proxy for a whole namespace, with every existing test still green. Making it
+ * a type error is stronger than any test could be.
+ */
+export const NAMESPACE_LABELS: Record<Namespace, { toolName: string; title: string }> = {
+  tickets: { toolName: 'zendesk_tickets', title: 'Zendesk Tickets' },
+  help_center: { toolName: 'zendesk_help_center', title: 'Zendesk Help Center' },
+  users: { toolName: 'zendesk_users', title: 'Zendesk Users' },
+  requests: { toolName: 'zendesk_requests', title: 'Zendesk Requests' },
 };

--- a/src/routing/registry.ts
+++ b/src/routing/registry.ts
@@ -1,17 +1,37 @@
 import type { Namespace } from '../config';
+import { LIST_PROMOTED_ARTICLES_TOOL } from '../guidance/article-resources';
 import type { ToolDefinition } from '../tools/definitions';
 
 export interface FilterOptions {
   readOnly: boolean;
   namespaces?: Namespace[] | undefined;
   tools?: string[] | undefined;
+  /**
+   * Mirrors `config.promotedArticles`. When explicitly false
+   * (`--no-promoted-articles`), `list_promoted_articles` is dropped: that
+   * listing must make ZERO Zendesk calls, and gating only the resource `list`
+   * callback would leave the tool callable and still scanning. `!== false` so a
+   * hand-built config without the field keeps the default-on behaviour.
+   */
+  promotedArticles?: boolean | undefined;
 }
 
+/**
+ * The single authority on which tools a config exposes.
+ *
+ * Every filter lives here rather than at the call sites, because there is more
+ * than one consumer -- `registerToolset` registers them and `renderToolSurface`
+ * prints them -- and a filter applied in only one of the two makes
+ * `--print-tools` lie about the running server.
+ */
 export const filterTools = (allTools: ToolDefinition[], options: FilterOptions): ToolDefinition[] =>
   allTools.filter((tool) => {
     if (options.readOnly && !tool.readOnly) return false;
     if (options.namespaces?.length && !options.namespaces.includes(tool.namespace)) return false;
     if (options.tools?.length && !options.tools.includes(tool.name)) return false;
+    if (options.promotedArticles === false && tool.name === LIST_PROMOTED_ARTICLES_TOOL) {
+      return false;
+    }
     return true;
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,10 +3,7 @@ import * as z from 'zod/v4';
 import { ZendeskApiError } from './client/zendesk-api';
 import type { Config } from './config';
 import { ARTICLE_RESOURCES_SCAN_MAX_PAGES } from './constants';
-import {
-  createArticleResourcesProvider,
-  LIST_PROMOTED_ARTICLES_TOOL,
-} from './guidance/article-resources';
+import { createArticleResourcesProvider } from './guidance/article-resources';
 import {
   articleResourceEnabled,
   articleResourceUri,
@@ -227,19 +224,15 @@ export const registerToolset = (
     for (const handle of registered) handle.remove();
   };
 
-  // Apply filters (--read-only, --namespace, --tool)
+  // Apply filters (--read-only, --namespace, --tool, --no-promoted-articles).
+  // All of them live in filterTools so `--print-tools` renders exactly this set;
+  // a filter applied only here would make that diagnostic lie.
   const filteredTools = filterTools(tools, {
     readOnly: config.readOnly,
     namespaces: config.namespaces,
     tools: config.tools,
-  })
-    // When the promoted pre-listing is disabled (`--no-promoted-articles`), also
-    // drop the companion `list_promoted_articles` tool. That listing must then make
-    // ZERO Zendesk calls: gating only the resource `list` callback (below) would
-    // leave the tool callable, and its promoted-article scan would still hit the
-    // API. Read-by-id (`<scheme>://article/{id}`) is unaffected — it stays
-    // registered. `!== false` so an unset flag (hand-built configs) keeps default-on.
-    .filter((t) => config.promotedArticles !== false || t.name !== LIST_PROMOTED_ARTICLES_TOOL);
+    promotedArticles: config.promotedArticles,
+  });
 
   // Registration is atomic: if any registerTool/registerResource throws partway
   // (e.g. a hot-reloaded module introduced a duplicate tool name), roll back the

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ import {
   topologyResourceUri,
 } from './guidance/instructions';
 import { createTopologyProvider } from './guidance/topology';
-import { filterTools, groupByNamespace } from './routing/registry';
+import { filterTools, groupByNamespace, NAMESPACE_LABELS } from './routing/registry';
 import type { ToolAnnotations, ToolResult } from './tools/definitions';
 import { createAllTools, type ToolDefinition } from './tools/index';
 import { type Logger, silentLogger } from './utils/logger';
@@ -51,12 +51,6 @@ const runHandler = async (
     }
     throw err;
   }
-};
-
-const NAMESPACE_LABELS: Record<string, { toolName: string; title: string }> = {
-  tickets: { toolName: 'zendesk_tickets', title: 'Zendesk Tickets' },
-  help_center: { toolName: 'zendesk_help_center', title: 'Zendesk Help Center' },
-  users: { toolName: 'zendesk_users', title: 'Zendesk Users' },
 };
 
 // Keep proxy descriptions compact: a proxy tool concatenates one line per
@@ -276,6 +270,9 @@ export const registerToolset = (
       case 'namespace': {
         const grouped = groupByNamespace(filteredTools);
         for (const [namespace, nsTools] of grouped) {
+          // Total by construction: NAMESPACE_LABELS is typed Record<Namespace, ...>,
+          // so a namespace without a label is a compile error, not a silent skip.
+          // The guard is only here for noUncheckedIndexedAccess.
           const label = NAMESPACE_LABELS[namespace];
           if (label) {
             registered.push(

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -1,0 +1,56 @@
+import * as z from 'zod/v4';
+import { zendeskUpload } from '../client/zendesk-api';
+import type { ZendeskUpload } from '../types';
+
+/**
+ * File-attachment input, shared by every tool that can carry files on a comment.
+ *
+ * Lives here rather than inside a tool factory because both audiences need it:
+ * an agent attaching a screenshot to a public reply, and an end user attaching a
+ * log to their own request. The Uploads API (`POST /api/v2/uploads.json`) is
+ * documented as allowed for end users, so the same code path serves both.
+ */
+export const attachmentSchema = z.object({
+  file_name: z.string().min(1).describe('File name, e.g. "app.log" or "screenshot.png".'),
+  file_base64: z.string().min(1).base64().describe('File content encoded as base64.'),
+  content_type: z
+    .string()
+    .min(1)
+    .default('application/octet-stream')
+    .describe('MIME type, e.g. "text/plain", "image/png", "application/pdf".'),
+});
+
+export type AttachmentInput = z.infer<typeof attachmentSchema>;
+
+/**
+ * Upload each file via the Zendesk Uploads API, aggregating them under a single
+ * upload token (the token from the first upload is passed to the next), and
+ * return that token for use in a comment's `uploads` array.
+ *
+ * Sequential on purpose: the aggregation is what makes one token carry several
+ * files, and it requires the previous token as input, so the calls cannot be
+ * parallelized.
+ */
+export const uploadAttachments = async (
+  subdomain: string,
+  token: string,
+  files: AttachmentInput[],
+): Promise<string> => {
+  let uploadToken: string | undefined;
+  for (const file of files) {
+    const { upload } = await zendeskUpload<{ upload: ZendeskUpload }>(
+      subdomain,
+      token,
+      file.file_name,
+      Buffer.from(file.file_base64, 'base64'),
+      file.content_type,
+      uploadToken,
+    );
+    uploadToken = upload.token;
+  }
+  return uploadToken as string;
+};
+
+/** ` with N attachment(s)` for a confirmation message, or '' when there are none. */
+export const formatAttachmentSuffix = (count?: number): string =>
+  count ? ` with ${count} attachment(s)` : '';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 import type { ToolContext, ToolDefinition } from './definitions';
 import { createHelpCenterTools } from './help-center';
+import { createRequestTools } from './requests';
 import { createSearchTools } from './search';
 import { createTicketTools } from './tickets';
 import { createUserTools } from './users';
@@ -8,6 +9,7 @@ export type { ToolContext, ToolDefinition } from './definitions';
 
 export const createAllTools = (ctx: ToolContext): ToolDefinition[] => [
   ...createTicketTools(ctx),
+  ...createRequestTools(ctx),
   ...createSearchTools(ctx),
   ...createHelpCenterTools(ctx),
   ...createUserTools(ctx),

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -973,8 +973,10 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
           after.status === 'solved'
             ? `Request #${request_id} is now **solved**.`
             : `Zendesk accepted the update but request #${request_id} is still **${after.status}**, ` +
-              'so it was not solved. This usually means the assignment changed between the check ' +
-              'and the update; re-read it with get_request.';
+              'so it was not solved. Two causes produce this silently: the token belongs to an ' +
+              'agent rather than to the requester -- Zendesk answers 200 and ignores `solved` for ' +
+              'them -- or the assignment changed between the check and the update. Re-read it ' +
+              'with get_request.';
         return { content: [{ type: 'text', text }] };
       },
     },

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -235,6 +235,11 @@ const fetchAllRequestComments = async (
     tool: 'get_request',
     path: `/requests/${requestId}/comments`,
     extract: (response) => response.comments,
+    // Asked for explicitly rather than relying on the default: `users` is a
+    // documented sideload of this endpoint, and a sideload that has to be named
+    // to arrive would leave every comment attributed to a bare id. Harmless
+    // when it comes back anyway.
+    params: { include: 'users' },
     maxPages: MAX_COMMENT_PAGES,
     capEnvVar: 'ZENDESK_MAX_COMMENT_PAGES',
     onPage: (response) => {
@@ -264,6 +269,11 @@ const SYSTEM_FIELD_TYPES: ReadonlySet<string> = new Set([
   'group',
   'assignee',
   'tags',
+  // The Ticket status field on accounts using custom ticket statuses. Agent-set
+  // like `status`, and listed here for the same reason: left out, a form
+  // carrying it as portal-required would make create_request demand a value in
+  // `custom_fields` that no submitter can supply.
+  'custom_status',
 ]);
 
 const isCustomField = (field: ZendeskTicketField): boolean => !SYSTEM_FIELD_TYPES.has(field.type);
@@ -428,8 +438,16 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
           'ticket with create_ticket (namespace: tickets).',
       );
     }
+    // With no id given, the account default is the right answer -- but a single
+    // visible form that is NOT the default is a real shape (the default form can
+    // be hidden from end users, and `fallback_to_default` only fires when
+    // NOTHING matched), and refusing it would break the promise that an account
+    // with one form gets that one. With several forms and no default, there is
+    // nothing to guess from and the refusal below stands.
     const form =
-      formId === undefined ? forms.find((f) => f.default) : forms.find((f) => f.id === formId);
+      formId === undefined
+        ? (forms.find((f) => f.default) ?? (forms.length === 1 ? forms[0] : undefined))
+        : forms.find((f) => f.id === formId);
     if (!form) {
       const available = forms.map((f) => `${f.display_name || f.name} (${f.id})`).join(', ');
       throw new Error(
@@ -478,7 +496,19 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
           '',
           'Call get_request_form with a form id to see the questions it asks.',
         ].join('\n');
-        return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
+        // This tool takes no page or filter, so the default truncation advice
+        // would send the caller in circles (#265). Name what can be done.
+        return {
+          content: [
+            {
+              type: 'text',
+              text: truncateIfNeeded(
+                text,
+                'list_request_forms takes no parameters, so this listing cannot be narrowed from the call; read one form in full with get_request_form.',
+              ),
+            },
+          ],
+        };
       },
     },
     {
@@ -508,7 +538,15 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
         const token = await getToken();
         const { form, fields } = await resolveForm('get_request_form', token, form_id);
         return {
-          content: [{ type: 'text', text: truncateIfNeeded(renderFormSpec(form, fields)) }],
+          content: [
+            {
+              type: 'text',
+              text: truncateIfNeeded(
+                renderFormSpec(form, fields),
+                'get_request_form takes only form_id, so this description cannot be narrowed from the call; the fields it lists are the ones this form asks for.',
+              ),
+            },
+          ],
         };
       },
     },
@@ -737,7 +775,13 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
           const thread = comments.map((c) => formatRequestComment(c, authors)).join('\n\n');
           text += `\n\n---\n# Conversation\n\n${thread}`;
         }
-        return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
+        // Neither parameter narrows the payload, so the default "use pagination
+        // or filters" advice would send the caller in circles (#265): the one
+        // thing that shrinks this response is dropping the conversation.
+        const advice = include_comments
+          ? `get_request appends the whole conversation as one unpaginated block; call it again with include_comments false to read request #${request_id}'s status and description alone.`
+          : 'get_request takes no pagination or filter parameters, so this response cannot be narrowed from the call.';
+        return { content: [{ type: 'text', text: truncateIfNeeded(text, advice) }] };
       },
     },
     {

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -91,7 +91,17 @@ const END_USER_FORM_PARAMS = {
  * form invisible or a required field unenforced, and the caller then gets a
  * confidently wrong "no such form" or an opaque Zendesk 422.
  */
-interface PageWalk<T, R extends ZendeskListResponse<T>> {
+/**
+ * All the walker itself reads off a page. `extract` and `onPage` supply the
+ * rest, so the response need not be a `ZendeskListResponse<T>` -- which matters
+ * for a listing whose sideload is not of type `T` (see
+ * `RequestCommentsResponse`).
+ */
+interface PagedResponse {
+  next_page?: string | null;
+}
+
+interface PageWalk<T, R extends PagedResponse> {
   subdomain: string;
   token: string;
   tool: string;
@@ -106,7 +116,7 @@ interface PageWalk<T, R extends ZendeskListResponse<T>> {
   onPage?: (response: R) => void;
 }
 
-const fetchAllPages = async <T, R extends ZendeskListResponse<T> = ZendeskListResponse<T>>({
+const fetchAllPages = async <T, R extends PagedResponse = ZendeskListResponse<T>>({
   subdomain,
   token,
   tool,
@@ -204,7 +214,12 @@ const fetchVisibleTicketFields = async (
  * attributes each comment, and a later page's authors need not appear in the
  * first page's.
  */
-type RequestCommentsResponse = ZendeskListResponse<ZendeskComment> & {
+// `users` is omitted before being re-declared: `ZendeskListResponse<T>` types
+// every sideload key as `T[]`, so a plain intersection would make each author a
+// `ZendeskComment & ZendeskRequestCommentAuthor`. That compiles, and it lets a
+// comment field be read off an author record that never carries one -- exactly
+// the silently-missing-value trap, but type-checked.
+type RequestCommentsResponse = Omit<ZendeskListResponse<ZendeskComment>, 'users'> & {
   users?: ZendeskRequestCommentAuthor[];
 };
 

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -81,17 +81,6 @@ const END_USER_FORM_PARAMS = {
 } as const;
 
 /**
- * Walk an offset-paginated listing to the end, following `next_page` and
- * nothing else.
- *
- * `next_page` is the only trustworthy end-of-list signal on these endpoints:
- * `count` can be the pre-filter total, and a short page can still be followed
- * by another. Hitting the cap throws rather than returning a partial list --
- * for both callers a missing entry is worse than an error, because it makes a
- * form invisible or a required field unenforced, and the caller then gets a
- * confidently wrong "no such form" or an opaque Zendesk 422.
- */
-/**
  * All the walker itself reads off a page. `extract` and `onPage` supply the
  * rest, so the response need not be a `ZendeskListResponse<T>` -- which matters
  * for a listing whose sideload is not of type `T` (see
@@ -116,6 +105,17 @@ interface PageWalk<T, R extends PagedResponse> {
   onPage?: (response: R) => void;
 }
 
+/**
+ * Walk an offset-paginated listing to the end, following `next_page` and
+ * nothing else.
+ *
+ * `next_page` is the only trustworthy end-of-list signal on these endpoints:
+ * `count` can be the pre-filter total, and a short page can still be followed
+ * by another. Hitting the cap throws rather than returning a partial list --
+ * for both callers a missing entry is worse than an error, because it makes a
+ * form invisible or a required field unenforced, and the caller then gets a
+ * confidently wrong "no such form" or an opaque Zendesk 422.
+ */
 const fetchAllPages = async <T, R extends PagedResponse = ZendeskListResponse<T>>({
   subdomain,
   token,
@@ -296,11 +296,25 @@ const fieldSpec = (field: ZendeskTicketField): string => {
 // API enforces that server-side is unverified -- so the model is told the rule
 // and left to conduct the conversation, rather than being handed a field list
 // that is wrong for half the answers.
-const conditionSpec = (condition: ZendeskFormCondition): string => {
+//
+// Named by label, not by bare id: a rule reading "when field 360000000001 is
+// severity_1" asks the model to conduct a conversation about a field the
+// customer has no name for. The id is kept alongside so the rule still joins
+// onto the Fields section below, and is the only thing left when the field is
+// not among those the caller can see.
+const fieldRef = (id: number, byId: Map<number, ZendeskTicketField>): string => {
+  const field = byId.get(id);
+  return field ? `${field.title_in_portal || field.title} (field id ${id})` : `field ${id}`;
+};
+
+const conditionSpec = (
+  condition: ZendeskFormCondition,
+  byId: Map<number, ZendeskTicketField>,
+): string => {
   const children = (condition.child_fields ?? [])
-    .map((child) => `field ${child.id}${child.is_required ? ' (then required)' : ''}`)
+    .map((child) => `${fieldRef(child.id, byId)}${child.is_required ? ' (then required)' : ''}`)
     .join(', ');
-  return `- When field ${condition.parent_field_id} is \`${String(condition.value)}\`: ${
+  return `- When ${fieldRef(condition.parent_field_id, byId)} is \`${String(condition.value)}\`: ${
     children || 'no additional fields'
   }`;
 };
@@ -333,7 +347,7 @@ const renderFormSpec = (form: ZendeskTicketForm, fields: ZendeskTicketField[]): 
           '## Conditional fields',
           'Some fields appear, or become required, only for certain answers. Ask for them once',
           'the controlling answer is known rather than up front:',
-          ...conditions.map(conditionSpec),
+          ...conditions.map((condition) => conditionSpec(condition, byId)),
         ].join('\n')
       : '',
     '',

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -80,21 +80,67 @@ const END_USER_FORM_PARAMS = {
   fallback_to_default: 'true',
 } as const;
 
+/**
+ * Walk an offset-paginated listing to the end, following `next_page` and
+ * nothing else.
+ *
+ * `next_page` is the only trustworthy end-of-list signal on these endpoints:
+ * `count` can be the pre-filter total, and a short page can still be followed
+ * by another. Hitting the cap throws rather than returning a partial list --
+ * for both callers a missing entry is worse than an error, because it makes a
+ * form invisible or a required field unenforced, and the caller then gets a
+ * confidently wrong "no such form" or an opaque Zendesk 422.
+ */
+const fetchAllPages = async <T>(
+  subdomain: string,
+  token: string,
+  tool: string,
+  path: string,
+  extract: (response: ZendeskListResponse<T>) => T[] | undefined,
+  params: Record<string, string> = {},
+  maxPages = TICKET_FIELD_SCAN_MAX_PAGES,
+): Promise<T[]> => {
+  const items: T[] = [];
+  let page = 1;
+  while (true) {
+    const response = await withForbiddenGuidance(tool, `GET ${path}`, () =>
+      zendeskGet<ZendeskListResponse<T>>(subdomain, token, path, {
+        ...params,
+        ...buildOffsetParams(MAX_PAGE_SIZE, page),
+      }),
+    );
+    items.push(...(extract(response) ?? []));
+    if (!response.next_page) return items;
+    if (page >= maxPages) {
+      throw new Error(
+        `${tool} could not read all of ${path}: the account exposes more than ${maxPages} ` +
+          'pages of it. Continuing from a partial list would hide entries and produce a ' +
+          'confidently wrong answer, so this stops here. Raise ' +
+          'ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES and retry.',
+      );
+    }
+    page += 1;
+  }
+};
+
+// Paginated for the same reason the field listing is: an account with more
+// forms than fit one page would otherwise have some of them invisible to
+// `list_request_forms`, and `resolveForm` would reject their ids with "no
+// request form with id X is available to you" -- a confident refusal of a form
+// that does exist.
 const fetchEndUserForms = async (
   subdomain: string,
   token: string,
   tool: string,
-): Promise<ZendeskTicketForm[]> => {
-  const response = await withForbiddenGuidance(tool, 'GET /ticket_forms', () =>
-    zendeskGet<ZendeskListResponse<ZendeskTicketForm>>(
-      subdomain,
-      token,
-      '/ticket_forms',
-      END_USER_FORM_PARAMS,
-    ),
+): Promise<ZendeskTicketForm[]> =>
+  fetchAllPages<ZendeskTicketForm>(
+    subdomain,
+    token,
+    tool,
+    '/ticket_forms',
+    (response) => response.ticket_forms,
+    END_USER_FORM_PARAMS,
   );
-  return response.ticket_forms ?? [];
-};
 
 /**
  * Every ticket field the caller can see, paged defensively.
@@ -114,38 +160,13 @@ const fetchVisibleTicketFields = async (
   token: string,
   tool: string,
 ): Promise<ZendeskTicketField[]> => {
-  const fields: ZendeskTicketField[] = [];
-  let page = 1;
-  let truncated = false;
-  while (true) {
-    const response = await withForbiddenGuidance(tool, 'GET /ticket_fields', () =>
-      zendeskGet<ZendeskListResponse<ZendeskTicketField>>(
-        subdomain,
-        token,
-        '/ticket_fields',
-        buildOffsetParams(MAX_PAGE_SIZE, page),
-      ),
-    );
-    fields.push(...(response.ticket_fields ?? []));
-    if (!response.next_page) break;
-    if (page >= TICKET_FIELD_SCAN_MAX_PAGES) {
-      truncated = true;
-      break;
-    }
-    page += 1;
-  }
-  // Hitting the cap is not a partial result to quietly live with: the form spec
-  // would omit a field, and validateSubmission would then not enforce it,
-  // producing exactly the opaque 422 that check exists to prevent. Fail loudly
-  // rather than describe a form we only half read.
-  if (truncated) {
-    throw new Error(
-      `${tool} could not read every ticket field: the account exposes more than ` +
-        `${TICKET_FIELD_SCAN_MAX_PAGES} pages of them. Describing the form from a partial ` +
-        'list would omit required fields and let a submission fail with an opaque Zendesk ' +
-        'error, so this stops here. Raise ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES and retry.',
-    );
-  }
+  const fields = await fetchAllPages<ZendeskTicketField>(
+    subdomain,
+    token,
+    tool,
+    '/ticket_fields',
+    (response) => response.ticket_fields,
+  );
   // Zendesk already filters to portal-visible fields for an end-user token but
   // not for an agent one, so filter here too: the same tool must describe the
   // same form whichever identity calls it.

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -1,6 +1,11 @@
 import * as z from 'zod/v4';
 import { ZendeskApiError, zendeskGet, zendeskPost, zendeskPut } from '../client/zendesk-api';
-import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, TICKET_FIELD_SCAN_MAX_PAGES } from '../constants';
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_COMMENT_PAGES,
+  MAX_PAGE_SIZE,
+  TICKET_FIELD_SCAN_MAX_PAGES,
+} from '../constants';
 import type {
   ZendeskComment,
   ZendeskFormCondition,
@@ -111,7 +116,8 @@ const fetchVisibleTicketFields = async (
 ): Promise<ZendeskTicketField[]> => {
   const fields: ZendeskTicketField[] = [];
   let page = 1;
-  while (page <= TICKET_FIELD_SCAN_MAX_PAGES) {
+  let truncated = false;
+  while (true) {
     const response = await withForbiddenGuidance(tool, 'GET /ticket_fields', () =>
       zendeskGet<ZendeskListResponse<ZendeskTicketField>>(
         subdomain,
@@ -122,13 +128,92 @@ const fetchVisibleTicketFields = async (
     );
     fields.push(...(response.ticket_fields ?? []));
     if (!response.next_page) break;
+    if (page >= TICKET_FIELD_SCAN_MAX_PAGES) {
+      truncated = true;
+      break;
+    }
     page += 1;
+  }
+  // Hitting the cap is not a partial result to quietly live with: the form spec
+  // would omit a field, and validateSubmission would then not enforce it,
+  // producing exactly the opaque 422 that check exists to prevent. Fail loudly
+  // rather than describe a form we only half read.
+  if (truncated) {
+    throw new Error(
+      `${tool} could not read every ticket field: the account exposes more than ` +
+        `${TICKET_FIELD_SCAN_MAX_PAGES} pages of them. Describing the form from a partial ` +
+        'list would omit required fields and let a submission fail with an opaque Zendesk ' +
+        'error, so this stops here. Raise ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES and retry.',
+    );
   }
   // Zendesk already filters to portal-visible fields for an end-user token but
   // not for an agent one, so filter here too: the same tool must describe the
   // same form whichever identity calls it.
   return fields.filter((field) => field.visible_in_portal !== false);
 };
+
+/**
+ * Every public comment on a request, paged.
+ *
+ * `get_request` promises the whole conversation, so it has to page: one GET
+ * stops at Zendesk's page size, and a long-running ticket would lose its
+ * oldest exchanges with nothing to say so. Bounded by the same cap the
+ * agent-side comment walk uses.
+ *
+ * The `users` sideload accumulates across pages -- it is what attributes each
+ * comment, and a later page's authors need not appear in the first page's.
+ */
+const fetchAllRequestComments = async (
+  subdomain: string,
+  token: string,
+  requestId: number,
+): Promise<{ comments: ZendeskComment[]; authors: Map<number, ZendeskRequestCommentAuthor> }> => {
+  const comments: ZendeskComment[] = [];
+  const authors = new Map<number, ZendeskRequestCommentAuthor>();
+  let page = 1;
+  while (page <= MAX_COMMENT_PAGES) {
+    const response = await withForbiddenGuidance(
+      'get_request',
+      `GET /requests/${requestId}/comments`,
+      () =>
+        zendeskGet<ZendeskListResponse<ZendeskComment> & { users?: ZendeskRequestCommentAuthor[] }>(
+          subdomain,
+          token,
+          `/requests/${requestId}/comments`,
+          buildOffsetParams(MAX_PAGE_SIZE, page),
+        ),
+    );
+    comments.push(...(response.comments ?? []));
+    for (const user of response.users ?? []) authors.set(user.id, user);
+    if (!response.next_page) break;
+    page += 1;
+  }
+  return { comments, authors };
+};
+
+// Zendesk field `type` values for the built-in fields every form carries. They
+// are NOT things a submitter sends in `custom_fields`: `subject` and
+// `description` are this tool's own `subject`/`body` parameters, and the rest
+// are agent-side (status, priority, type, group, assignee, tags) and dropped
+// outright when an end user sets them.
+//
+// This matters more than it looks. A real form's `ticket_field_ids` includes
+// the system subject and description, and both are marked required in the
+// portal -- so treating every id in that list as a custom field to collect
+// would make `create_request` demand "Subject (field id 1)" in `custom_fields`
+// and refuse every submission, which no caller could satisfy.
+const SYSTEM_FIELD_TYPES: ReadonlySet<string> = new Set([
+  'subject',
+  'description',
+  'status',
+  'tickettype',
+  'priority',
+  'group',
+  'assignee',
+  'tags',
+]);
+
+const isCustomField = (field: ZendeskTicketField): boolean => !SYSTEM_FIELD_TYPES.has(field.type);
 
 const formSummary = (form: ZendeskTicketForm): string =>
   [
@@ -170,19 +255,25 @@ const conditionSpec = (condition: ZendeskFormCondition): string => {
 const renderFormSpec = (form: ZendeskTicketForm, fields: ZendeskTicketField[]): string => {
   const byId = new Map(fields.map((field) => [field.id, field]));
   // Ordered by the form, not by the field listing: that order is what the
-  // portal shows and what a submitter should be asked in.
+  // portal shows and what a submitter should be asked in. System fields are
+  // dropped here -- subject and description are create_request's own
+  // parameters, and the rest are agent-side.
   const formFields = form.ticket_field_ids
     .map((id) => byId.get(id))
-    .filter((field): field is ZendeskTicketField => field !== undefined);
+    .filter((field): field is ZendeskTicketField => field !== undefined)
+    .filter(isCustomField);
   const required = formFields.filter((field) => field.required_in_portal);
   const conditions = form.end_user_conditions ?? [];
 
   return [
     `# ${form.display_name || form.name} (form id ${form.id})`,
     '',
+    'Always needed: a subject and a description (the `subject` and `body` parameters',
+    'of create_request). The fields below are what this form asks for on top of those.',
+    '',
     required.length > 0
       ? `**Required**: ${required.map((f) => f.title_in_portal || f.title).join(', ')}`
-      : '**Required**: subject and description only.',
+      : '**Required**: nothing beyond the subject and description.',
     conditions.length > 0
       ? [
           '',
@@ -197,7 +288,7 @@ const renderFormSpec = (form: ZendeskTicketForm, fields: ZendeskTicketField[]): 
     '',
     formFields.length > 0
       ? formFields.map(fieldSpec).join('\n\n')
-      : 'This form exposes no custom fields; send subject and description only.',
+      : 'This form exposes no custom fields; send subject and body only.',
   ]
     .filter(Boolean)
     .join('\n');
@@ -229,6 +320,11 @@ const validateSubmission = (
   const missing = form.ticket_field_ids
     .map((id) => byId.get(id))
     .filter((field): field is ZendeskTicketField => field?.required_in_portal === true)
+    // System fields are excluded: `subject` and `description` arrive as this
+    // tool's own parameters (and are already `.min(1)`), and the agent-side
+    // ones cannot be set by an end user at all. Enforcing them as
+    // `custom_fields` entries would refuse every submission.
+    .filter(isCustomField)
     .filter((field) => !providedIds.has(field.id));
 
   if (missing.length > 0) {
@@ -570,19 +666,8 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
           // The `users` sideload comes back by default and carries an `agent`
           // flag, which is what distinguishes a reply from the user's own
           // comment without inferring anything from ids.
-          const response = await withForbiddenGuidance(
-            'get_request',
-            `GET /requests/${request_id}/comments`,
-            () =>
-              zendeskGet<{
-                comments: ZendeskComment[];
-                users?: ZendeskRequestCommentAuthor[];
-              }>(subdomain, token, `/requests/${request_id}/comments`),
-          );
-          const authors = new Map((response.users ?? []).map((user) => [user.id, user]));
-          const thread = response.comments
-            .map((c) => formatRequestComment(c, authors))
-            .join('\n\n');
+          const { comments, authors } = await fetchAllRequestComments(subdomain, token, request_id);
+          const thread = comments.map((c) => formatRequestComment(c, authors)).join('\n\n');
           text += `\n\n---\n# Conversation\n\n${thread}`;
         }
         return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -9,6 +9,7 @@ import {
 import type {
   ZendeskComment,
   ZendeskFormCondition,
+  ZendeskFormConditionChild,
   ZendeskListResponse,
   ZendeskRequest,
   ZendeskRequestCommentAuthor,
@@ -53,6 +54,15 @@ const forbidden = (tool: string, endpoint: string, error: ZendeskApiError, hint?
       'add_public_comment (namespace: tickets).',
     { cause: error },
   );
+
+// Every path scoped to a single request id has a cause the generic message
+// does not: the id may simply belong to somebody else. Zendesk answers 403
+// there, and telling the caller their Help Center is closed or their token is
+// not Help-Center-enabled sends them to fix something that is not broken. Named
+// only on these paths -- on `/ticket_forms` it would be a wrong diagnosis in
+// turn, and that path has its own hint.
+const OTHER_USERS_REQUEST_HINT =
+  'A request id that belongs to another user is refused the same way, so check the id is one of your own.';
 
 /** Run `fetch`, rewriting a 403 into guidance naming the end-user surface. */
 const withForbiddenGuidance = async <T>(
@@ -257,6 +267,7 @@ const fetchAllRequestComments = async (
     params: { include: 'users' },
     maxPages: MAX_COMMENT_PAGES,
     capEnvVar: 'ZENDESK_MAX_COMMENT_PAGES',
+    forbiddenHint: OTHER_USERS_REQUEST_HINT,
     onPage: (response) => {
       for (const user of response.users ?? []) authors.set(user.id, user);
     },
@@ -332,12 +343,38 @@ const fieldRef = (id: number, byId: Map<number, ZendeskTicketField>): string => 
   return field ? `${field.title_in_portal || field.title} (field id ${id})` : `field ${id}`;
 };
 
+/**
+ * Whether a conditional child field is required *of a submitter*, in words.
+ *
+ * `is_required` alone is not the answer: `required_on_statuses` narrows it to
+ * particular ticket statuses, and a field required only "when open" is not
+ * required of a customer submitting a new request. Saying "then required" there
+ * would send the assistant hunting for an answer Zendesk will not ask for.
+ *
+ * A new request starts at `new`, so that is the status this reads for -- with
+ * the caveat Zendesk documents, that a trigger can move a ticket off `new`
+ * immediately, which is why the wording says when the field becomes required
+ * rather than that it never will.
+ */
+const childRequirement = (child: ZendeskFormConditionChild): string => {
+  if (!child.is_required) return '';
+  const scope = child.required_on_statuses;
+  // No scope at all, or every status: required whenever the field shows.
+  if (!scope || scope.type === 'ALL_STATUSES') return ' (then required)';
+  if (scope.type === 'NO_STATUSES') return '';
+  const statuses = scope.statuses ?? [];
+  if (statuses.length === 0) return ' (then required)';
+  return statuses.includes('new')
+    ? ' (then required)'
+    : ` (then required once the request is ${statuses.join(' or ')}, not to submit it)`;
+};
+
 const conditionSpec = (
   condition: ZendeskFormCondition,
   byId: Map<number, ZendeskTicketField>,
 ): string => {
   const children = (condition.child_fields ?? [])
-    .map((child) => `${fieldRef(child.id, byId)}${child.is_required ? ' (then required)' : ''}`)
+    .map((child) => `${fieldRef(child.id, byId)}${childRequirement(child)}`)
     .join(', ');
   return `- When ${fieldRef(condition.parent_field_id, byId)} is \`${String(condition.value)}\`: ${
     children || 'no additional fields'
@@ -780,6 +817,7 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
           `GET /requests/${request_id}`,
           () =>
             zendeskGet<{ request: ZendeskRequest }>(subdomain, token, `/requests/${request_id}`),
+          OTHER_USERS_REQUEST_HINT,
         );
         let text = formatRequest(request);
         if (include_comments) {
@@ -847,6 +885,7 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
             zendeskPut<{ request: ZendeskRequest }>(subdomain, token, `/requests/${request_id}`, {
               request: { comment: { body, ...(uploads && { uploads }) } },
             }),
+          OTHER_USERS_REQUEST_HINT,
         );
         const suffix = formatAttachmentSuffix(attachments?.length);
         return {
@@ -892,6 +931,7 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
           'mark_request_solved',
           `GET ${endpoint}`,
           () => zendeskGet<{ request: ZendeskRequest }>(subdomain, token, endpoint),
+          OTHER_USERS_REQUEST_HINT,
         );
         if (before.status === 'solved' || before.status === 'closed') {
           return {
@@ -926,6 +966,7 @@ export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
             zendeskPut<{ request: ZendeskRequest }>(subdomain, token, endpoint, {
               request: { solved: true },
             }),
+          OTHER_USERS_REQUEST_HINT,
         );
         // Verified from the response body rather than assumed from the 2xx.
         const text =

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -91,32 +91,49 @@ const END_USER_FORM_PARAMS = {
  * form invisible or a required field unenforced, and the caller then gets a
  * confidently wrong "no such form" or an opaque Zendesk 422.
  */
-const fetchAllPages = async <T>(
-  subdomain: string,
-  token: string,
-  tool: string,
-  path: string,
-  extract: (response: ZendeskListResponse<T>) => T[] | undefined,
-  params: Record<string, string> = {},
+interface PageWalk<T, R extends ZendeskListResponse<T>> {
+  subdomain: string;
+  token: string;
+  tool: string;
+  path: string;
+  extract: (response: R) => T[] | undefined;
+  /** Extra query params, merged before the pagination ones. */
+  params?: Record<string, string>;
+  maxPages?: number;
+  /** The env var to name when the cap is hit, so the message is actionable. */
+  capEnvVar?: string;
+  /** Called per page, for a listing that also carries a sideload to accumulate. */
+  onPage?: (response: R) => void;
+}
+
+const fetchAllPages = async <T, R extends ZendeskListResponse<T> = ZendeskListResponse<T>>({
+  subdomain,
+  token,
+  tool,
+  path,
+  extract,
+  params = {},
   maxPages = TICKET_FIELD_SCAN_MAX_PAGES,
-): Promise<T[]> => {
+  capEnvVar = 'ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES',
+  onPage,
+}: PageWalk<T, R>): Promise<T[]> => {
   const items: T[] = [];
   let page = 1;
   while (true) {
     const response = await withForbiddenGuidance(tool, `GET ${path}`, () =>
-      zendeskGet<ZendeskListResponse<T>>(subdomain, token, path, {
+      zendeskGet<R>(subdomain, token, path, {
         ...params,
         ...buildOffsetParams(MAX_PAGE_SIZE, page),
       }),
     );
     items.push(...(extract(response) ?? []));
+    onPage?.(response);
     if (!response.next_page) return items;
     if (page >= maxPages) {
       throw new Error(
         `${tool} could not read all of ${path}: the account exposes more than ${maxPages} ` +
           'pages of it. Continuing from a partial list would hide entries and produce a ' +
-          'confidently wrong answer, so this stops here. Raise ' +
-          'ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES and retry.',
+          `confidently wrong answer, so this stops here. Raise ${capEnvVar} and retry.`,
       );
     }
     page += 1;
@@ -133,14 +150,14 @@ const fetchEndUserForms = async (
   token: string,
   tool: string,
 ): Promise<ZendeskTicketForm[]> =>
-  fetchAllPages<ZendeskTicketForm>(
+  fetchAllPages<ZendeskTicketForm>({
     subdomain,
     token,
     tool,
-    '/ticket_forms',
-    (response) => response.ticket_forms,
-    END_USER_FORM_PARAMS,
-  );
+    path: '/ticket_forms',
+    extract: (response) => response.ticket_forms,
+    params: END_USER_FORM_PARAMS,
+  });
 
 /**
  * Every ticket field the caller can see, paged defensively.
@@ -160,13 +177,13 @@ const fetchVisibleTicketFields = async (
   token: string,
   tool: string,
 ): Promise<ZendeskTicketField[]> => {
-  const fields = await fetchAllPages<ZendeskTicketField>(
+  const fields = await fetchAllPages<ZendeskTicketField>({
     subdomain,
     token,
     tool,
-    '/ticket_fields',
-    (response) => response.ticket_fields,
-  );
+    path: '/ticket_fields',
+    extract: (response) => response.ticket_fields,
+  });
   // Zendesk already filters to portal-visible fields for an end-user token but
   // not for an agent one, so filter here too: the same tool must describe the
   // same form whichever identity calls it.
@@ -174,41 +191,41 @@ const fetchVisibleTicketFields = async (
 };
 
 /**
- * Every public comment on a request, paged.
+ * Every public comment on a request, paged through the same walker the form and
+ * field listings use.
  *
- * `get_request` promises the whole conversation, so it has to page: one GET
- * stops at Zendesk's page size, and a long-running ticket would lose its
- * oldest exchanges with nothing to say so. Bounded by the same cap the
- * agent-side comment walk uses.
+ * `get_request` promises the whole conversation, so it must page -- one GET
+ * stops at Zendesk's page size and a long-running ticket would lose its oldest
+ * exchanges. Sharing the walker is what makes it *fail* rather than truncate at
+ * the cap: a second loop here had the opposite semantics, silently returning a
+ * partial thread on the one tool that promises a complete one.
  *
- * The `users` sideload accumulates across pages -- it is what attributes each
- * comment, and a later page's authors need not appear in the first page's.
+ * The `users` sideload accumulates across pages via `onPage` -- it is what
+ * attributes each comment, and a later page's authors need not appear in the
+ * first page's.
  */
+type RequestCommentsResponse = ZendeskListResponse<ZendeskComment> & {
+  users?: ZendeskRequestCommentAuthor[];
+};
+
 const fetchAllRequestComments = async (
   subdomain: string,
   token: string,
   requestId: number,
 ): Promise<{ comments: ZendeskComment[]; authors: Map<number, ZendeskRequestCommentAuthor> }> => {
-  const comments: ZendeskComment[] = [];
   const authors = new Map<number, ZendeskRequestCommentAuthor>();
-  let page = 1;
-  while (page <= MAX_COMMENT_PAGES) {
-    const response = await withForbiddenGuidance(
-      'get_request',
-      `GET /requests/${requestId}/comments`,
-      () =>
-        zendeskGet<ZendeskListResponse<ZendeskComment> & { users?: ZendeskRequestCommentAuthor[] }>(
-          subdomain,
-          token,
-          `/requests/${requestId}/comments`,
-          buildOffsetParams(MAX_PAGE_SIZE, page),
-        ),
-    );
-    comments.push(...(response.comments ?? []));
-    for (const user of response.users ?? []) authors.set(user.id, user);
-    if (!response.next_page) break;
-    page += 1;
-  }
+  const comments = await fetchAllPages<ZendeskComment, RequestCommentsResponse>({
+    subdomain,
+    token,
+    tool: 'get_request',
+    path: `/requests/${requestId}/comments`,
+    extract: (response) => response.comments,
+    maxPages: MAX_COMMENT_PAGES,
+    capEnvVar: 'ZENDESK_MAX_COMMENT_PAGES',
+    onPage: (response) => {
+      for (const user of response.users ?? []) authors.set(user.id, user);
+    },
+  });
   return { comments, authors };
 };
 

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -43,13 +43,14 @@ import type { ToolContext, ToolDefinition } from './definitions';
 //
 // ASCII only, same as the other rewritten auth messages: these can travel
 // through header-adjacent paths that reject non-ASCII bytes.
-const forbidden = (tool: string, endpoint: string, error: ZendeskApiError): Error =>
+const forbidden = (tool: string, endpoint: string, error: ZendeskApiError, hint?: string): Error =>
   new Error(
     `${tool} reads the end-user Requests surface (${endpoint}), which Zendesk serves to a ` +
       'signed-in requester. The current token was refused (HTTP 403). Either the Help Center ' +
-      'is closed to this account, or this token is not a Help-Center-enabled user. For the ' +
-      'agent-side equivalents use create_ticket, get_ticket, list_tickets or add_public_comment ' +
-      '(namespace: tickets).',
+      `is closed to this account, or this token is not a Help-Center-enabled user.${
+        hint ? ` ${hint}` : ''
+      } For the agent-side equivalents use create_ticket, get_ticket, list_tickets or ` +
+      'add_public_comment (namespace: tickets).',
     { cause: error },
   );
 
@@ -58,12 +59,13 @@ const withForbiddenGuidance = async <T>(
   tool: string,
   endpoint: string,
   fetch: () => Promise<T>,
+  hint?: string,
 ): Promise<T> => {
   try {
     return await fetch();
   } catch (error) {
     if (error instanceof ZendeskApiError && error.status === 403) {
-      throw forbidden(tool, endpoint, error);
+      throw forbidden(tool, endpoint, error, hint);
     }
     throw error;
   }
@@ -103,6 +105,8 @@ interface PageWalk<T, R extends PagedResponse> {
   capEnvVar?: string;
   /** Called per page, for a listing that also carries a sideload to accumulate. */
   onPage?: (response: R) => void;
+  /** Extra sentence for the 403 message, when this path has its own cause. */
+  forbiddenHint?: string;
 }
 
 /**
@@ -126,15 +130,20 @@ const fetchAllPages = async <T, R extends PagedResponse = ZendeskListResponse<T>
   maxPages = TICKET_FIELD_SCAN_MAX_PAGES,
   capEnvVar = 'ZENDESK_TICKET_FIELD_SCAN_MAX_PAGES',
   onPage,
+  forbiddenHint,
 }: PageWalk<T, R>): Promise<T[]> => {
   const items: T[] = [];
   let page = 1;
   while (true) {
-    const response = await withForbiddenGuidance(tool, `GET ${path}`, () =>
-      zendeskGet<R>(subdomain, token, path, {
-        ...params,
-        ...buildOffsetParams(MAX_PAGE_SIZE, page),
-      }),
+    const response = await withForbiddenGuidance(
+      tool,
+      `GET ${path}`,
+      () =>
+        zendeskGet<R>(subdomain, token, path, {
+          ...params,
+          ...buildOffsetParams(MAX_PAGE_SIZE, page),
+        }),
+      forbiddenHint,
     );
     items.push(...(extract(response) ?? []));
     onPage?.(response);
@@ -167,6 +176,12 @@ const fetchEndUserForms = async (
     path: '/ticket_forms',
     extract: (response) => response.ticket_forms,
     params: END_USER_FORM_PARAMS,
+    // Multiple ticket forms are a plan feature, so this endpoint has a third
+    // cause the generic message would mis-diagnose as a Help Center or token
+    // problem. Every request tool that needs a form goes through here,
+    // create_request included, so getting the blame right matters.
+    forbiddenHint:
+      'This endpoint can also be unavailable on a Zendesk plan without multiple ticket forms.',
   });
 
 /**

--- a/src/tools/requests.ts
+++ b/src/tools/requests.ts
@@ -1,0 +1,730 @@
+import * as z from 'zod/v4';
+import { ZendeskApiError, zendeskGet, zendeskPost, zendeskPut } from '../client/zendesk-api';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, TICKET_FIELD_SCAN_MAX_PAGES } from '../constants';
+import type {
+  ZendeskComment,
+  ZendeskFormCondition,
+  ZendeskListResponse,
+  ZendeskRequest,
+  ZendeskRequestCommentAuthor,
+  ZendeskTicketField,
+  ZendeskTicketForm,
+} from '../types';
+import {
+  formatList,
+  formatRequest,
+  formatRequestComment,
+  truncateIfNeeded,
+} from '../utils/formatting';
+import {
+  buildOffsetParams,
+  extractOffsetPaginationMeta,
+  PAGE_DESC,
+  PER_PAGE_DESC,
+} from '../utils/pagination';
+import {
+  type AttachmentInput,
+  attachmentSchema,
+  formatAttachmentSuffix,
+  uploadAttachments,
+} from './attachments';
+import type { ToolContext, ToolDefinition } from './definitions';
+
+// Zendesk reserves `/api/v2/requests` for requesters; the agent paths
+// (`/tickets`, `/search`) answer 403 for an end user, and vice versa some of
+// these behave differently under an agent token. This message is thrown in
+// place of the generic "Permission denied" so the caller learns which surface
+// they are on rather than which HTTP code came back.
+//
+// ASCII only, same as the other rewritten auth messages: these can travel
+// through header-adjacent paths that reject non-ASCII bytes.
+const forbidden = (tool: string, endpoint: string, error: ZendeskApiError): Error =>
+  new Error(
+    `${tool} reads the end-user Requests surface (${endpoint}), which Zendesk serves to a ` +
+      'signed-in requester. The current token was refused (HTTP 403). Either the Help Center ' +
+      'is closed to this account, or this token is not a Help-Center-enabled user. For the ' +
+      'agent-side equivalents use create_ticket, get_ticket, list_tickets or add_public_comment ' +
+      '(namespace: tickets).',
+    { cause: error },
+  );
+
+/** Run `fetch`, rewriting a 403 into guidance naming the end-user surface. */
+const withForbiddenGuidance = async <T>(
+  tool: string,
+  endpoint: string,
+  fetch: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await fetch();
+  } catch (error) {
+    if (error instanceof ZendeskApiError && error.status === 403) {
+      throw forbidden(tool, endpoint, error);
+    }
+    throw error;
+  }
+};
+
+// The forms a customer may actually pick from. `active=true` is load-bearing:
+// Zendesk already hides forms that are not `end_user_visible` from an end-user
+// token, but it does NOT hide inactive ones. `fallback_to_default=true` returns
+// the default form when nothing else matches, so an account with a single form
+// degrades to that form rather than to an empty list.
+const END_USER_FORM_PARAMS = {
+  active: 'true',
+  end_user_visible: 'true',
+  fallback_to_default: 'true',
+} as const;
+
+const fetchEndUserForms = async (
+  subdomain: string,
+  token: string,
+  tool: string,
+): Promise<ZendeskTicketForm[]> => {
+  const response = await withForbiddenGuidance(tool, 'GET /ticket_forms', () =>
+    zendeskGet<ZendeskListResponse<ZendeskTicketForm>>(
+      subdomain,
+      token,
+      '/ticket_forms',
+      END_USER_FORM_PARAMS,
+    ),
+  );
+  return response.ticket_forms ?? [];
+};
+
+/**
+ * Every ticket field the caller can see, paged defensively.
+ *
+ * `GET /ticket_fields` cannot be trusted to say when it is done. Under an
+ * end-user token its `count` is the UNFILTERED total (27 while returning 8
+ * objects with `next_page: null`), and in cursor mode `page[size]` is applied
+ * before the visibility filter, so a short page is not the last page. So this
+ * follows `next_page` and nothing else, bounded by a page cap.
+ *
+ * The per-field lookup would be the obvious alternative and is not available:
+ * `GET /ticket_fields/{id}` answers 403 for an end user. The list is the only
+ * way in.
+ */
+const fetchVisibleTicketFields = async (
+  subdomain: string,
+  token: string,
+  tool: string,
+): Promise<ZendeskTicketField[]> => {
+  const fields: ZendeskTicketField[] = [];
+  let page = 1;
+  while (page <= TICKET_FIELD_SCAN_MAX_PAGES) {
+    const response = await withForbiddenGuidance(tool, 'GET /ticket_fields', () =>
+      zendeskGet<ZendeskListResponse<ZendeskTicketField>>(
+        subdomain,
+        token,
+        '/ticket_fields',
+        buildOffsetParams(MAX_PAGE_SIZE, page),
+      ),
+    );
+    fields.push(...(response.ticket_fields ?? []));
+    if (!response.next_page) break;
+    page += 1;
+  }
+  // Zendesk already filters to portal-visible fields for an end-user token but
+  // not for an agent one, so filter here too: the same tool must describe the
+  // same form whichever identity calls it.
+  return fields.filter((field) => field.visible_in_portal !== false);
+};
+
+const formSummary = (form: ZendeskTicketForm): string =>
+  [
+    `- **${form.display_name || form.name}** (form id ${form.id})${form.default ? ' — default' : ''}`,
+    form.display_name && form.display_name !== form.name ? `  - Internal name: ${form.name}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+// One field as a submitter needs to see it: the portal label, whether it is
+// required of them, and the exact option values Zendesk will accept.
+const fieldSpec = (field: ZendeskTicketField): string => {
+  const options = field.custom_field_options ?? field.system_field_options ?? [];
+  return [
+    `### ${field.title_in_portal || field.title} (field id ${field.id})`,
+    `- **Type**: ${field.type} | **${field.required_in_portal ? 'required' : 'optional'}**`,
+    field.description ? `- **Help text**: ${field.description}` : '',
+    options.length > 0 ? '- **Accepted values** (label → value to send):' : '',
+    ...options.map((option) => `  - ${option.name} → ${option.value}`),
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+// Conditions are surfaced as data, not evaluated. Which fields a submitter
+// actually sees can depend on answers already given, and whether the Requests
+// API enforces that server-side is unverified -- so the model is told the rule
+// and left to conduct the conversation, rather than being handed a field list
+// that is wrong for half the answers.
+const conditionSpec = (condition: ZendeskFormCondition): string => {
+  const children = (condition.child_fields ?? [])
+    .map((child) => `field ${child.id}${child.is_required ? ' (then required)' : ''}`)
+    .join(', ');
+  return `- When field ${condition.parent_field_id} is \`${String(condition.value)}\`: ${
+    children || 'no additional fields'
+  }`;
+};
+
+const renderFormSpec = (form: ZendeskTicketForm, fields: ZendeskTicketField[]): string => {
+  const byId = new Map(fields.map((field) => [field.id, field]));
+  // Ordered by the form, not by the field listing: that order is what the
+  // portal shows and what a submitter should be asked in.
+  const formFields = form.ticket_field_ids
+    .map((id) => byId.get(id))
+    .filter((field): field is ZendeskTicketField => field !== undefined);
+  const required = formFields.filter((field) => field.required_in_portal);
+  const conditions = form.end_user_conditions ?? [];
+
+  return [
+    `# ${form.display_name || form.name} (form id ${form.id})`,
+    '',
+    required.length > 0
+      ? `**Required**: ${required.map((f) => f.title_in_portal || f.title).join(', ')}`
+      : '**Required**: subject and description only.',
+    conditions.length > 0
+      ? [
+          '',
+          '## Conditional fields',
+          'Some fields appear, or become required, only for certain answers. Ask for them once',
+          'the controlling answer is known rather than up front:',
+          ...conditions.map(conditionSpec),
+        ].join('\n')
+      : '',
+    '',
+    '## Fields',
+    '',
+    formFields.length > 0
+      ? formFields.map(fieldSpec).join('\n\n')
+      : 'This form exposes no custom fields; send subject and description only.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+/**
+ * Refuse a submission the API would accept and quietly mangle.
+ *
+ * Two silent failures are guarded here. An unknown `ticket_form_id` makes
+ * Zendesk answer 201 having substituted the account's DEFAULT form, so the
+ * request lands on the wrong form with no error at all. And a missing
+ * `required_in_portal` field is enforced only against end users -- an agent
+ * token gets 201 with an empty subject -- so an agent-side check would pass
+ * where a customer's submission fails.
+ *
+ * Only UNCONDITIONALLY required fields are enforced. A field required through
+ * `end_user_conditions` depends on answers we may not have, and blocking on it
+ * would refuse valid submissions; Zendesk's own 422 is the backstop there.
+ */
+const validateSubmission = (
+  form: ZendeskTicketForm,
+  fields: ZendeskTicketField[],
+  provided: Array<{ id: number; value: unknown }>,
+): void => {
+  const byId = new Map(fields.map((field) => [field.id, field]));
+  const providedIds = new Set(
+    provided.filter((entry) => entry.value !== null && entry.value !== '').map((e) => e.id),
+  );
+  const missing = form.ticket_field_ids
+    .map((id) => byId.get(id))
+    .filter((field): field is ZendeskTicketField => field?.required_in_portal === true)
+    .filter((field) => !providedIds.has(field.id));
+
+  if (missing.length > 0) {
+    const list = missing
+      .map((field) => `${field.title_in_portal || field.title} (field id ${field.id})`)
+      .join(', ');
+    throw new Error(
+      `This form requires values the submission does not carry: ${list}. Ask for them, then ` +
+        'resend with those ids in custom_fields. Call get_request_form for their accepted values.',
+    );
+  }
+};
+
+const REQUEST_STATUS = z.enum(['new', 'open', 'pending', 'hold', 'solved', 'closed']);
+
+export const createRequestTools = (ctx: ToolContext): ToolDefinition[] => {
+  const { subdomain, getToken } = ctx;
+
+  // Resolve a form id to the form and the fields it needs, in one place: both
+  // get_request_form and create_request start from exactly this.
+  const resolveForm = async (
+    tool: string,
+    token: string,
+    formId: number | undefined,
+  ): Promise<{ form: ZendeskTicketForm; fields: ZendeskTicketField[] }> => {
+    const [forms, fields] = await Promise.all([
+      fetchEndUserForms(subdomain, token, tool),
+      fetchVisibleTicketFields(subdomain, token, tool),
+    ]);
+    if (forms.length === 0) {
+      throw new Error(
+        `No request form is available to this user on ${subdomain}.zendesk.com. The Help Center ` +
+          'may be closed, or no form is marked visible to end users. An agent can still open a ' +
+          'ticket with create_ticket (namespace: tickets).',
+      );
+    }
+    const form =
+      formId === undefined ? forms.find((f) => f.default) : forms.find((f) => f.id === formId);
+    if (!form) {
+      const available = forms.map((f) => `${f.display_name || f.name} (${f.id})`).join(', ');
+      throw new Error(
+        formId === undefined
+          ? `No default request form on ${subdomain}.zendesk.com. Pick one explicitly: ${available}.`
+          : `No request form with id ${formId} is available to you. Available: ${available}. ` +
+              'Sending an unknown id would make Zendesk silently substitute the default form, so ' +
+              'this is refused rather than guessed.',
+      );
+    }
+    return { form, fields };
+  };
+
+  return [
+    {
+      name: 'list_request_forms',
+      namespace: 'requests',
+      readOnly: true,
+      title: 'List Request Forms',
+      description:
+        'List the kinds of request you can submit to this Zendesk — the forms a customer picks between on the Help Center, such as "Report a bug" or "Feature request". Returns each form\'s customer-facing name, its numeric id, and which one is the account default. Call this first when opening a request so the user chooses the right kind, then get_request_form to learn what that form asks for. Only forms that are active and visible to end users are listed; an account with a single form returns just that one. This is the end-user view: agents picking a form for someone else want list_ticket_fields and create_ticket instead.',
+      inputSchema: z.object({}),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async () => {
+        const token = await getToken();
+        const forms = await fetchEndUserForms(subdomain, token, 'list_request_forms');
+        if (forms.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No request form is available to you on this Zendesk. The Help Center may be closed, or no form is marked visible to end users.',
+              },
+            ],
+          };
+        }
+        const text = [
+          `${forms.length} kind(s) of request available:`,
+          '',
+          forms.map(formSummary).join('\n'),
+          '',
+          'Call get_request_form with a form id to see the questions it asks.',
+        ].join('\n');
+        return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
+      },
+    },
+    {
+      name: 'get_request_form',
+      namespace: 'requests',
+      readOnly: true,
+      title: 'Get Request Form',
+      description:
+        'Read what one request form actually asks for, so the user can be walked through it question by question. Returns the fields on that form in the order the portal shows them, each with its customer-facing label, whether it is required, and for dropdowns the exact values Zendesk accepts — plus any conditional rules ("if Type is Bug, Version becomes required"). Joins the form definition with the field definitions, because the form itself carries only field ids. Use it after list_request_forms and before create_request; omit form_id to describe the account default form. Conditional fields are reported as rules rather than resolved, since which ones apply depends on answers not yet given.',
+      inputSchema: z.object({
+        form_id: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            'Form id whose questions to read, as returned by list_request_forms. Omit to describe the account default form.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { form_id } = params as { form_id?: number };
+        const token = await getToken();
+        const { form, fields } = await resolveForm('get_request_form', token, form_id);
+        return {
+          content: [{ type: 'text', text: truncateIfNeeded(renderFormSpec(form, fields)) }],
+        };
+      },
+    },
+    {
+      name: 'create_request',
+      namespace: 'requests',
+      readOnly: false,
+      title: 'Submit a Request',
+      description:
+        'Submit a new support request as the signed-in user — the MCP equivalent of the Help Center\'s "Submit a request" form. Returns the created request with its number, which the user can then follow with list_requests and get_request. Required fields are checked before sending: an unknown form id, or a missing field the form marks required, is refused here rather than sent, because Zendesk would answer 201 having silently substituted the default form or accepted an empty subject. Call get_request_form first to learn which fields to gather. Priority and type cannot be set by an end user — Zendesk drops them — so triage is left to the agents. This posts as the authenticated user; an agent opening a ticket on someone else\'s behalf wants create_ticket instead.',
+      inputSchema: z.object({
+        subject: z
+          .string()
+          .min(1)
+          .describe(
+            'One-line summary of the request, shown as the ticket title to the support agents who pick it up.',
+          ),
+        body: z
+          .string()
+          .min(1)
+          .describe(
+            'The request itself: what happened, what was expected, and any steps to reproduce. Becomes the first public comment on the ticket.',
+          ),
+        form_id: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            'Form id chosen from list_request_forms, deciding which questions apply. Omit to use the account default form.',
+          ),
+        custom_fields: z
+          .array(z.object({ id: z.number().int(), value: z.unknown() }))
+          .optional()
+          .describe(
+            "Answers to the form's own questions, as { id, value } pairs. Take both the ids and the accepted values from get_request_form; a value Zendesk does not recognise is dropped without an error.",
+          ),
+        attachments: z
+          .array(attachmentSchema)
+          .optional()
+          .describe(
+            'Files to attach to the request, such as a screenshot or a log, with their content base64-encoded.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { subject, body, form_id, custom_fields, attachments } = params as {
+          subject: string;
+          body: string;
+          form_id?: number;
+          custom_fields?: Array<{ id: number; value: unknown }>;
+          attachments?: AttachmentInput[];
+        };
+        const token = await getToken();
+        const { form, fields } = await resolveForm('create_request', token, form_id);
+        validateSubmission(form, fields, custom_fields ?? []);
+
+        const uploads = attachments?.length
+          ? [await uploadAttachments(subdomain, token, attachments)]
+          : undefined;
+
+        const { request } = await withForbiddenGuidance('create_request', 'POST /requests', () =>
+          zendeskPost<{ request: ZendeskRequest }>(subdomain, token, '/requests', {
+            request: {
+              subject,
+              ticket_form_id: form.id,
+              comment: { body, ...(uploads && { uploads }) },
+              ...(custom_fields && { custom_fields }),
+            },
+          }),
+        );
+        const suffix = formatAttachmentSuffix(attachments?.length);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Request #${request.id} submitted${suffix}.\n\n${formatRequest(request)}`,
+            },
+          ],
+        };
+      },
+    },
+    {
+      name: 'list_requests',
+      namespace: 'requests',
+      readOnly: true,
+      title: 'List My Requests',
+      description:
+        "List the requests the signed-in user submitted, newest activity first by default. Returns each request with its number, subject, status and whether the user can mark it solved; pass a query to search their own requests by free text instead of listing all of them. Scoped to the caller by Zendesk itself — it can never return anyone else's tickets — which is why an agent calling this sees only requests they raised, not their queue. Use get_request to read one with its full conversation. Agents wanting a queue want list_tickets, search_tickets or get_view_tickets instead.",
+      inputSchema: z.object({
+        query: z
+          .string()
+          .min(1)
+          .optional()
+          .describe(
+            "Free text to match against the caller's own requests. When given, the search endpoint is used instead of the plain listing; omit it to list everything.",
+          ),
+        status: z
+          .array(REQUEST_STATUS)
+          .min(1)
+          .optional()
+          .describe(
+            'Restrict to these ticket states, e.g. ["open","pending"] for anything still being worked. Validated here because Zendesk silently returns every request when it does not recognise a status.',
+          ),
+        sort_by: z
+          .enum(['created_at', 'updated_at'])
+          .default('updated_at')
+          .describe(
+            'Which timestamp orders the results: updated_at surfaces recent activity, created_at the newest submissions.',
+          ),
+        sort_order: z
+          .enum(['asc', 'desc'])
+          .default('desc')
+          .describe(
+            'Direction of that ordering; desc puts the most recent first, which is what a user following their tickets wants.',
+          ),
+        per_page: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE)
+          .describe(PER_PAGE_DESC),
+        page: z.number().int().min(1).default(1).describe(PAGE_DESC),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { query, status, sort_by, sort_order, per_page, page } = params as {
+          query?: string;
+          status?: string[];
+          sort_by: string;
+          sort_order: string;
+          per_page: number;
+          page: number;
+        };
+        const token = await getToken();
+        // `per_page` is passed on BOTH paths on purpose: the search endpoint
+        // otherwise defaults to 15 while the listing defaults to 100, and one
+        // tool that silently paginates two ways is a trap.
+        const path = query ? '/requests/search' : '/requests';
+        const response = await withForbiddenGuidance('list_requests', `GET ${path}`, () =>
+          zendeskGet<ZendeskListResponse<ZendeskRequest>>(subdomain, token, path, {
+            ...(query && { query }),
+            ...(status?.length && { status: status.join(',') }),
+            sort_by,
+            sort_order,
+            ...buildOffsetParams(per_page, page),
+          }),
+        );
+        const requests = response.requests ?? [];
+        const meta = extractOffsetPaginationMeta(response, requests.length, per_page, page);
+        if (requests.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: query
+                  ? `No request of yours matches "${query}".`
+                  : 'You have not submitted any request matching this filter.',
+              },
+            ],
+          };
+        }
+        const header = query ? `Searched your requests for "${query}".` : 'Your requests.';
+        return {
+          content: [
+            { type: 'text', text: `${header}\n\n${formatList(requests, formatRequest, meta)}` },
+          ],
+        };
+      },
+    },
+    {
+      name: 'get_request',
+      namespace: 'requests',
+      readOnly: true,
+      title: 'Get My Request',
+      description:
+        'Read one of the signed-in user\'s own requests, optionally with the whole conversation on it. Returns the request\'s status, the form it was submitted on, whether the user may mark it solved, and — with include_comments — every public message on it, each labelled with its author and marked when that author is a support agent. Internal agent notes are never returned on this path, so nothing agent-private can leak through it. A request belonging to someone else answers "permission denied" rather than "not found", so a denial here does not tell you whether that id exists. Find the number with list_requests; agents reading a ticket they do not own want get_ticket instead.',
+      inputSchema: z.object({
+        request_id: z
+          .number()
+          .int()
+          .describe(
+            'Number of the request to read, as shown by list_requests or returned when it was submitted.',
+          ),
+        include_comments: z
+          .boolean()
+          .default(false)
+          .describe(
+            "When true, appends the full public conversation — agent replies and the user's own messages. Defaults to false so a status check stays cheap.",
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { request_id, include_comments } = params as {
+          request_id: number;
+          include_comments: boolean;
+        };
+        const token = await getToken();
+        const { request } = await withForbiddenGuidance(
+          'get_request',
+          `GET /requests/${request_id}`,
+          () =>
+            zendeskGet<{ request: ZendeskRequest }>(subdomain, token, `/requests/${request_id}`),
+        );
+        let text = formatRequest(request);
+        if (include_comments) {
+          // The `users` sideload comes back by default and carries an `agent`
+          // flag, which is what distinguishes a reply from the user's own
+          // comment without inferring anything from ids.
+          const response = await withForbiddenGuidance(
+            'get_request',
+            `GET /requests/${request_id}/comments`,
+            () =>
+              zendeskGet<{
+                comments: ZendeskComment[];
+                users?: ZendeskRequestCommentAuthor[];
+              }>(subdomain, token, `/requests/${request_id}/comments`),
+          );
+          const authors = new Map((response.users ?? []).map((user) => [user.id, user]));
+          const thread = response.comments
+            .map((c) => formatRequestComment(c, authors))
+            .join('\n\n');
+          text += `\n\n---\n# Conversation\n\n${thread}`;
+        }
+        return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
+      },
+    },
+    {
+      name: 'add_request_comment',
+      namespace: 'requests',
+      readOnly: false,
+      title: 'Reply on My Request',
+      description:
+        "Reply on one of the signed-in user's own requests, optionally attaching files. Returns confirmation with the request's status after the reply, which matters because replying on a request that was already solved REOPENS it — Zendesk moves it back to open, and the user should know that is what their message did. The comment is always public: end users cannot post internal notes, and Zendesk silently ignores any attempt to mark one private. A closed request rejects new comments outright. Agents replying to a requester want add_public_comment, or add_private_note for an internal note.",
+      inputSchema: z.object({
+        request_id: z
+          .number()
+          .int()
+          .describe('Number of the request to reply on, as shown by list_requests.'),
+        body: z
+          .string()
+          .min(1)
+          .describe(
+            'The message to send. Visible to the support agents on the ticket and included in their email notification.',
+          ),
+        attachments: z
+          .array(attachmentSchema)
+          .optional()
+          .describe(
+            'Files to attach to this reply, such as a screenshot or a log, with their content base64-encoded.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { request_id, body, attachments } = params as {
+          request_id: number;
+          body: string;
+          attachments?: AttachmentInput[];
+        };
+        const token = await getToken();
+        const uploads = attachments?.length
+          ? [await uploadAttachments(subdomain, token, attachments)]
+          : undefined;
+        const { request } = await withForbiddenGuidance(
+          'add_request_comment',
+          `PUT /requests/${request_id}`,
+          () =>
+            zendeskPut<{ request: ZendeskRequest }>(subdomain, token, `/requests/${request_id}`, {
+              request: { comment: { body, ...(uploads && { uploads }) } },
+            }),
+        );
+        const suffix = formatAttachmentSuffix(attachments?.length);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Reply added to request #${request_id}${suffix}. It is now **${request.status}**.`,
+            },
+          ],
+        };
+      },
+    },
+    {
+      name: 'mark_request_solved',
+      namespace: 'requests',
+      readOnly: false,
+      title: 'Mark My Request Solved',
+      description:
+        "Close one of the signed-in user's own requests, for when they consider it resolved. Returns the request's status read back from Zendesk, not merely an acknowledgement: this operation is refused unless the request is actually solvable by its requester, because Zendesk answers 200 and changes nothing when it is not, which would otherwise be reported as success. A request is only solvable once an agent has been assigned to it, so a brand-new or unassigned one cannot be closed this way — leave it, or reply with add_request_comment to say it is no longer needed. Marking an already-solved request solved again is a no-op. Agents closing a ticket want update_ticket with status solved.",
+      inputSchema: z.object({
+        request_id: z
+          .number()
+          .int()
+          .describe(
+            'Number of the request to close. Check get_request first: its "can you mark it solved" line has to say yes.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { request_id } = params as { request_id: number };
+        const token = await getToken();
+        const endpoint = `/requests/${request_id}`;
+
+        // Read before writing. Zendesk accepts `solved: true` on a request the
+        // requester may not solve, answers 200, and leaves the status alone --
+        // so without this the tool would report a success that never happened.
+        const { request: before } = await withForbiddenGuidance(
+          'mark_request_solved',
+          `GET ${endpoint}`,
+          () => zendeskGet<{ request: ZendeskRequest }>(subdomain, token, endpoint),
+        );
+        if (before.status === 'solved' || before.status === 'closed') {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Request #${request_id} is already **${before.status}**. Nothing to do.`,
+              },
+            ],
+          };
+        }
+        if (!before.can_be_solved_by_me) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text:
+                  `Request #${request_id} cannot be marked solved by you: Zendesk only allows ` +
+                  'that once an agent has been assigned to it. It is currently ' +
+                  `**${before.status}**. Sending it anyway would return success and change ` +
+                  'nothing, so it was not sent. Use add_request_comment to tell the agents it ' +
+                  'is resolved on your side.',
+              },
+            ],
+          };
+        }
+
+        const { request: after } = await withForbiddenGuidance(
+          'mark_request_solved',
+          `PUT ${endpoint}`,
+          () =>
+            zendeskPut<{ request: ZendeskRequest }>(subdomain, token, endpoint, {
+              request: { solved: true },
+            }),
+        );
+        // Verified from the response body rather than assumed from the 2xx.
+        const text =
+          after.status === 'solved'
+            ? `Request #${request_id} is now **solved**.`
+            : `Zendesk accepted the update but request #${request_id} is still **${after.status}**, ` +
+              'so it was not solved. This usually means the assignment changed between the check ' +
+              'and the update; re-read it with get_request.';
+        return { content: [{ type: 'text', text }] };
+      },
+    },
+  ];
+};

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -5,7 +5,6 @@ import {
   zendeskGet,
   zendeskPost,
   zendeskPut,
-  zendeskUpload,
 } from '../client/zendesk-api';
 import {
   DEFAULT_PAGE_SIZE,
@@ -28,7 +27,6 @@ import type {
   ZendeskTicket,
   ZendeskTicketAttachment,
   ZendeskTicketField,
-  ZendeskUpload,
   ZendeskUser,
   ZendeskView,
   ZendeskViewCount,
@@ -61,6 +59,12 @@ import {
   PAGE_DESC,
   PER_PAGE_DESC,
 } from '../utils/pagination';
+import {
+  type AttachmentInput,
+  attachmentSchema,
+  formatAttachmentSuffix,
+  uploadAttachments,
+} from './attachments';
 import type { ToolContext, ToolDefinition, ToolImageContent, ToolTextContent } from './definitions';
 
 // The per-image cap in MB, for the skip message. Derived once: both operands
@@ -555,39 +559,6 @@ const formatMacroPreviewDiff = (
 export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
   const { subdomain, getToken } = ctx;
 
-  const attachmentSchema = z.object({
-    file_name: z.string().min(1).describe('File name, e.g. "app.log" or "screenshot.png".'),
-    file_base64: z.string().min(1).base64().describe('File content encoded as base64.'),
-    content_type: z
-      .string()
-      .min(1)
-      .default('application/octet-stream')
-      .describe('MIME type, e.g. "text/plain", "image/png", "application/pdf".'),
-  });
-  type AttachmentInput = z.infer<typeof attachmentSchema>;
-
-  // Upload each file via the Zendesk Uploads API, aggregating them under a single
-  // upload token (the token from the first upload is passed to the next), and
-  // return that token for use in a comment's `uploads` array.
-  const uploadAttachments = async (token: string, files: AttachmentInput[]): Promise<string> => {
-    let uploadToken: string | undefined;
-    for (const file of files) {
-      const { upload } = await zendeskUpload<{ upload: ZendeskUpload }>(
-        subdomain,
-        token,
-        file.file_name,
-        Buffer.from(file.file_base64, 'base64'),
-        file.content_type,
-        uploadToken,
-      );
-      uploadToken = upload.token;
-    }
-    return uploadToken as string;
-  };
-
-  const formatAttachmentSuffix = (count?: number): string =>
-    count ? ` with ${count} attachment(s)` : '';
-
   return [
     {
       name: 'get_ticket',
@@ -1033,7 +1004,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         };
         const token = await getToken();
         const uploads = attachments?.length
-          ? [await uploadAttachments(token, attachments)]
+          ? [await uploadAttachments(subdomain, token, attachments)]
           : undefined;
         await zendeskPut(subdomain, token, `/tickets/${ticket_id}`, {
           ticket: { comment: { body, public: false, ...(uploads && { uploads }) } },
@@ -1083,7 +1054,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         };
         const token = await getToken();
         const uploads = attachments?.length
-          ? [await uploadAttachments(token, attachments)]
+          ? [await uploadAttachments(subdomain, token, attachments)]
           : undefined;
         await zendeskPut(subdomain, token, `/tickets/${ticket_id}`, {
           ticket: { comment: { body, public: true, ...(uploads && { uploads }) } },

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,13 +132,30 @@ export interface ZendeskTicketForm {
 
 // One condition set inside a form's `end_user_conditions`: when
 // `parent_field_id` holds `value`, the listed `child_fields` become visible,
-// each with its own `is_required` override. Rendered verbatim for the model to
-// reason about rather than evaluated -- whether the Requests API enforces these
+// each with its own `is_required` override. Rendered for the model to reason
+// about rather than evaluated -- whether the Requests API enforces these
 // server-side is unverified (no form on the probed instance carried any).
+//
+// `required_on_statuses` narrows `is_required` to particular ticket statuses,
+// and Zendesk documents it as applying to end-user forms, not only agent ones
+// (https://support.zendesk.com/hc/en-us/articles/4408846008218). It is what
+// makes `is_required` alone insufficient for a submission-time tool: a field
+// required only "when open" is NOT required of the customer submitting a new
+// request. Optional because a form without status-scoped requirements omits it.
+export interface ZendeskFormConditionChild {
+  id: number;
+  is_required?: boolean;
+  required_on_statuses?: {
+    /** ALL_STATUSES ignores `statuses`; NO_STATUSES means required nowhere. */
+    type?: 'ALL_STATUSES' | 'SOME_STATUSES' | 'NO_STATUSES';
+    statuses?: string[];
+  };
+}
+
 export interface ZendeskFormCondition {
   parent_field_id: number;
   value: unknown;
-  child_fields?: Array<{ id: number; is_required?: boolean; required_on_statuses?: unknown }>;
+  child_fields?: ZendeskFormConditionChild[];
 }
 
 // GET /api/v2/views — a Zendesk view: a saved, per-agent ticket queue

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,15 @@ export interface ZendeskFieldOption {
 // `id` is what create_ticket / update_ticket custom_fields expect; `type`
 // determines whether `custom_field_options` (dropdown/multiselect) or
 // `system_field_options` (system fields like priority) carry the valid values.
+//
+// The `*_in_portal` trio describes the field as an END USER sees it on a
+// request form, and is a different axis from `active`/`required`, which are the
+// agent-side flags. A field can be `required: false` (an agent may solve a
+// ticket without it) yet `required_in_portal: true` (a customer cannot submit
+// without it) -- so the end-user tools read the portal flags and never the
+// agent ones. Present on every object the endpoint returns, for both roles, but
+// declared optional because `GET /ticket_fields` is also the agent-facing
+// listing and nothing should start depending on them there.
 export interface ZendeskTicketField {
   id: number;
   type: string;
@@ -86,6 +95,50 @@ export interface ZendeskTicketField {
   tag?: string | null;
   custom_field_options?: ZendeskFieldOption[];
   system_field_options?: ZendeskFieldOption[];
+  /** Whether the field is shown to end users on a request form. */
+  visible_in_portal?: boolean;
+  /** Whether an end user must fill it to submit. Independent of `required`. */
+  required_in_portal?: boolean;
+  /** Whether an end user may change it after submitting. */
+  editable_in_portal?: boolean;
+  /** The label shown to end users; may differ from the agent-side `title`. */
+  title_in_portal?: string;
+}
+
+// GET /api/v2/ticket_forms — a request form: the named set of fields a customer
+// picks between on the Help Center ("Bug", "Feature request", ...). Readable by
+// end users, who receive only the forms marked `end_user_visible`; Zendesk does
+// NOT filter out inactive ones, so `active` still has to be honoured.
+//
+// `ticket_field_ids` is a SUPERSET of what any one submitter sees:
+// `end_user_conditions` can hide a field, or make it required, depending on
+// another field's value. We surface those conditions as data rather than
+// evaluating them (see the end-user tool descriptions).
+//
+// `display_name` is the customer-facing name and `name` the internal one; the
+// `raw_*` variants may hold an unresolved dynamic-content placeholder
+// (`{{dc.some_key}}`), so the resolved fields are the ones to render.
+export interface ZendeskTicketForm {
+  id: number;
+  name: string;
+  display_name: string;
+  active: boolean;
+  end_user_visible: boolean;
+  default: boolean;
+  position?: number;
+  ticket_field_ids: number[];
+  end_user_conditions?: ZendeskFormCondition[];
+}
+
+// One condition set inside a form's `end_user_conditions`: when
+// `parent_field_id` holds `value`, the listed `child_fields` become visible,
+// each with its own `is_required` override. Rendered verbatim for the model to
+// reason about rather than evaluated -- whether the Requests API enforces these
+// server-side is unverified (no form on the probed instance carried any).
+export interface ZendeskFormCondition {
+  parent_field_id: number;
+  value: unknown;
+  child_fields?: Array<{ id: number; is_required?: boolean; required_on_statuses?: unknown }>;
 }
 
 // GET /api/v2/views — a Zendesk view: a saved, per-agent ticket queue
@@ -216,6 +269,43 @@ export interface ZendeskComment {
   public: boolean;
   created_at: string;
   attachments?: ZendeskTicketAttachment[];
+}
+
+// GET/POST/PUT /api/v2/requests — a ticket as its REQUESTER sees it. Not a
+// trimmed ZendeskTicket: there is no `tags`, `assignee_id` is only present when
+// the form exposes it to end users, and `can_be_solved_by_me` exists nowhere
+// else. Hence a dedicated interface and a dedicated formatter.
+//
+// `can_be_solved_by_me` is read-only and tracks ASSIGNMENT, not status: false
+// while the ticket is unassigned, true once an agent owns it and the type is
+// not `problem`. Writing `solved: true` when it is false returns 200 and
+// changes nothing, so it has to be checked before offering the operation.
+export interface ZendeskRequest {
+  id: number;
+  subject: string;
+  description: string;
+  status: string;
+  priority?: string | null;
+  type?: string | null;
+  requester_id: number;
+  organization_id?: number | null;
+  ticket_form_id?: number | null;
+  can_be_solved_by_me?: boolean;
+  due_at?: string | null;
+  custom_fields?: Array<{ id: number; value: unknown }>;
+  via?: { channel?: string };
+  created_at: string;
+  updated_at: string;
+}
+
+// The `users` sideload that `GET /requests/{id}/comments` returns by default.
+// Five keys only -- no email, no role -- so it is safe to render to the
+// requester, and `agent` is what tells an agent's reply from the customer's own
+// comment without guessing from ids.
+export interface ZendeskRequestCommentAuthor {
+  id: number;
+  name: string;
+  agent: boolean;
 }
 
 // GET /api/v2/tickets/{id}/audits — the immutable, chronological record of every
@@ -420,6 +510,8 @@ export interface ZendeskListResponse<T> {
   permission_groups?: T[];
   sla_policies?: T[];
   ticket_fields?: T[];
+  ticket_forms?: T[];
+  requests?: T[];
   macros?: T[];
   meta?: {
     has_more: boolean;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -13,6 +13,8 @@ import type {
   ZendeskMacroAction,
   ZendeskOrganization,
   ZendeskPermissionGroup,
+  ZendeskRequest,
+  ZendeskRequestCommentAuthor,
   ZendeskSection,
   ZendeskSlaLiveMetric,
   ZendeskSlaPolicy,
@@ -200,6 +202,54 @@ export const formatComment = (comment: ZendeskComment): string => {
   ];
   if (comment.attachments?.length) {
     const summary = comment.attachments.map((a) => `#${a.id} (${a.content_type})`).join(', ');
+    lines.push(`Attachments: ${summary}`);
+  }
+  lines.push('', comment.body);
+  return lines.join('\n');
+};
+
+// A request as its requester sees it. Deliberately NOT formatTicket: that one
+// dereferences `ticket.tags.length` unguarded and a Request carries no `tags`,
+// so reusing it would throw; it also renders `assignee_id`, which end users are
+// not shown, and omits `can_be_solved_by_me`, which is the field that decides
+// whether the "mark solved" operation is even offered.
+export const formatRequest = (request: ZendeskRequest): string =>
+  [
+    `## Request #${request.id}: ${request.subject}`,
+    `- **Status**: ${request.status}${request.type ? ` | **Type**: ${request.type}` : ''}${
+      request.priority ? ` | **Priority**: ${request.priority}` : ''
+    }`,
+    request.ticket_form_id ? `- **Form**: ${request.ticket_form_id}` : '',
+    // Stated in both directions on purpose: "no" is the answer to "can I close
+    // this?", and leaving it implicit invites a pointless attempt that Zendesk
+    // would accept with a 200 and silently ignore.
+    `- **Can you mark it solved**: ${request.can_be_solved_by_me ? 'yes' : 'no'}`,
+    request.via?.channel ? `- **Submitted via**: ${request.via.channel}` : '',
+    `- **Created**: ${request.created_at} | **Updated**: ${request.updated_at}`,
+    request.description ? `\n${request.description}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+// A comment on one's own request. formatComment is wrong here twice over: it
+// labels a non-public comment "Internal note", which cannot reach this path at
+// all (Zendesk filters agent notes out of /requests/{id}/comments), and it
+// prints a bare `author_id` where the endpoint hands us a `users` sideload with
+// a name and an `agent` flag -- which is exactly what tells an agent's reply
+// from the customer's own comment.
+export const formatRequestComment = (
+  comment: ZendeskComment,
+  authors: Map<number, ZendeskRequestCommentAuthor>,
+): string => {
+  const author = authors.get(comment.author_id);
+  const who = author
+    ? `${author.name}${author.agent ? ' (support agent)' : ''}`
+    : `user ${comment.author_id}`;
+  const lines = [`### Comment by ${who}`, `*${comment.created_at}*`];
+  if (comment.attachments?.length) {
+    const summary = comment.attachments
+      .map((a) => `${a.file_name} (#${a.id}, ${a.content_type})`)
+      .join(', ');
     lines.push(`Attachments: ${summary}`);
   }
   lines.push('', comment.body);

--- a/tests/functional/STATE.md
+++ b/tests/functional/STATE.md
@@ -1,6 +1,6 @@
 ---
-branch: claude/issue-100-analysis-tj9dq9
-current_run: 2026-06-26-pr102
+branch: claude/issue-48-analysis-czaqzt
+current_run: 2026-09-03-pr264
 holder: leading
 ---
 
@@ -18,3 +18,4 @@ raw + report artifacts.
 | 03-single-readonly     | OK      | 2026-06-06  |
 | 04-all-baseline        | OK      | 2026-06-06  |
 | 05-strict-params       | OK      | 2026-06-27  |
+| 06-requests-namespace  | PENDING | 2026-09-03  |

--- a/tests/functional/scenarios/06-requests-namespace/expected.md
+++ b/tests/functional/scenarios/06-requests-namespace/expected.md
@@ -1,0 +1,60 @@
+# ⚠️ LEADING LLM ONLY — DO NOT READ IF YOU ARE THE EXECUTOR
+
+Reading this file biases the report. Stop now and read only `spec.md`.
+
+---
+
+## Expected values (verdict criteria)
+
+- **A1 — opt-in, negative.** No entry named `zendesk_requests` in the default
+  listing. This is the load-bearing assertion of the scenario: `requests` is
+  excluded from `DEFAULT_NAMESPACES` in `src/config.ts`, so an operator who does
+  not ask for it must not receive it.
+- **A2 — no collateral drift.** The default listing still holds the same three
+  proxies as scenario 02 (`zendesk_tickets`, `zendesk_help_center`,
+  `zendesk_users`). A count of 4 means the opt-in gate leaked.
+- **A3 — opt-in, positive.** `tools.length === 1`, name `zendesk_requests`.
+  `--namespace` REPLACES the default set rather than adding to it, so the
+  agent proxies must be gone here.
+- **A4 — operation count.** Exactly 7 `- **<name>**:` lines in the proxy
+  description (`buildOperationList` emits one per operation).
+- **A5 — operation names.** Set equality; order follows the factory and is not
+  asserted.
+- **A6 — write markers.** Exactly 3 carry the ` (write)` suffix:
+  `create_request`, `add_request_comment`, `mark_request_solved`. The four reads
+  must not.
+- **A7 — strict schemas.** `additionalProperties: false` on all 7, including
+  `list_request_forms`, whose schema is `z.object({})` and must still serialize
+  as `{type:"object", properties:{}, additionalProperties:false}` (#100).
+- **A8 — parameter descriptions.** Every property under
+  `inputSchema.properties` has a non-empty `description`. This is the Glama
+  Parameter Semantics dimension, and the deterministic floor
+  (`tests/unit/tools/tool-quality.test.ts`) already gates it — a failure here
+  means the wire serialization dropped what the Zod schema carried.
+- **A9 — audience disambiguation.** Each first sentence must scope the tool to
+  the signed-in user's own requests. Only the first sentence is surfaced by a
+  namespace proxy (`summarizeDescription`), and these tools can be exposed
+  alongside `list_tickets` / `create_ticket` / `add_public_comment`, so an
+  ambiguous opener is a real defect, not a style note.
+- **A10 — the phantom-solve disclosure.** Must say the operation is refused
+  unless the requester may actually solve the request. Zendesk answers 200 and
+  changes nothing otherwise, so a model that does not know this will report a
+  success that never happened.
+- **A11 — the reopen disclosure.** Must say a reply on a solved request reopens
+  it. Measured behaviour; a user should not reopen their ticket unknowingly.
+- **A12 — the diagnostic flag.** Output names `zendesk_requests` and its 7
+  operations. Crucially it must NOT open a browser or block on OAuth: tool
+  definitions are pure and `--print-tools` short-circuits before the token
+  store is built. A browser window opening here is a failure.
+
+## Failure diagnostics
+
+| If FAIL on | Likely cause | Where to look |
+| ---------- | ------------ | ------------- |
+| A1, A2 | `requests` leaked into the default set, or the default is applied in `loadConfig` instead of the schema (so `ConfigSchema.parse` callers miss it) | `src/config.ts` `DEFAULT_NAMESPACES` and the `namespaces` field |
+| A3 | `--namespace` treated as additive, or `NAMESPACE_LABELS` missing the `requests` entry (which would silently register no proxy) | `src/routing/registry.ts`, `src/server.ts` `case 'namespace'` |
+| A4, A5 | A tool missing from `createRequestTools`, or filtered out unexpectedly | `src/tools/requests.ts`, `src/tools/index.ts` |
+| A6 | `readOnly` flag wrong on a definition; check it matches `annotations.readOnlyHint` | `src/tools/requests.ts` |
+| A7 | Strict-schema registration regressed | `src/server.ts` (`inputSchema.strict()`) |
+| A8, A9, A10, A11 | Description or `.describe()` text weakened | `src/tools/requests.ts` |
+| A12 | `--print-tools` wired after the token store, or rendering diverged from `registerToolset` | `src/index.ts`, `src/routing/print.ts` |

--- a/tests/functional/scenarios/06-requests-namespace/spec.md
+++ b/tests/functional/scenarios/06-requests-namespace/spec.md
@@ -1,0 +1,88 @@
+---
+pr: 264
+mode: namespace
+read_only: false
+namespaces: [requests]
+channels: [A]
+---
+
+# 06 — requests namespace (end-user surface, opt-in)
+
+Verify at the wire level that the end-user request surface is **opt-in**: absent
+from the default `tools/list`, present and complete when `--namespace requests`
+is passed, and that its descriptions disambiguate it from the agent ticket
+tools it sits beside.
+
+## Steps
+
+1. Make sure you've built once on this branch: `pnpm build`.
+2. Make sure `ZENDESK_SUBDOMAIN` is exported (see `tests/functional/README.md`).
+3. Dump **three** listings:
+
+   ```sh
+   # a) the default surface — the end-user proxy must NOT be here
+   node tests/functional/bin/dump-tools-list.mjs \
+     > tests/functional/reports/06-requests-namespace.default.raw.json
+
+   # b) the opt-in surface, proxied
+   node tests/functional/bin/dump-tools-list.mjs --namespace requests \
+     > tests/functional/reports/06-requests-namespace.raw.json
+
+   # c) the opt-in surface, flat, so every tool's own schema is visible
+   node tests/functional/bin/dump-tools-list.mjs --namespace requests --mode all \
+     > tests/functional/reports/06-requests-namespace.flat.raw.json
+   ```
+
+4. Also run the diagnostic flag and paste its output verbatim into the report —
+   it needs no credential and makes no network call:
+
+   ```sh
+   node dist/index.js "$ZENDESK_SUBDOMAIN" --print-tools --namespace requests
+   ```
+
+5. Inspect the JSON. For (c), look at each entry's `name`, `description` and
+   `inputSchema`.
+6. Fill in the report at
+   `tests/functional/reports/06-requests-namespace.report.md`.
+
+## Assertions to record
+
+For each assertion, set `pass: true|false`, fill `actual` with the value you
+observed, and copy the `desc` verbatim. **Do not** look up expected values —
+`expected.md` is off-limits to you.
+
+```json
+{
+  "scenario": "06-requests-namespace",
+  "mode": "namespace",
+  "readOnly": false,
+  "namespaces": ["requests"],
+  "branch": "claude/issue-48-analysis-czaqzt",
+  "assertions": [
+    { "id": "A1", "desc": "in the DEFAULT listing (a), no tool is named zendesk_requests",             "pass": null, "actual": null },
+    { "id": "A2", "desc": "in the DEFAULT listing (a), the tool count is unchanged from scenario 02",  "pass": null, "actual": null },
+    { "id": "A3", "desc": "with --namespace requests (b), tools/list returns exactly 1 entry named zendesk_requests", "pass": null, "actual": null },
+    { "id": "A4", "desc": "that proxy's description lists exactly 7 operations",                        "pass": null, "actual": null },
+    { "id": "A5", "desc": "the operation names are list_request_forms, get_request_form, create_request, list_requests, get_request, add_request_comment, mark_request_solved", "pass": null, "actual": null },
+    { "id": "A6", "desc": "exactly 3 of those operations are marked (write) in the proxy description", "pass": null, "actual": null },
+    { "id": "A7", "desc": "in flat mode (c), every entry has inputSchema.additionalProperties === false", "pass": null, "actual": null },
+    { "id": "A8", "desc": "in flat mode (c), every parameter of every entry has a non-empty description", "pass": null, "actual": null },
+    { "id": "A9", "desc": "each of the 7 descriptions' FIRST sentence makes clear it acts on the caller's own requests, not an agent queue", "pass": null, "actual": null },
+    { "id": "A10", "desc": "mark_request_solved's description states that it is refused when the request is not solvable by its requester", "pass": null, "actual": null },
+    { "id": "A11", "desc": "add_request_comment's description states that replying to a solved request reopens it", "pass": null, "actual": null },
+    { "id": "A12", "desc": "--print-tools output names zendesk_requests and its 7 operations, with no network call and no auth prompt", "pass": null, "actual": null }
+  ],
+  "summary": "<one-line synthesis: green / which IDs failed>"
+}
+```
+
+Record the `--print-tools` output verbatim under a `## print-tools` heading in
+the report — it is the artifact for A12.
+
+## When done
+
+1. Update `tests/functional/STATE.md`: set this scenario `status: done`,
+   bump `holder` to `leading`.
+2. `git add tests/functional/reports/06-requests-namespace.* tests/functional/STATE.md`.
+3. Commit with `test(functional): run scenario 06-requests-namespace` and push.
+4. Notify the leading LLM in chat.

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -252,8 +252,28 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(names).toContain('zendesk_tickets');
         expect(names).toContain('zendesk_help_center');
         expect(names).toContain('zendesk_users');
+        // The end-user surface is opt-in: absent unless named explicitly.
+        expect(names).not.toContain('zendesk_requests');
         // No individual tools leak through the proxy facade.
         expect(names).not.toContain('get_current_user');
+      });
+
+      it('exposes the requests proxy only when that namespace is named', async () => {
+        connected = await harness.connect(
+          makeConfig({ mode: 'namespace', namespaces: ['requests'] }),
+        );
+        const { tools } = await connected.client.listTools();
+
+        expect(toolNames(tools)).toEqual(['zendesk_requests']);
+      });
+
+      it('leaves the end-user tools out of flat mode by default', async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const names = toolNames((await connected.client.listTools()).tools);
+
+        expect(names).toContain('get_ticket');
+        expect(names).not.toContain('create_request');
+        expect(names).not.toContain('list_request_forms');
       });
 
       it('exposes a single proxy in "single" mode', async () => {
@@ -268,6 +288,20 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         const { tools } = await connected.client.listTools();
 
         expect(toolNames(tools)).toEqual(['zendesk_users']);
+      });
+
+      it('applies the read-only filter to the opt-in namespace too', async () => {
+        connected = await harness.connect(
+          makeConfig({ mode: 'all', namespaces: ['requests'], readOnly: true }),
+        );
+        const names = toolNames((await connected.client.listTools()).tools);
+
+        // "Follow my tickets but do not let me open new ones" is a real
+        // deployment shape, and it falls out of the existing filter for free.
+        expect(names).toContain('list_requests');
+        expect(names).toContain('get_request');
+        expect(names).not.toContain('create_request');
+        expect(names).not.toContain('mark_request_solved');
       });
 
       it('applies the read-only filter', async () => {
@@ -410,6 +444,83 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         // Per-section presence status, not a word-count verdict.
         expect(text).toContain('| Idx | Heading | Status');
         expect(text).not.toContain('different');
+      });
+
+      it('walks the end-user journey through the requests proxy (#48)', async () => {
+        // The opt-in namespace has to be named, both here and in production.
+        connected = await harness.connect(
+          makeConfig({ mode: 'namespace', namespaces: ['requests'] }),
+        );
+
+        const forms = await connected.client.callTool({
+          name: 'zendesk_requests',
+          arguments: { operation: 'list_request_forms', params: {} },
+        });
+        expect(forms.isError).toBeFalsy();
+        expect(textOf(forms)).toContain('Report a bug');
+
+        // The form spec is the cross-call join: the form carries field ids, and
+        // the field definitions come from a second endpoint.
+        const spec = await connected.client.callTool({
+          name: 'zendesk_requests',
+          arguments: { operation: 'get_request_form', params: { form_id: 900 } },
+        });
+        expect(spec.isError).toBeFalsy();
+        expect(textOf(spec)).toContain('How severe is it? (field id 360000000001)');
+
+        const submitted = await connected.client.callTool({
+          name: 'zendesk_requests',
+          arguments: {
+            operation: 'create_request',
+            params: {
+              subject: 'Export is broken',
+              body: 'Nothing downloads.',
+              form_id: 900,
+              custom_fields: [{ id: 360000000001, value: 'severity_2' }],
+            },
+          },
+        });
+        expect(submitted.isError).toBeFalsy();
+        expect(textOf(submitted)).toContain('submitted');
+
+        const thread = await connected.client.callTool({
+          name: 'zendesk_requests',
+          arguments: {
+            operation: 'get_request',
+            params: { request_id: 5001, include_comments: true },
+          },
+        });
+        expect(thread.isError).toBeFalsy();
+        expect(textOf(thread)).toContain('Comment by Sam Support (support agent)');
+      });
+
+      it('refuses to report a phantom solve through the requests proxy (#48)', async () => {
+        connected = await harness.connect(
+          makeConfig({ mode: 'namespace', namespaces: ['requests'] }),
+        );
+
+        // Request 5002 is unassigned, so Zendesk would answer 200 and change
+        // nothing. Over the wire, that must read as a refusal, not a success.
+        const result = await connected.client.callTool({
+          name: 'zendesk_requests',
+          arguments: { operation: 'mark_request_solved', params: { request_id: 5002 } },
+        });
+        expect(result.isError).toBeFalsy();
+        expect(textOf(result)).toContain('cannot be marked solved by you');
+      });
+
+      it('cannot reach a ticket operation through the requests proxy (#48)', async () => {
+        connected = await harness.connect(
+          makeConfig({ mode: 'namespace', namespaces: ['requests'] }),
+        );
+
+        // Each proxy dispatches only within its own namespace, so the end-user
+        // proxy must not be a back door to the agent surface.
+        const result = await connected.client.callTool({
+          name: 'zendesk_requests',
+          arguments: { operation: 'create_ticket', params: { subject: 'x', description: 'y' } },
+        });
+        expect(textOf(result)).toContain('Unknown operation "create_ticket"');
       });
 
       it('audits then publishes a section translation through the help_center proxy (#224)', async () => {

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -161,6 +161,27 @@ export const MOCK_TICKET_FIELD_PORTAL_OPTIONAL = {
 // GET /ticket_forms — the forms an end user picks between. `display_name` is
 // deliberately different from `name` (customer-facing vs internal), which is
 // what list_request_forms has to surface.
+// The parent field of a conditional rule. Portal-visible and portal-OPTIONAL on
+// purpose: a condition gates on an answer the submitter gives freely, and
+// keeping it optional leaves MOCK_TICKET_FORM_FEATURE as the form with no
+// required custom field.
+export const MOCK_TICKET_FIELD_CONDITION_PARENT = {
+  id: 360000000003,
+  type: 'tagger',
+  title: 'Blocking',
+  description: 'Does this stop you working?',
+  active: true,
+  required: false,
+  visible_in_portal: true,
+  required_in_portal: false,
+  editable_in_portal: true,
+  title_in_portal: 'Is it blocking you?',
+  custom_field_options: [
+    { name: 'Yes', value: 'yes' },
+    { name: 'No', value: 'no' },
+  ],
+};
+
 export const MOCK_TICKET_FORM_BUG = {
   id: 900,
   name: 'Bug report (internal)',
@@ -183,11 +204,16 @@ export const MOCK_TICKET_FORM_FEATURE = {
   end_user_visible: true,
   default: false,
   position: 2,
-  ticket_field_ids: [1, 2, 360000000002],
+  // The condition's parent field is ON the form: a real Zendesk form cannot gate
+  // on a field a submitter has no way to answer, and leaving it out made the
+  // rendered rule name a field absent from the same output. It is deliberately
+  // the OPTIONAL parent, so this form keeps being the one whose only
+  // portal-required fields are the system ones.
+  ticket_field_ids: [1, 2, 360000000003, 360000000002],
   end_user_conditions: [
     {
-      parent_field_id: 360000000001,
-      value: 'severity_1',
+      parent_field_id: 360000000003,
+      value: 'yes',
       child_fields: [{ id: 360000000002, is_required: true }],
     },
   ],
@@ -961,6 +987,7 @@ export const handlers = [
         MOCK_TICKET_FIELD_SYSTEM,
         MOCK_TICKET_FIELD_CUSTOM,
         MOCK_TICKET_FIELD_PORTAL_OPTIONAL,
+        MOCK_TICKET_FIELD_CONDITION_PARENT,
       ],
       meta: { has_more: false, after_cursor: '' },
     }),

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -115,6 +115,35 @@ export const MOCK_TICKET_FIELD_CUSTOM = {
   ],
 };
 
+// The system subject and description fields. EVERY real Zendesk form carries
+// these and marks them required in the portal, and their absence from the
+// fixtures is what hid a blocking bug: treating them as custom fields made
+// create_request demand "Subject (field id 1)" in `custom_fields`, which no
+// caller can satisfy. They belong in the form fixture for that reason.
+export const MOCK_TICKET_FIELD_SUBJECT = {
+  id: 1,
+  type: 'subject',
+  title: 'Subject',
+  description: null,
+  active: true,
+  required: true,
+  visible_in_portal: true,
+  required_in_portal: true,
+  editable_in_portal: true,
+};
+
+export const MOCK_TICKET_FIELD_DESCRIPTION = {
+  id: 2,
+  type: 'description',
+  title: 'Description',
+  description: null,
+  active: true,
+  required: true,
+  visible_in_portal: true,
+  required_in_portal: true,
+  editable_in_portal: true,
+};
+
 // A portal-visible but OPTIONAL field, so the required/optional split in the
 // form spec is exercised rather than assumed.
 export const MOCK_TICKET_FIELD_PORTAL_OPTIONAL = {
@@ -140,7 +169,7 @@ export const MOCK_TICKET_FORM_BUG = {
   end_user_visible: true,
   default: true,
   position: 1,
-  ticket_field_ids: [10, 360000000001, 360000000002],
+  ticket_field_ids: [1, 2, 10, 360000000001, 360000000002],
   end_user_conditions: [],
 };
 
@@ -154,7 +183,7 @@ export const MOCK_TICKET_FORM_FEATURE = {
   end_user_visible: true,
   default: false,
   position: 2,
-  ticket_field_ids: [360000000002],
+  ticket_field_ids: [1, 2, 360000000002],
   end_user_conditions: [
     {
       parent_field_id: 360000000001,
@@ -880,6 +909,8 @@ export const handlers = [
   http.get(`${BASE}/ticket_fields`, () =>
     HttpResponse.json({
       ticket_fields: [
+        MOCK_TICKET_FIELD_SUBJECT,
+        MOCK_TICKET_FIELD_DESCRIPTION,
         MOCK_TICKET_FIELD_SYSTEM,
         MOCK_TICKET_FIELD_CUSTOM,
         MOCK_TICKET_FIELD_PORTAL_OPTIONAL,

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -85,6 +85,10 @@ export const MOCK_TICKET_FIELD_SYSTEM = {
   description: 'Ticket priority',
   active: true,
   required: false,
+  // Agents see priority; customers do not. Keeps the end-user tools' portal
+  // filter honest instead of every fixture field being visible.
+  visible_in_portal: false,
+  required_in_portal: false,
   system_field_options: [
     { name: 'Low', value: 'low' },
     { name: 'High', value: 'high' },
@@ -99,9 +103,131 @@ export const MOCK_TICKET_FIELD_CUSTOM = {
   active: true,
   required: true,
   tag: null,
+  // Portal-visible AND portal-required, with a customer-facing label that
+  // differs from the agent title -- the case the end-user form spec must render.
+  visible_in_portal: true,
+  required_in_portal: true,
+  editable_in_portal: true,
+  title_in_portal: 'How severe is it?',
   custom_field_options: [
     { name: 'Sev-1', value: 'severity_1' },
     { name: 'Sev-2', value: 'severity_2' },
+  ],
+};
+
+// A portal-visible but OPTIONAL field, so the required/optional split in the
+// form spec is exercised rather than assumed.
+export const MOCK_TICKET_FIELD_PORTAL_OPTIONAL = {
+  id: 360000000002,
+  type: 'text',
+  title: 'Affected version',
+  description: 'Which version were you using?',
+  active: true,
+  required: false,
+  visible_in_portal: true,
+  required_in_portal: false,
+  editable_in_portal: true,
+};
+
+// GET /ticket_forms — the forms an end user picks between. `display_name` is
+// deliberately different from `name` (customer-facing vs internal), which is
+// what list_request_forms has to surface.
+export const MOCK_TICKET_FORM_BUG = {
+  id: 900,
+  name: 'Bug report (internal)',
+  display_name: 'Report a bug',
+  active: true,
+  end_user_visible: true,
+  default: true,
+  position: 1,
+  ticket_field_ids: [10, 360000000001, 360000000002],
+  end_user_conditions: [],
+};
+
+// A second form carrying a conditional rule, so the condition rendering is
+// covered: answering Severity = sev-1 makes the version field required.
+export const MOCK_TICKET_FORM_FEATURE = {
+  id: 901,
+  name: 'Feature request',
+  display_name: 'Feature request',
+  active: true,
+  end_user_visible: true,
+  default: false,
+  position: 2,
+  ticket_field_ids: [360000000002],
+  end_user_conditions: [
+    {
+      parent_field_id: 360000000001,
+      value: 'severity_1',
+      child_fields: [{ id: 360000000002, is_required: true }],
+    },
+  ],
+};
+
+// GET/POST/PUT /api/v2/requests — a ticket as its requester sees it. No `tags`,
+// no `assignee_id`, and `can_be_solved_by_me` true (an agent is assigned), which
+// is the state in which mark_request_solved is allowed to act.
+export const MOCK_REQUEST = {
+  id: 5001,
+  subject: 'The export button does nothing',
+  description: 'Clicking export spins forever and no file arrives.',
+  status: 'open',
+  priority: 'normal',
+  type: 'incident',
+  requester_id: 456,
+  organization_id: null,
+  ticket_form_id: 900,
+  can_be_solved_by_me: true,
+  due_at: null,
+  custom_fields: [{ id: 360000000001, value: 'severity_2' }],
+  via: { channel: 'web' },
+  created_at: '2026-01-05T09:00:00Z',
+  updated_at: '2026-01-06T11:30:00Z',
+};
+
+// Unassigned, so `can_be_solved_by_me` is false. Zendesk would answer 200 to
+// `solved: true` here and change nothing, which is exactly what the tool must
+// refuse to report as success.
+export const MOCK_REQUEST_UNSOLVABLE = {
+  ...MOCK_REQUEST,
+  id: 5002,
+  subject: 'Feature idea: bulk export',
+  status: 'new',
+  can_be_solved_by_me: false,
+};
+
+// GET /requests/{id}/comments — note the `users` sideload Zendesk returns by
+// default, whose `agent` flag is what tells a support reply from the customer's
+// own comment. Five keys only: no email, nothing agent-private.
+export const MOCK_REQUEST_COMMENTS = {
+  comments: [
+    {
+      id: 9001,
+      body: 'Clicking export spins forever and no file arrives.',
+      author_id: 456,
+      public: true,
+      created_at: '2026-01-05T09:00:00Z',
+    },
+    {
+      id: 9002,
+      body: 'Thanks for the report — which browser are you on?',
+      author_id: 789,
+      public: true,
+      created_at: '2026-01-06T11:30:00Z',
+      attachments: [
+        {
+          id: 4242,
+          file_name: 'diagnostic.txt',
+          content_url: 'https://testsubdomain.zendesk.com/attachments/4242/diagnostic.txt',
+          content_type: 'text/plain',
+          size: 128,
+        },
+      ],
+    },
+  ],
+  users: [
+    { id: 456, name: 'Dana Customer', agent: false },
+    { id: 789, name: 'Sam Support', agent: true },
   ],
 };
 
@@ -691,6 +817,55 @@ export const handlers = [
   ),
   http.post(`${BASE}/uploads`, () => HttpResponse.json({ upload: MOCK_UPLOAD })),
 
+  // --- End-user Requests surface (namespace: requests) ---
+  // Order matters: the literal `/requests/search` must be registered before
+  // `/requests/:id`, or MSW captures "search" as the id.
+  http.get(`${BASE}/ticket_forms`, () =>
+    HttpResponse.json({
+      ticket_forms: [MOCK_TICKET_FORM_BUG, MOCK_TICKET_FORM_FEATURE],
+      count: 2,
+      next_page: null,
+    }),
+  ),
+  http.get(`${BASE}/requests/search`, ({ request }) => {
+    const query = new URL(request.url).searchParams.get('query') ?? '';
+    // Echo the caller's query back through the filter so a search that matches
+    // nothing is distinguishable from one that matches.
+    const requests = query.includes('nothing') ? [] : [MOCK_REQUEST];
+    return HttpResponse.json({ requests, count: requests.length, next_page: null });
+  }),
+  http.get(`${BASE}/requests/:id/comments`, () => HttpResponse.json(MOCK_REQUEST_COMMENTS)),
+  http.get(`${BASE}/requests/:id`, ({ params }) => {
+    const id = Number(params['id']);
+    if (id === MOCK_REQUEST_UNSOLVABLE.id) {
+      return HttpResponse.json({ request: MOCK_REQUEST_UNSOLVABLE });
+    }
+    if (id === 5003) {
+      return HttpResponse.json({ request: { ...MOCK_REQUEST, id: 5003, status: 'solved' } });
+    }
+    return HttpResponse.json({ request: { ...MOCK_REQUEST, id } });
+  }),
+  http.get(`${BASE}/requests`, ({ request }) => {
+    const status = new URL(request.url).searchParams.get('status');
+    const requests = status === 'closed' ? [] : [MOCK_REQUEST];
+    return HttpResponse.json({ requests, count: requests.length, next_page: null });
+  }),
+  http.post(`${BASE}/requests`, async ({ request }) => {
+    const body = (await request.json()) as { request: Record<string, unknown> };
+    return HttpResponse.json({ request: { ...MOCK_REQUEST, id: 5010, ...body.request } });
+  }),
+  http.put(`${BASE}/requests/:id`, async ({ request, params }) => {
+    const body = (await request.json()) as {
+      request: { solved?: boolean; comment?: { body: string } };
+    };
+    // Mirror the two real transitions: `solved: true` solves it, and a comment
+    // on a solved request reopens it.
+    const status = body.request.solved ? 'solved' : 'open';
+    return HttpResponse.json({
+      request: { ...MOCK_REQUEST, id: Number(params['id']), status },
+    });
+  }),
+
   // Macros — active macros for the current user, and the per-ticket apply
   // (preview) endpoint. The apply route sits under /tickets/:id/ but has extra
   // path segments, so it does not collide with the Show Ticket handler above.
@@ -704,7 +879,11 @@ export const handlers = [
   // Ticket field definitions (system + custom), cursor-paginated like /tickets.
   http.get(`${BASE}/ticket_fields`, () =>
     HttpResponse.json({
-      ticket_fields: [MOCK_TICKET_FIELD_SYSTEM, MOCK_TICKET_FIELD_CUSTOM],
+      ticket_fields: [
+        MOCK_TICKET_FIELD_SYSTEM,
+        MOCK_TICKET_FIELD_CUSTOM,
+        MOCK_TICKET_FIELD_PORTAL_OPTIONAL,
+      ],
       meta: { has_more: false, after_cursor: '' },
     }),
   ),

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -128,6 +128,21 @@ describe('loadConfig', () => {
     expect(config.namespaces).toEqual(['requests', 'help_center']);
   });
 
+  // Regression: `--tool` is an inventory picker in its own right. Before the
+  // namespace default existed it could name any tool; leaving the default in
+  // place made `--tool list_requests` resolve to nothing, because filterTools
+  // ANDs the two filters and `requests` is not in the default set.
+  it('opens the namespace filter when --tool names a non-default namespace tool', () => {
+    const config = loadConfig(['mycompany', '--tool', 'list_requests']);
+    expect(config.namespaces).toEqual(['tickets', 'help_center', 'users', 'requests']);
+    expect(config.tools).toEqual(['list_requests']);
+  });
+
+  it('still lets an explicit --namespace win over that widening', () => {
+    const config = loadConfig(['mycompany', '--tool', 'list_requests', '--namespace', 'tickets']);
+    expect(config.namespaces).toEqual(['tickets']);
+  });
+
   it('does not print the tool surface unless asked', () => {
     expect(loadConfig(['mycompany']).printTools).toBe(false);
   });

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { loadConfig, VALUE_FLAG_NAMES } from '../../src/config';
+import { ConfigSchema, DEFAULT_NAMESPACES, loadConfig, VALUE_FLAG_NAMES } from '../../src/config';
 
 describe('loadConfig', () => {
   beforeEach(() => {
@@ -94,6 +94,46 @@ describe('loadConfig', () => {
   it('parses multiple --namespace flags', () => {
     const config = loadConfig(['mycompany', '--namespace', 'tickets', '--namespace', 'users']);
     expect(config.namespaces).toEqual(['tickets', 'users']);
+  });
+
+  // Asserted exactly, not with toContain: the whole point of the default list
+  // is which namespaces it leaves OUT, and a toContain-only test would pass
+  // just as happily if a namespace were dropped from it.
+  it('defaults to the agent namespaces, excluding the opt-in requests surface', () => {
+    const config = loadConfig(['mycompany']);
+    expect(config.namespaces).toEqual(['tickets', 'help_center', 'users']);
+    expect(config.namespaces).not.toContain('requests');
+  });
+
+  it('exposes that same list as DEFAULT_NAMESPACES', () => {
+    expect([...DEFAULT_NAMESPACES]).toEqual(['tickets', 'help_center', 'users']);
+  });
+
+  // The default must not survive an explicit --namespace: opting in to the
+  // end-user surface has to mean *only* that surface, or a customer-facing
+  // deployment would still carry the whole agent toolset.
+  it('replaces the default set entirely when --namespace requests is passed', () => {
+    const config = loadConfig(['mycompany', '--namespace', 'requests']);
+    expect(config.namespaces).toEqual(['requests']);
+  });
+
+  it('accepts requests alongside another namespace', () => {
+    const config = loadConfig([
+      'mycompany',
+      '--namespace',
+      'requests',
+      '--namespace',
+      'help_center',
+    ]);
+    expect(config.namespaces).toEqual(['requests', 'help_center']);
+  });
+
+  it('does not print the tool surface unless asked', () => {
+    expect(loadConfig(['mycompany']).printTools).toBe(false);
+  });
+
+  it('parses --print-tools flag', () => {
+    expect(loadConfig(['mycompany', '--print-tools']).printTools).toBe(true);
   });
 
   it('reads subdomain from env when not in CLI', () => {
@@ -579,5 +619,52 @@ describe('loadConfig', () => {
       expect(config.callbackPort).toBeUndefined();
       expect(config.logLevel).toBe('info');
     });
+  });
+});
+
+// The default lives in the schema rather than in loadConfig because the
+// integration harness parses a Config directly; these assertions pin that.
+describe('ConfigSchema namespaces', () => {
+  const parse = (namespaces?: unknown) =>
+    ConfigSchema.parse({
+      subdomain: 'mycompany',
+      oauthClientId: 'mycompany_zendesk',
+      logLevel: 'info',
+      mode: 'all',
+      readOnly: false,
+      transport: 'stdio',
+      host: '127.0.0.1',
+      port: 0,
+      ...(namespaces === undefined ? {} : { namespaces }),
+    });
+
+  it('applies the default when the field is absent, not only via loadConfig', () => {
+    expect(parse().namespaces).toEqual(['tickets', 'help_center', 'users']);
+  });
+
+  // loadConfig passes printTools explicitly, so its schema default is only ever
+  // reached through this parse path -- which the integration harness uses.
+  it('defaults printTools to false when the field is absent', () => {
+    expect(parse().printTools).toBe(false);
+  });
+
+  it('rejects an empty array instead of treating it as "every namespace"', () => {
+    // filterTools guards on `?.length`, so [] would mean "no filter" and would
+    // quietly expose the opt-in requests surface. Refuse it at parse time.
+    expect(() => parse([])).toThrow();
+  });
+
+  it('rejects an unknown namespace', () => {
+    expect(() => parse(['nope'])).toThrow();
+  });
+
+  it('accepts requests as a namespace', () => {
+    expect(parse(['requests']).namespaces).toEqual(['requests']);
+  });
+
+  it('does not mutate DEFAULT_NAMESPACES when a parsed config is edited', () => {
+    const config = parse();
+    config.namespaces.push('requests');
+    expect([...DEFAULT_NAMESPACES]).toEqual(['tickets', 'help_center', 'users']);
   });
 });

--- a/tests/unit/routing/print.test.ts
+++ b/tests/unit/routing/print.test.ts
@@ -73,14 +73,36 @@ describe('renderToolSurface', () => {
     );
   });
 
-  it('prefixes a read-only proxy with [RO], as the proxy description does', () => {
+  // The server puts the [RO] marker in a proxy's DESCRIPTION, never in its
+  // name. Printing `[RO] zendesk_tickets` here named a tool no client sees, so
+  // read-only is stated in the header instead.
+  it('prints real tool names in read-only mode, not an [RO]-prefixed one', () => {
     const out = renderToolSurface(
       makeConfig({ namespaces: ['tickets'], readOnly: true }),
       twoTools,
     );
-    expect(out).toContain('  [RO] zendesk_tickets');
+    expect(out).toContain('  zendesk_tickets');
+    expect(out).not.toContain('[RO]');
+    expect(out.split('\n')[0]).toContain('Read-only: yes');
     // The write tool is filtered out before the proxy is described.
     expect(out).not.toContain('write_thing');
+  });
+
+  // The point of this output is that it matches the running server, so it has
+  // to honour every filter registerToolset honours -- including this one, which
+  // used to be applied only at registration.
+  it('drops list_promoted_articles when the pre-listing is disabled', () => {
+    const enabled = renderToolSurface(
+      makeConfig({ mode: 'all', namespaces: ['help_center'] }),
+      allTools,
+    );
+    expect(enabled).toContain('list_promoted_articles');
+
+    const disabled = renderToolSurface(
+      makeConfig({ mode: 'all', namespaces: ['help_center'], promotedArticles: false }),
+      allTools,
+    );
+    expect(disabled).not.toContain('list_promoted_articles');
   });
 
   it('renders single mode as one proxy wrapping every operation', () => {

--- a/tests/unit/routing/print.test.ts
+++ b/tests/unit/routing/print.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { type Config, ConfigSchema } from '../../../src/config';
+import { renderToolSurface } from '../../../src/routing/print';
+import type { ToolContext, ToolDefinition } from '../../../src/tools/definitions';
+import { createAllTools } from '../../../src/tools/index';
+
+const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'token' };
+const allTools = createAllTools(ctx);
+
+const makeConfig = (overrides: Partial<Config> = {}): Config =>
+  ConfigSchema.parse({
+    subdomain: 'testsubdomain',
+    oauthClientId: 'testsubdomain_zendesk',
+    logLevel: 'info',
+    mode: 'namespace',
+    readOnly: false,
+    transport: 'stdio',
+    host: '127.0.0.1',
+    port: 0,
+    ...overrides,
+  });
+
+// A minimal pair of definitions, so the mode branches can be asserted on an
+// exact string without the assertion churning every time a real tool is added.
+const stub = (name: string, namespace: ToolDefinition['namespace'], readOnly: boolean) =>
+  ({ name, namespace, readOnly }) as ToolDefinition;
+
+const twoTools = [stub('read_thing', 'tickets', true), stub('write_thing', 'tickets', false)];
+
+describe('renderToolSurface', () => {
+  it('states the knobs in force on the first line', () => {
+    const out = renderToolSurface(makeConfig(), allTools);
+    expect(out.split('\n')[0]).toBe(
+      'Mode: namespace | Namespaces: tickets, help_center, users | Read-only: no',
+    );
+  });
+
+  it('reports read-only mode in the header', () => {
+    const out = renderToolSurface(makeConfig({ readOnly: true }), allTools);
+    expect(out.split('\n')[0]).toContain('Read-only: yes');
+  });
+
+  it('names the --tool filter in the header only when one is set', () => {
+    expect(renderToolSurface(makeConfig(), allTools)).not.toContain('Tool filter');
+    const out = renderToolSurface(makeConfig({ mode: 'all', tools: ['get_ticket'] }), allTools);
+    expect(out).toContain('Tool filter: get_ticket');
+  });
+
+  // Two entries, so the separator itself is asserted and not just the presence
+  // of the names.
+  it('comma-separates several --tool filters', () => {
+    const out = renderToolSurface(
+      makeConfig({ mode: 'all', tools: ['get_ticket', 'list_tickets'] }),
+      allTools,
+    );
+    expect(out.split('\n')[0]).toBe(
+      'Mode: all | Namespaces: tickets, help_center, users | Read-only: no' +
+        ' | Tool filter: get_ticket, list_tickets',
+    );
+  });
+
+  it('renders namespace mode as one proxy per namespace with its operations', () => {
+    const out = renderToolSurface(makeConfig({ namespaces: ['tickets'] }), twoTools);
+    expect(out).toBe(
+      [
+        'Mode: namespace | Namespaces: tickets | Read-only: no',
+        '',
+        '1 proxy tool(s) exposed:',
+        '  zendesk_tickets',
+        '    - read_thing',
+        '    - write_thing (write)',
+      ].join('\n'),
+    );
+  });
+
+  it('prefixes a read-only proxy with [RO], as the proxy description does', () => {
+    const out = renderToolSurface(
+      makeConfig({ namespaces: ['tickets'], readOnly: true }),
+      twoTools,
+    );
+    expect(out).toContain('  [RO] zendesk_tickets');
+    // The write tool is filtered out before the proxy is described.
+    expect(out).not.toContain('write_thing');
+  });
+
+  it('renders single mode as one proxy wrapping every operation', () => {
+    const out = renderToolSurface(
+      makeConfig({ mode: 'single', namespaces: ['tickets'] }),
+      twoTools,
+    );
+    expect(out).toBe(
+      [
+        'Mode: single | Namespaces: tickets | Read-only: no',
+        '',
+        '1 proxy tool exposed, wrapping 2 operation(s):',
+        '  zendesk',
+        '    - read_thing',
+        '    - write_thing (write)',
+      ].join('\n'),
+    );
+  });
+
+  it('renders all mode as a flat list marking the write tools', () => {
+    const out = renderToolSurface(makeConfig({ mode: 'all', namespaces: ['tickets'] }), twoTools);
+    expect(out).toBe(
+      [
+        'Mode: all | Namespaces: tickets | Read-only: no',
+        '',
+        '2 tool(s) exposed individually:',
+        '  read_thing',
+        '  write_thing (write)',
+      ].join('\n'),
+    );
+  });
+
+  it('says so plainly when the filters leave nothing', () => {
+    const out = renderToolSurface(makeConfig({ mode: 'all', tools: ['no_such_tool'] }), allTools);
+    expect(out).toContain('No tools exposed. Check --namespace / --tool / --read-only.');
+  });
+
+  // The whole point of the flag: seeing that the end-user surface is opt-in
+  // without booting a server.
+  it('shows no requests proxy under the default namespaces', () => {
+    const out = renderToolSurface(makeConfig(), allTools);
+    expect(out).not.toContain('zendesk_requests');
+  });
+
+  it('rejects a mode outside the union', () => {
+    const bogus = { ...makeConfig(), mode: 'nope' } as unknown as Config;
+    expect(() => renderToolSurface(bogus, twoTools)).toThrow('Unsupported tool mode: nope');
+  });
+});

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { filterTools, groupByNamespace } from '../../../src/routing/registry';
+import { Namespace } from '../../../src/config';
+import { filterTools, groupByNamespace, NAMESPACE_LABELS } from '../../../src/routing/registry';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createAllTools } from '../../../src/tools/index';
 
@@ -67,5 +68,25 @@ describe('groupByNamespace', () => {
     expect(ticketCount).toBe(18); // 17 ticket tools + 1 search
     expect(hcCount).toBe(29);
     expect(userCount).toBe(5);
+  });
+});
+
+// Asserted as a whole rather than probed key by key. These strings are the
+// client-visible proxy tool names and titles: a typo or an emptied value is a
+// broken tool surface, and nothing else in the suite reads the titles at all.
+describe('NAMESPACE_LABELS', () => {
+  it('maps every namespace to its proxy name and title', () => {
+    expect(NAMESPACE_LABELS).toEqual({
+      tickets: { toolName: 'zendesk_tickets', title: 'Zendesk Tickets' },
+      help_center: { toolName: 'zendesk_help_center', title: 'Zendesk Help Center' },
+      users: { toolName: 'zendesk_users', title: 'Zendesk Users' },
+      requests: { toolName: 'zendesk_requests', title: 'Zendesk Requests' },
+    });
+  });
+
+  // The type already makes an incomplete literal a compile error; this catches
+  // the reverse drift, a label left behind for a namespace that no longer exists.
+  it('covers exactly the Namespace enum, with no extra keys', () => {
+    expect(Object.keys(NAMESPACE_LABELS).sort()).toEqual([...Namespace.options].sort());
   });
 });

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -56,6 +56,7 @@ describe('groupByNamespace', () => {
   it('groups tools by namespace', () => {
     const grouped = groupByNamespace(allTools);
     expect(grouped.has('tickets')).toBe(true);
+    expect(grouped.has('requests')).toBe(true);
     expect(grouped.has('help_center')).toBe(true);
     expect(grouped.has('users')).toBe(true);
   });
@@ -65,9 +66,11 @@ describe('groupByNamespace', () => {
     const ticketCount = grouped.get('tickets')?.length ?? 0;
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
+    const requestCount = grouped.get('requests')?.length ?? 0;
     expect(ticketCount).toBe(18); // 17 ticket tools + 1 search
     expect(hcCount).toBe(29);
     expect(userCount).toBe(5);
+    expect(requestCount).toBe(7);
   });
 });
 

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -52,6 +52,24 @@ describe('filterTools', () => {
   });
 });
 
+describe('filterTools promotedArticles gate', () => {
+  it('keeps list_promoted_articles when the flag is unset or true', () => {
+    const unset = filterTools(allTools, { readOnly: false });
+    const on = filterTools(allTools, { readOnly: false, promotedArticles: true });
+    expect(unset.some((t) => t.name === 'list_promoted_articles')).toBe(true);
+    expect(on.some((t) => t.name === 'list_promoted_articles')).toBe(true);
+  });
+
+  it('drops only that tool when the flag is false', () => {
+    const off = filterTools(allTools, { readOnly: false, promotedArticles: false });
+    expect(off.some((t) => t.name === 'list_promoted_articles')).toBe(false);
+    expect(off).toHaveLength(allTools.length - 1);
+    // Reading a known article by id is unaffected; only the scan-backed
+    // listing goes away.
+    expect(off.some((t) => t.name === 'get_article')).toBe(true);
+  });
+});
+
 describe('groupByNamespace', () => {
   it('groups tools by namespace', () => {
     const grouped = groupByNamespace(allTools);

--- a/tests/unit/tools/requests.test.ts
+++ b/tests/unit/tools/requests.test.ts
@@ -47,6 +47,70 @@ describe('list_request_forms', () => {
     expect(text).not.toContain('Internal name: Feature request');
   });
 
+  // An account with more forms than fit a page would otherwise have some of
+  // them invisible here, and resolveForm would then reject their ids as
+  // "not available to you" -- a confident refusal of a form that exists.
+  it('pages the form listing rather than showing only the first page', async () => {
+    let calls = 0;
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () => {
+        calls += 1;
+        if (calls === 1) {
+          return HttpResponse.json({
+            ticket_forms: [MOCK_TICKET_FORM_BUG],
+            next_page: `${BASE}/ticket_forms?page=2`,
+          });
+        }
+        return HttpResponse.json({
+          ticket_forms: [{ ...MOCK_TICKET_FORM_BUG, id: 902, display_name: 'Billing question' }],
+          next_page: null,
+        });
+      }),
+    );
+    const text = await textOf('list_request_forms', {});
+    expect(calls).toBe(2);
+    expect(text).toContain('Report a bug');
+    expect(text).toContain('Billing question');
+    expect(text).toContain('2 kind(s) of request available');
+  });
+
+  it('can resolve a form that only appears on a later page', async () => {
+    let calls = 0;
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () => {
+        calls += 1;
+        return calls === 1
+          ? HttpResponse.json({
+              ticket_forms: [MOCK_TICKET_FORM_BUG],
+              next_page: `${BASE}/ticket_forms?page=2`,
+            })
+          : HttpResponse.json({
+              ticket_forms: [
+                { ...MOCK_TICKET_FORM_BUG, id: 902, display_name: 'Billing question' },
+              ],
+              next_page: null,
+            });
+      }),
+    );
+    const text = await textOf('get_request_form', { form_id: 902 });
+    expect(text).toContain('Billing question (form id 902)');
+  });
+
+  it('refuses to list forms from a truncated scan', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () =>
+        HttpResponse.json({
+          ticket_forms: [MOCK_TICKET_FORM_BUG],
+          // Always another page: forces the cap.
+          next_page: `${BASE}/ticket_forms?page=99`,
+        }),
+      ),
+    );
+    await expect(textOf('list_request_forms', {})).rejects.toThrow(
+      /could not read all of \/ticket_forms/,
+    );
+  });
+
   it('says so plainly when the Help Center exposes no form', async () => {
     mswServer.use(http.get(`${BASE}/ticket_forms`, () => HttpResponse.json({ ticket_forms: [] })));
     const text = await textOf('list_request_forms', {});
@@ -160,7 +224,7 @@ describe('get_request_form', () => {
       ),
     );
     await expect(textOf('get_request_form', { form_id: 900 })).rejects.toThrow(
-      /could not read every ticket field/,
+      /could not read all of \/ticket_fields/,
     );
   });
 

--- a/tests/unit/tools/requests.test.ts
+++ b/tests/unit/tools/requests.test.ts
@@ -1,10 +1,13 @@
 import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
+import { CHARACTER_LIMIT } from '../../../src/constants';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createRequestTools } from '../../../src/tools/requests';
 import {
   MOCK_REQUEST,
   MOCK_TICKET_FIELD_CUSTOM,
+  MOCK_TICKET_FIELD_DESCRIPTION,
+  MOCK_TICKET_FIELD_SUBJECT,
   MOCK_TICKET_FORM_BUG,
   MOCK_TICKET_FORM_FEATURE,
 } from '../../msw-handlers';
@@ -114,6 +117,28 @@ describe('list_request_forms', () => {
     await expect(textOf('list_request_forms', {})).rejects.toThrow(
       /could not read all of \/ticket_forms/,
     );
+  });
+
+  // The schema is z.object({}) — there is nothing to paginate or filter, so the
+  // default "use pagination or filters" advice would send the caller in
+  // circles (#265).
+  it('says the listing cannot be narrowed rather than advising pagination', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () =>
+        HttpResponse.json({
+          ticket_forms: Array.from({ length: 200 }, (_, i) => ({
+            ...MOCK_TICKET_FORM_BUG,
+            id: 900 + i,
+            display_name: 'x'.repeat(200),
+          })),
+          next_page: null,
+        }),
+      ),
+    );
+    const text = await textOf('list_request_forms', {});
+    expect(text).toContain('Response truncated');
+    expect(text).toContain('list_request_forms takes no parameters');
+    expect(text).not.toContain('Use pagination or filters');
   });
 
   it('says so plainly when the Help Center exposes no form', async () => {
@@ -267,6 +292,55 @@ describe('get_request_form', () => {
     );
   });
 
+  // The account default can be hidden from end users, and `fallback_to_default`
+  // fires only when NOTHING matched — so the single visible form is routinely
+  // not the default one. Refusing it would break the promise that an account
+  // with one form gets that one.
+  it('describes the only visible form even when it is not the account default', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () =>
+        HttpResponse.json({ ticket_forms: [MOCK_TICKET_FORM_FEATURE], next_page: null }),
+      ),
+    );
+    const text = await textOf('get_request_form', {});
+    expect(text).toContain('Feature request (form id 901)');
+  });
+
+  // With several forms and no default there is nothing to guess from, so the
+  // refusal still stands rather than picking the first one.
+  it('still refuses to guess between several forms when none is the default', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () =>
+        HttpResponse.json({
+          ticket_forms: [
+            MOCK_TICKET_FORM_FEATURE,
+            { ...MOCK_TICKET_FORM_FEATURE, id: 902, display_name: 'Billing question' },
+          ],
+          next_page: null,
+        }),
+      ),
+    );
+    await expect(textOf('get_request_form', {})).rejects.toThrow(/No default request form/);
+    await expect(textOf('get_request_form', {})).rejects.toThrow(/Billing question \(902\)/);
+  });
+
+  it('says the description cannot be narrowed rather than advising pagination', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_fields`, () =>
+        HttpResponse.json({
+          ticket_fields: [
+            { ...MOCK_TICKET_FIELD_CUSTOM, description: 'x'.repeat(CHARACTER_LIMIT) },
+          ],
+          next_page: null,
+        }),
+      ),
+    );
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).toContain('Response truncated');
+    expect(text).toContain('get_request_form takes only form_id');
+    expect(text).not.toContain('Use pagination or filters');
+  });
+
   it('refuses an unknown form id and names the ones that exist', async () => {
     await expect(textOf('get_request_form', { form_id: 4242 })).rejects.toThrow(
       /No request form with id 4242/,
@@ -397,6 +471,43 @@ describe('create_request', () => {
   it('submits a form whose only portal-required fields are the system ones', async () => {
     const text = await textOf('create_request', { subject: 'S', body: 'B', form_id: 901 });
     expect(text).toContain('submitted');
+  });
+
+  // The Ticket status field (type `custom_status`) is agent-set like `status`.
+  // Treated as a custom field it would be demanded in `custom_fields`, which no
+  // submitter can satisfy -- the same trap the system subject sprung.
+  it('never demands the ticket status field, whatever the form marks required', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () =>
+        HttpResponse.json({
+          ticket_forms: [{ ...MOCK_TICKET_FORM_BUG, ticket_field_ids: [1, 2, 11] }],
+          next_page: null,
+        }),
+      ),
+      http.get(`${BASE}/ticket_fields`, () =>
+        HttpResponse.json({
+          ticket_fields: [
+            MOCK_TICKET_FIELD_SUBJECT,
+            MOCK_TICKET_FIELD_DESCRIPTION,
+            {
+              id: 11,
+              type: 'custom_status',
+              title: 'Status',
+              description: null,
+              active: true,
+              required: false,
+              visible_in_portal: true,
+              required_in_portal: true,
+            },
+          ],
+          next_page: null,
+        }),
+      ),
+    );
+    const text = await textOf('create_request', { subject: 'S', body: 'B', form_id: 900 });
+    expect(text).toContain('submitted');
+    // And it is not presented as a question to ask either.
+    expect(await textOf('get_request_form', { form_id: 900 })).not.toContain('field id 11');
   });
 
   it('treats an empty value as absent for a required field', async () => {
@@ -612,6 +723,60 @@ describe('get_request', () => {
     await expect(
       textOf('get_request', { request_id: 5001, include_comments: true }),
     ).rejects.toThrow(/ZENDESK_MAX_COMMENT_PAGES/);
+  });
+
+  // `users` is a documented sideload of this endpoint, so it is asked for by
+  // name: a sideload that has to be requested to arrive would leave every
+  // comment attributed to a bare id.
+  it('asks for the users sideload by name', async () => {
+    const includes: (string | null)[] = [];
+    mswServer.use(
+      http.get(`${BASE}/requests/:id/comments`, ({ request }) => {
+        includes.push(new URL(request.url).searchParams.get('include'));
+        return HttpResponse.json({ comments: [], next_page: null });
+      }),
+    );
+    await textOf('get_request', { request_id: 5001, include_comments: true });
+    expect(includes).toEqual(['users']);
+  });
+
+  // Neither parameter narrows this response; the one thing that shrinks it is
+  // dropping the conversation, so that is what the advice names (#265).
+  it('points a truncated conversation at include_comments false, not at pagination', async () => {
+    mswServer.use(
+      http.get(`${BASE}/requests/:id/comments`, () =>
+        HttpResponse.json({
+          comments: [
+            {
+              id: 1,
+              body: 'x'.repeat(CHARACTER_LIMIT),
+              author_id: 456,
+              public: true,
+              created_at: 'day1',
+            },
+          ],
+          next_page: null,
+        }),
+      ),
+    );
+    const text = await textOf('get_request', { request_id: 5001, include_comments: true });
+    expect(text).toContain('Response truncated');
+    expect(text).toContain("include_comments false to read request #5001's status");
+    expect(text).not.toContain('Use pagination or filters');
+  });
+
+  it('says a request that overflows on its own cannot be narrowed', async () => {
+    mswServer.use(
+      http.get(`${BASE}/requests/:id`, () =>
+        HttpResponse.json({
+          request: { ...MOCK_REQUEST, description: 'x'.repeat(CHARACTER_LIMIT) },
+        }),
+      ),
+    );
+    const text = await textOf('get_request', { request_id: 5001, include_comments: false });
+    expect(text).toContain('Response truncated');
+    expect(text).toContain('get_request takes no pagination or filter parameters');
+    expect(text).not.toContain('Use pagination or filters');
   });
 
   it('falls back to the author id when the sideload is absent', async () => {

--- a/tests/unit/tools/requests.test.ts
+++ b/tests/unit/tools/requests.test.ts
@@ -2,7 +2,7 @@ import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createRequestTools } from '../../../src/tools/requests';
-import { MOCK_REQUEST, MOCK_TICKET_FORM_BUG } from '../../msw-handlers';
+import { MOCK_REQUEST, MOCK_TICKET_FIELD_CUSTOM, MOCK_TICKET_FORM_BUG } from '../../msw-handlers';
 import { mswServer } from '../../setup';
 
 const BASE = 'https://testsubdomain.zendesk.com/api/v2';
@@ -110,6 +110,60 @@ describe('get_request_form', () => {
     expect(text).not.toContain('## Conditional fields');
   });
 
+  // The bug this guards: every real form carries the system subject and
+  // description fields, both portal-required. Treating them as custom fields
+  // made create_request demand "Subject (field id 1)" in `custom_fields`,
+  // which no caller can satisfy, and made this spec tell them to send it.
+  it('does not present the system subject and description as fields to send', async () => {
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).not.toContain('field id 1)');
+    expect(text).not.toContain('field id 2)');
+    expect(text).not.toContain('### Subject');
+    expect(text).not.toContain('### Description');
+  });
+
+  it('says up front that a subject and a description are always needed', async () => {
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).toContain('Always needed: a subject and a description');
+  });
+
+  it('lists only the custom fields as required, not the system ones', async () => {
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).toContain('**Required**: How severe is it?');
+    expect(text).not.toContain('**Required**: Subject');
+  });
+
+  it('reports a form with no custom fields as needing nothing more', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () =>
+        HttpResponse.json({
+          ticket_forms: [{ ...MOCK_TICKET_FORM_BUG, ticket_field_ids: [1, 2] }],
+        }),
+      ),
+    );
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).toContain('**Required**: nothing beyond the subject and description.');
+    expect(text).toContain('send subject and body only');
+  });
+
+  // Reading a form from a partial field list would omit a required field, which
+  // validateSubmission would then not enforce -- producing the opaque 422 that
+  // check exists to prevent. So it must fail loudly instead.
+  it('refuses to describe a form when the field list is truncated', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_fields`, () =>
+        HttpResponse.json({
+          ticket_fields: [MOCK_TICKET_FIELD_CUSTOM],
+          // Always another page: forces the page cap.
+          next_page: `${BASE}/ticket_fields?page=99`,
+        }),
+      ),
+    );
+    await expect(textOf('get_request_form', { form_id: 900 })).rejects.toThrow(
+      /could not read every ticket field/,
+    );
+  });
+
   it('refuses an unknown form id and names the ones that exist', async () => {
     await expect(textOf('get_request_form', { form_id: 4242 })).rejects.toThrow(
       /No request form with id 4242/,
@@ -213,6 +267,33 @@ describe('create_request', () => {
     await expect(
       textOf('create_request', { subject: 'S', body: 'B', form_id: 900 }),
     ).rejects.toThrow(/How severe is it\? \(field id 360000000001\)/);
+  });
+
+  // The other half of the blocking bug: with the system fields enforced, this
+  // call -- the simplest valid submission there is -- threw.
+  it('accepts a submission carrying only subject, body and the custom field', async () => {
+    const text = await textOf('create_request', {
+      subject: 'Export is broken',
+      body: 'Nothing downloads.',
+      form_id: 900,
+      custom_fields: [{ id: 360000000001, value: 'severity_2' }],
+    });
+    expect(text).toContain('submitted');
+  });
+
+  it('never demands the system subject or description in custom_fields', async () => {
+    await expect(
+      textOf('create_request', { subject: 'S', body: 'B', form_id: 900 }),
+    ).rejects.toThrow(/How severe is it\?/);
+    // The error names the custom field only -- not "Subject (field id 1)".
+    await expect(
+      textOf('create_request', { subject: 'S', body: 'B', form_id: 900 }),
+    ).rejects.not.toThrow(/field id 1\)/);
+  });
+
+  it('submits a form whose only portal-required fields are the system ones', async () => {
+    const text = await textOf('create_request', { subject: 'S', body: 'B', form_id: 901 });
+    expect(text).toContain('submitted');
   });
 
   it('treats an empty value as absent for a required field', async () => {
@@ -366,6 +447,36 @@ describe('get_request', () => {
   it('lists a comment attachment by name', async () => {
     const text = await textOf('get_request', { request_id: 5001, include_comments: true });
     expect(text).toContain('diagnostic.txt');
+  });
+
+  // The description promises "every public message", so a thread longer than one
+  // page must be walked rather than silently cut off.
+  it('pages the conversation and accumulates authors across pages', async () => {
+    let calls = 0;
+    mswServer.use(
+      http.get(`${BASE}/requests/:id/comments`, () => {
+        calls += 1;
+        if (calls === 1) {
+          return HttpResponse.json({
+            comments: [{ id: 1, body: 'First', author_id: 456, public: true, created_at: 'day1' }],
+            users: [{ id: 456, name: 'Dana Customer', agent: false }],
+            next_page: `${BASE}/requests/5001/comments?page=2`,
+          });
+        }
+        return HttpResponse.json({
+          comments: [{ id: 2, body: 'Second', author_id: 789, public: true, created_at: 'day2' }],
+          // An author who appears only on the later page.
+          users: [{ id: 789, name: 'Sam Support', agent: true }],
+          next_page: null,
+        });
+      }),
+    );
+    const text = await textOf('get_request', { request_id: 5001, include_comments: true });
+    expect(calls).toBe(2);
+    expect(text).toContain('First');
+    expect(text).toContain('Second');
+    expect(text).toContain('Comment by Dana Customer');
+    expect(text).toContain('Comment by Sam Support (support agent)');
   });
 
   it('falls back to the author id when the sideload is absent', async () => {

--- a/tests/unit/tools/requests.test.ts
+++ b/tests/unit/tools/requests.test.ts
@@ -543,6 +543,38 @@ describe('get_request', () => {
     expect(text).toContain('Comment by Sam Support (support agent)');
   });
 
+  // The same failure the form and field walks refuse: a partial thread on the
+  // one tool whose description promises "every public message".
+  it('refuses a conversation it could not read to the end', async () => {
+    mswServer.use(
+      http.get(`${BASE}/requests/:id/comments`, () =>
+        HttpResponse.json({
+          comments: [{ id: 1, body: 'First', author_id: 456, public: true, created_at: 'day1' }],
+          users: [{ id: 456, name: 'Dana Customer', agent: false }],
+          // Always another page: forces the cap.
+          next_page: `${BASE}/requests/5001/comments?page=99`,
+        }),
+      ),
+    );
+    await expect(
+      textOf('get_request', { request_id: 5001, include_comments: true }),
+    ).rejects.toThrow(/could not read all of \/requests\/5001\/comments/);
+  });
+
+  it('names the comment page cap variable, not the field one, when it truncates', async () => {
+    mswServer.use(
+      http.get(`${BASE}/requests/:id/comments`, () =>
+        HttpResponse.json({
+          comments: [],
+          next_page: `${BASE}/requests/5001/comments?page=99`,
+        }),
+      ),
+    );
+    await expect(
+      textOf('get_request', { request_id: 5001, include_comments: true }),
+    ).rejects.toThrow(/ZENDESK_MAX_COMMENT_PAGES/);
+  });
+
   it('falls back to the author id when the sideload is absent', async () => {
     mswServer.use(
       http.get(`${BASE}/requests/:id/comments`, () =>

--- a/tests/unit/tools/requests.test.ts
+++ b/tests/unit/tools/requests.test.ts
@@ -1,0 +1,458 @@
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import type { ToolContext } from '../../../src/tools/definitions';
+import { createRequestTools } from '../../../src/tools/requests';
+import { MOCK_REQUEST, MOCK_TICKET_FORM_BUG } from '../../msw-handlers';
+import { mswServer } from '../../setup';
+
+const BASE = 'https://testsubdomain.zendesk.com/api/v2';
+const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
+
+const findTool = (name: string) => {
+  const tool = createRequestTools(ctx).find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool ${name} not found`);
+  return tool;
+};
+
+const textOf = async (name: string, params: Record<string, unknown>): Promise<string> => {
+  const result = await findTool(name).handler(params);
+  return result.content.map((block) => ('text' in block ? block.text : '')).join('\n');
+};
+
+describe('createRequestTools', () => {
+  it('creates 7 tools', () => {
+    expect(createRequestTools(ctx)).toHaveLength(7);
+  });
+
+  it('puts every tool in the requests namespace', () => {
+    expect(createRequestTools(ctx).every((t) => t.namespace === 'requests')).toBe(true);
+  });
+});
+
+describe('list_request_forms', () => {
+  it('lists the customer-facing name, the id and which form is the default', async () => {
+    const text = await textOf('list_request_forms', {});
+    expect(text).toContain('Report a bug');
+    expect(text).toContain('form id 900');
+    expect(text).toContain('default');
+    expect(text).toContain('Feature request');
+  });
+
+  // display_name is what a customer reads; name is internal. Both are shown
+  // when they differ so an agent can map one to the other.
+  it('shows the internal name only when it differs from the display name', async () => {
+    const text = await textOf('list_request_forms', {});
+    expect(text).toContain('Internal name: Bug report (internal)');
+    // The feature form has display_name === name, so it gets no second line.
+    expect(text).not.toContain('Internal name: Feature request');
+  });
+
+  it('says so plainly when the Help Center exposes no form', async () => {
+    mswServer.use(http.get(`${BASE}/ticket_forms`, () => HttpResponse.json({ ticket_forms: [] })));
+    const text = await textOf('list_request_forms', {});
+    expect(text).toContain('No request form is available to you');
+  });
+
+  it('rewrites a 403 into guidance naming the agent-side tools', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () => new HttpResponse('nope', { status: 403 })),
+    );
+    await expect(textOf('list_request_forms', {})).rejects.toThrow(/create_ticket/);
+    await expect(textOf('list_request_forms', {})).rejects.toThrow(/HTTP 403/);
+  });
+});
+
+describe('get_request_form', () => {
+  it('describes the default form when no id is given', async () => {
+    const text = await textOf('get_request_form', {});
+    expect(text).toContain('Report a bug (form id 900)');
+  });
+
+  it('renders the portal label, not the agent title', async () => {
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).toContain('How severe is it? (field id 360000000001)');
+  });
+
+  it('marks the portal-required field required and lists it up front', async () => {
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).toContain('**Required**: How severe is it?');
+    expect(text).toContain('**required**');
+  });
+
+  it('reports a portal-visible but optional field as optional', async () => {
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).toContain('Affected version (field id 360000000002)');
+    expect(text).toContain('**optional**');
+  });
+
+  // Priority is visible_in_portal: false. An end-user token would not even
+  // receive it, but an agent token does, and the same form must be described
+  // the same way either way.
+  it('drops fields the portal does not show, whoever is asking', async () => {
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).not.toContain('Priority');
+  });
+
+  it('lists the exact values a dropdown accepts', async () => {
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).toContain('Sev-1 → severity_1');
+  });
+
+  it('reports conditional rules as rules instead of resolving them', async () => {
+    const text = await textOf('get_request_form', { form_id: 901 });
+    expect(text).toContain('## Conditional fields');
+    expect(text).toContain('When field 360000000001 is `severity_1`: field 360000000002');
+    expect(text).toContain('(then required)');
+  });
+
+  it('omits the conditional section for a form without conditions', async () => {
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(text).not.toContain('## Conditional fields');
+  });
+
+  it('refuses an unknown form id and names the ones that exist', async () => {
+    await expect(textOf('get_request_form', { form_id: 4242 })).rejects.toThrow(
+      /No request form with id 4242/,
+    );
+    await expect(textOf('get_request_form', { form_id: 4242 })).rejects.toThrow(/Report a bug/);
+  });
+
+  // The endpoint's `count` is the unfiltered total and `next_page` is the only
+  // honest end-of-list signal, so the walker must follow it across pages.
+  it('follows next_page rather than trusting count or a short page', async () => {
+    let calls = 0;
+    mswServer.use(
+      http.get(`${BASE}/ticket_fields`, () => {
+        calls += 1;
+        if (calls === 1) {
+          return HttpResponse.json({
+            ticket_fields: [
+              {
+                id: 360000000001,
+                type: 'tagger',
+                title: 'Severity',
+                description: null,
+                active: true,
+                required: false,
+                visible_in_portal: true,
+                required_in_portal: true,
+                title_in_portal: 'How severe is it?',
+              },
+            ],
+            // A lie on both counts: more than returned, yet a next page exists.
+            count: 99,
+            next_page: `${BASE}/ticket_fields?page=2`,
+          });
+        }
+        return HttpResponse.json({
+          ticket_fields: [
+            {
+              id: 360000000002,
+              type: 'text',
+              title: 'Affected version',
+              description: null,
+              active: true,
+              required: false,
+              visible_in_portal: true,
+              required_in_portal: false,
+            },
+          ],
+          count: 99,
+          next_page: null,
+        });
+      }),
+    );
+    const text = await textOf('get_request_form', { form_id: 900 });
+    expect(calls).toBe(2);
+    expect(text).toContain('How severe is it?');
+    expect(text).toContain('Affected version');
+  });
+});
+
+describe('create_request', () => {
+  it('submits and returns the created request with its number', async () => {
+    const text = await textOf('create_request', {
+      subject: 'Export is broken',
+      body: 'Nothing downloads.',
+      form_id: 900,
+      custom_fields: [{ id: 360000000001, value: 'severity_2' }],
+    });
+    expect(text).toContain('Request #5010 submitted.');
+    expect(text).toContain('Export is broken');
+  });
+
+  it('sends the chosen form id through to Zendesk', async () => {
+    let sent: Record<string, unknown> | undefined;
+    mswServer.use(
+      http.post(`${BASE}/requests`, async ({ request }) => {
+        const body = (await request.json()) as { request: Record<string, unknown> };
+        sent = body.request;
+        return HttpResponse.json({ request: { ...MOCK_REQUEST, id: 5010 } });
+      }),
+    );
+    await textOf('create_request', {
+      subject: 'S',
+      body: 'B',
+      form_id: 901,
+      custom_fields: [{ id: 360000000002, value: '2.1' }],
+    });
+    expect(sent?.['ticket_form_id']).toBe(901);
+  });
+
+  // Zendesk answers 201 having substituted the default form, so an unknown id
+  // has to be caught here or the request lands on the wrong form silently.
+  it('refuses an unknown form id rather than letting Zendesk substitute one', async () => {
+    await expect(
+      textOf('create_request', { subject: 'S', body: 'B', form_id: 4242 }),
+    ).rejects.toThrow(/silently substitute the default form/);
+  });
+
+  // required_in_portal is enforced by Zendesk only against end users, so an
+  // agent-side preview would disagree with what a customer hits. Check locally.
+  it('refuses a submission missing a portal-required field, naming it', async () => {
+    await expect(
+      textOf('create_request', { subject: 'S', body: 'B', form_id: 900 }),
+    ).rejects.toThrow(/How severe is it\? \(field id 360000000001\)/);
+  });
+
+  it('treats an empty value as absent for a required field', async () => {
+    await expect(
+      textOf('create_request', {
+        subject: 'S',
+        body: 'B',
+        form_id: 900,
+        custom_fields: [{ id: 360000000001, value: '' }],
+      }),
+    ).rejects.toThrow(/requires values the submission does not carry/);
+  });
+
+  // Conditional requirements depend on answers we may not have; blocking on
+  // them would refuse valid submissions.
+  it('does not block on a field required only through a condition', async () => {
+    const text = await textOf('create_request', { subject: 'S', body: 'B', form_id: 901 });
+    expect(text).toContain('Request #5010 submitted.');
+  });
+
+  it('uploads attachments and reports how many were carried', async () => {
+    const text = await textOf('create_request', {
+      subject: 'S',
+      body: 'B',
+      form_id: 901,
+      attachments: [{ file_name: 'log.txt', file_base64: 'aGVsbG8=', content_type: 'text/plain' }],
+    });
+    expect(text).toContain('with 1 attachment(s)');
+  });
+});
+
+describe('list_requests', () => {
+  it('lists the requests with their status and solvability', async () => {
+    const text = await textOf('list_requests', {
+      sort_by: 'updated_at',
+      sort_order: 'desc',
+      per_page: 100,
+      page: 1,
+    });
+    expect(text).toContain('Your requests.');
+    expect(text).toContain('Request #5001');
+    expect(text).toContain('Can you mark it solved**: yes');
+  });
+
+  it('switches to the search endpoint when a query is given, and says so', async () => {
+    const text = await textOf('list_requests', {
+      query: 'export',
+      sort_by: 'updated_at',
+      sort_order: 'desc',
+      per_page: 100,
+      page: 1,
+    });
+    expect(text).toContain('Searched your requests for "export".');
+    expect(text).toContain('Request #5001');
+  });
+
+  // The search endpoint otherwise defaults to 15 while the listing defaults to
+  // 100; one tool paginating two ways would be a trap.
+  it('passes per_page on the search path too, so the page size never differs', async () => {
+    let seen: string | null = null;
+    mswServer.use(
+      http.get(`${BASE}/requests/search`, ({ request }) => {
+        seen = new URL(request.url).searchParams.get('per_page');
+        return HttpResponse.json({ requests: [MOCK_REQUEST], count: 1 });
+      }),
+    );
+    await textOf('list_requests', {
+      query: 'export',
+      sort_by: 'updated_at',
+      sort_order: 'desc',
+      per_page: 25,
+      page: 1,
+    });
+    expect(seen).toBe('25');
+  });
+
+  it('comma-joins the status filter Zendesk expects', async () => {
+    let seen: string | null = null;
+    mswServer.use(
+      http.get(`${BASE}/requests`, ({ request }) => {
+        seen = new URL(request.url).searchParams.get('status');
+        return HttpResponse.json({ requests: [MOCK_REQUEST], count: 1 });
+      }),
+    );
+    await textOf('list_requests', {
+      status: ['open', 'pending'],
+      sort_by: 'updated_at',
+      sort_order: 'desc',
+      per_page: 100,
+      page: 1,
+    });
+    expect(seen).toBe('open,pending');
+  });
+
+  it('reports an empty listing rather than an empty block', async () => {
+    const text = await textOf('list_requests', {
+      status: ['closed'],
+      sort_by: 'updated_at',
+      sort_order: 'desc',
+      per_page: 100,
+      page: 1,
+    });
+    expect(text).toContain('You have not submitted any request matching this filter.');
+  });
+
+  it('reports an empty search with the query that found nothing', async () => {
+    const text = await textOf('list_requests', {
+      query: 'nothing',
+      sort_by: 'updated_at',
+      sort_order: 'desc',
+      per_page: 100,
+      page: 1,
+    });
+    expect(text).toContain('No request of yours matches "nothing".');
+  });
+
+  // Zendesk returns EVERY request when it does not recognise a status, so the
+  // enum is validated here rather than sent.
+  it('rejects a status outside the ticket states', () => {
+    const parsed = findTool('list_requests').inputSchema.safeParse({ status: ['bogus'] });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an empty status array', () => {
+    const parsed = findTool('list_requests').inputSchema.safeParse({ status: [] });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('get_request', () => {
+  it('returns the request without its conversation by default', async () => {
+    const text = await textOf('get_request', { request_id: 5001, include_comments: false });
+    expect(text).toContain('Request #5001');
+    expect(text).not.toContain('# Conversation');
+  });
+
+  it('appends the conversation when asked', async () => {
+    const text = await textOf('get_request', { request_id: 5001, include_comments: true });
+    expect(text).toContain('# Conversation');
+    expect(text).toContain('Clicking export spins forever');
+  });
+
+  // The `users` sideload carries an `agent` flag; that is what tells a support
+  // reply from the customer's own comment, without inferring from ids.
+  it('names each author and marks the support agents', async () => {
+    const text = await textOf('get_request', { request_id: 5001, include_comments: true });
+    expect(text).toContain('Comment by Dana Customer');
+    expect(text).toContain('Comment by Sam Support (support agent)');
+  });
+
+  it('lists a comment attachment by name', async () => {
+    const text = await textOf('get_request', { request_id: 5001, include_comments: true });
+    expect(text).toContain('diagnostic.txt');
+  });
+
+  it('falls back to the author id when the sideload is absent', async () => {
+    mswServer.use(
+      http.get(`${BASE}/requests/:id/comments`, () =>
+        HttpResponse.json({
+          comments: [{ id: 1, body: 'Hi', author_id: 456, public: true, created_at: 'now' }],
+        }),
+      ),
+    );
+    const text = await textOf('get_request', { request_id: 5001, include_comments: true });
+    expect(text).toContain('Comment by user 456');
+  });
+
+  it('rewrites a 403 into end-user guidance', async () => {
+    mswServer.use(
+      http.get(`${BASE}/requests/:id`, () => new HttpResponse('nope', { status: 403 })),
+    );
+    await expect(
+      textOf('get_request', { request_id: 5001, include_comments: false }),
+    ).rejects.toThrow(/end-user Requests surface/);
+  });
+});
+
+describe('add_request_comment', () => {
+  it('replies and reports the status the request is in afterwards', async () => {
+    const text = await textOf('add_request_comment', { request_id: 5001, body: 'Still broken.' });
+    expect(text).toContain('Reply added to request #5001');
+    expect(text).toContain('It is now **open**');
+  });
+
+  it('carries attachments on the reply', async () => {
+    const text = await textOf('add_request_comment', {
+      request_id: 5001,
+      body: 'Log attached.',
+      attachments: [{ file_name: 'log.txt', file_base64: 'aGVsbG8=', content_type: 'text/plain' }],
+    });
+    expect(text).toContain('with 1 attachment(s)');
+  });
+});
+
+describe('mark_request_solved', () => {
+  it('solves a solvable request and reads the status back', async () => {
+    const text = await textOf('mark_request_solved', { request_id: 5001 });
+    expect(text).toContain('Request #5001 is now **solved**.');
+  });
+
+  // The sharp case: Zendesk answers 200 and changes nothing, so sending it
+  // would report a success that never happened.
+  it('refuses an unassigned request instead of reporting a phantom success', async () => {
+    let put = false;
+    mswServer.use(
+      http.put(`${BASE}/requests/:id`, () => {
+        put = true;
+        return HttpResponse.json({ request: MOCK_REQUEST });
+      }),
+    );
+    const text = await textOf('mark_request_solved', { request_id: 5002 });
+    expect(text).toContain('cannot be marked solved by you');
+    expect(text).toContain('add_request_comment');
+    expect(put).toBe(false);
+  });
+
+  it('treats an already-solved request as a no-op', async () => {
+    const text = await textOf('mark_request_solved', { request_id: 5003 });
+    expect(text).toContain('already **solved**');
+  });
+
+  // Verified from the response body, not assumed from the 2xx.
+  it('reports the truth when Zendesk accepts the update but does not solve it', async () => {
+    mswServer.use(
+      http.put(`${BASE}/requests/:id`, () =>
+        HttpResponse.json({ request: { ...MOCK_REQUEST, status: 'open' } }),
+      ),
+    );
+    const text = await textOf('mark_request_solved', { request_id: 5001 });
+    expect(text).toContain('still **open**');
+    expect(text).toContain('so it was not solved');
+  });
+});
+
+describe('the form fixture', () => {
+  // Guards the tests above: they assume this form is the default and carries
+  // both a required and an optional portal field.
+  it('is the default form and carries the fields the tests rely on', () => {
+    expect(MOCK_TICKET_FORM_BUG.default).toBe(true);
+    expect(MOCK_TICKET_FORM_BUG.ticket_field_ids).toContain(360000000001);
+    expect(MOCK_TICKET_FORM_BUG.ticket_field_ids).toContain(360000000002);
+  });
+});

--- a/tests/unit/tools/requests.test.ts
+++ b/tests/unit/tools/requests.test.ts
@@ -160,16 +160,28 @@ describe('list_request_forms', () => {
     );
   });
 
-  // The plan cause belongs to the form listing alone: naming it on the request
-  // endpoints would be a wrong diagnosis, not a helpful extra.
-  it('does not blame the plan for a 403 on the request endpoints', async () => {
+  // Each 403 names the causes that apply to ITS path and no others: on a
+  // request id the likeliest cause is that the id belongs to somebody else, and
+  // the plan cause would be a wrong diagnosis here just as the other-user cause
+  // would be on the form listing.
+  it('blames the right thing for a 403 on a request id', async () => {
     mswServer.use(
       http.get(`${BASE}/requests/:id`, () => new HttpResponse('nope', { status: 403 })),
     );
     await expect(textOf('get_request', { request_id: 5001 })).rejects.toThrow(/HTTP 403/);
+    await expect(textOf('get_request', { request_id: 5001 })).rejects.toThrow(
+      /belongs to another user/,
+    );
     await expect(textOf('get_request', { request_id: 5001 })).rejects.not.toThrow(
       /plan without multiple ticket forms/,
     );
+  });
+
+  it('does not blame another user for a 403 on the form listing', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () => new HttpResponse('nope', { status: 403 })),
+    );
+    await expect(textOf('list_request_forms', {})).rejects.not.toThrow(/belongs to another user/);
   });
 });
 
@@ -223,6 +235,115 @@ describe('get_request_form', () => {
     // values it accepts -- otherwise the rule names an unanswerable question.
     expect(text).toContain('### Is it blocking you? (field id 360000000003)');
     expect(text).toContain('Yes → yes');
+  });
+
+  // `is_required` alone is not the answer: required_on_statuses narrows it, and
+  // Zendesk documents that as applying to end-user forms too. A field required
+  // only once the request is open is NOT required to submit one, and saying
+  // "then required" would send the assistant hunting for an unwanted answer.
+  it('does not call a field required to submit when it is only required later', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () =>
+        HttpResponse.json({
+          ticket_forms: [
+            {
+              ...MOCK_TICKET_FORM_FEATURE,
+              end_user_conditions: [
+                {
+                  parent_field_id: 360000000003,
+                  value: 'yes',
+                  child_fields: [
+                    {
+                      id: 360000000002,
+                      is_required: true,
+                      required_on_statuses: {
+                        type: 'SOME_STATUSES',
+                        statuses: ['open', 'pending'],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          count: 1,
+          next_page: null,
+        }),
+      ),
+    );
+    const text = await textOf('get_request_form', { form_id: 901 });
+    expect(text).toContain('then required once the request is open or pending, not to submit it');
+  });
+
+  it('calls it required to submit when the statuses include a new request', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () =>
+        HttpResponse.json({
+          ticket_forms: [
+            {
+              ...MOCK_TICKET_FORM_FEATURE,
+              end_user_conditions: [
+                {
+                  parent_field_id: 360000000003,
+                  value: 'yes',
+                  child_fields: [
+                    {
+                      id: 360000000002,
+                      is_required: true,
+                      required_on_statuses: { type: 'SOME_STATUSES', statuses: ['new', 'open'] },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          count: 1,
+          next_page: null,
+        }),
+      ),
+    );
+    const text = await textOf('get_request_form', { form_id: 901 });
+    expect(text).toContain('(then required)');
+    expect(text).not.toContain('not to submit it');
+  });
+
+  // NO_STATUSES means required nowhere, so `is_required` must not win.
+  it('drops the required marker when the rule requires the field on no status', async () => {
+    mswServer.use(
+      http.get(`${BASE}/ticket_forms`, () =>
+        HttpResponse.json({
+          ticket_forms: [
+            {
+              ...MOCK_TICKET_FORM_FEATURE,
+              end_user_conditions: [
+                {
+                  parent_field_id: 360000000003,
+                  value: 'yes',
+                  child_fields: [
+                    {
+                      id: 360000000002,
+                      is_required: true,
+                      required_on_statuses: { type: 'NO_STATUSES', statuses: [] },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          count: 1,
+          next_page: null,
+        }),
+      ),
+    );
+    const text = await textOf('get_request_form', { form_id: 901 });
+    // Asserted on the rule line itself: the document says "required" elsewhere
+    // (the Required summary, each field's own marker), so a whole-text
+    // assertion would pass for the wrong reason.
+    expect(text).toContain(
+      'When Is it blocking you? (field id 360000000003) is `yes`: ' +
+        'Affected version (field id 360000000002)\n',
+    );
+    expect(text).not.toContain('(then required)');
   });
 
   // The fallback path: a rule may name a field the caller cannot see (an

--- a/tests/unit/tools/requests.test.ts
+++ b/tests/unit/tools/requests.test.ts
@@ -153,6 +153,23 @@ describe('list_request_forms', () => {
     );
     await expect(textOf('list_request_forms', {})).rejects.toThrow(/create_ticket/);
     await expect(textOf('list_request_forms', {})).rejects.toThrow(/HTTP 403/);
+    // Multiple ticket forms are a plan feature, so this path has a cause the
+    // generic message would mis-diagnose as a Help Center or token problem.
+    await expect(textOf('list_request_forms', {})).rejects.toThrow(
+      /plan without multiple ticket forms/,
+    );
+  });
+
+  // The plan cause belongs to the form listing alone: naming it on the request
+  // endpoints would be a wrong diagnosis, not a helpful extra.
+  it('does not blame the plan for a 403 on the request endpoints', async () => {
+    mswServer.use(
+      http.get(`${BASE}/requests/:id`, () => new HttpResponse('nope', { status: 403 })),
+    );
+    await expect(textOf('get_request', { request_id: 5001 })).rejects.toThrow(/HTTP 403/);
+    await expect(textOf('get_request', { request_id: 5001 })).rejects.not.toThrow(
+      /plan without multiple ticket forms/,
+    );
   });
 });
 

--- a/tests/unit/tools/requests.test.ts
+++ b/tests/unit/tools/requests.test.ts
@@ -2,7 +2,12 @@ import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createRequestTools } from '../../../src/tools/requests';
-import { MOCK_REQUEST, MOCK_TICKET_FIELD_CUSTOM, MOCK_TICKET_FORM_BUG } from '../../msw-handlers';
+import {
+  MOCK_REQUEST,
+  MOCK_TICKET_FIELD_CUSTOM,
+  MOCK_TICKET_FORM_BUG,
+  MOCK_TICKET_FORM_FEATURE,
+} from '../../msw-handlers';
 import { mswServer } from '../../setup';
 
 const BASE = 'https://testsubdomain.zendesk.com/api/v2';
@@ -165,8 +170,42 @@ describe('get_request_form', () => {
   it('reports conditional rules as rules instead of resolving them', async () => {
     const text = await textOf('get_request_form', { form_id: 901 });
     expect(text).toContain('## Conditional fields');
-    expect(text).toContain('When field 360000000001 is `severity_1`: field 360000000002');
-    expect(text).toContain('(then required)');
+    // Both sides of the rule are named by their portal label, with the id kept
+    // so the rule joins onto the Fields section. A rule reading "when field
+    // 360000000003 is yes" is not something an assistant can ask a customer.
+    expect(text).toContain(
+      'When Is it blocking you? (field id 360000000003) is `yes`: ' +
+        'Affected version (field id 360000000002) (then required)',
+    );
+    // And the field the rule gates on is described in the same output, with the
+    // values it accepts -- otherwise the rule names an unanswerable question.
+    expect(text).toContain('### Is it blocking you? (field id 360000000003)');
+    expect(text).toContain('Yes → yes');
+  });
+
+  // The fallback path: a rule may name a field the caller cannot see (an
+  // agent-only parent, or one beyond the field scan). It degrades to the bare
+  // id rather than dropping the rule or inventing a label.
+  it('falls back to the bare field id when the rule names an invisible field', async () => {
+    mswServer.use(
+      http.get('https://testsubdomain.zendesk.com/api/v2/ticket_forms', () =>
+        HttpResponse.json({
+          ticket_forms: [
+            {
+              ...MOCK_TICKET_FORM_FEATURE,
+              end_user_conditions: [
+                { parent_field_id: 999999, value: 'x', child_fields: [{ id: 888888 }] },
+              ],
+            },
+          ],
+          count: 1,
+          next_page: null,
+        }),
+      ),
+    );
+    const text = await textOf('get_request_form', { form_id: 901 });
+    expect(text).toContain('When field 999999 is `x`: field 888888');
+    expect(text).not.toContain('(then required)');
   });
 
   it('omits the conditional section for a form without conditions', async () => {

--- a/tests/unit/tools/requests.test.ts
+++ b/tests/unit/tools/requests.test.ts
@@ -993,6 +993,11 @@ describe('mark_request_solved', () => {
     const text = await textOf('mark_request_solved', { request_id: 5001 });
     expect(text).toContain('still **open**');
     expect(text).toContain('so it was not solved');
+    // Naming only the assignment race sent a validator hunting: the likelier
+    // cause on this surface is an agent token, for which Zendesk answers 200
+    // and ignores `solved` outright.
+    expect(text).toContain('the token belongs to an agent rather than to the requester');
+    expect(text).toContain('the assignment changed between the check and the update');
   });
 });
 

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -13,6 +13,8 @@ import {
   formatNodeTranslationSummary,
   formatOrganization,
   formatPermissionGroup,
+  formatRequest,
+  formatRequestComment,
   formatSection,
   formatSlaBlock,
   formatSlaPolicy,
@@ -36,6 +38,8 @@ import {
   MOCK_MACRO,
   MOCK_ORGANIZATION,
   MOCK_PERMISSION_GROUP,
+  MOCK_REQUEST,
+  MOCK_REQUEST_COMMENTS,
   MOCK_SECTION,
   MOCK_SECTION_TRANSLATION,
   MOCK_SLA_POLICY,
@@ -1181,5 +1185,114 @@ describe('formatNodeTranslationSummary', () => {
       - **Draft**: false
       - **Updated**: 2026-01-02T00:00:00Z"
     `);
+  });
+});
+
+describe('formatRequest', () => {
+  // Not formatTicket: that one dereferences `tags.length`, which a Request does
+  // not carry, and would throw here.
+  it('renders a request with its status, form and solvability', () => {
+    expect(formatRequest(MOCK_REQUEST)).toMatchInlineSnapshot(`
+      "## Request #5001: The export button does nothing
+      - **Status**: open | **Type**: incident | **Priority**: normal
+      - **Form**: 900
+      - **Can you mark it solved**: yes
+      - **Submitted via**: web
+      - **Created**: 2026-01-05T09:00:00Z | **Updated**: 2026-01-06T11:30:00Z
+
+      Clicking export spins forever and no file arrives."
+    `);
+  });
+
+  it('says no when the requester cannot solve it, rather than omitting the line', () => {
+    const text = formatRequest({ ...MOCK_REQUEST, can_be_solved_by_me: false });
+    expect(text).toContain('**Can you mark it solved**: no');
+  });
+
+  // `via` absent entirely, not `via: {}` -- the two differ, and only the absent
+  // case proves the optional chaining is load-bearing.
+  it('survives a request carrying no via block at all', () => {
+    const { via: _via, ...withoutVia } = MOCK_REQUEST;
+    expect(formatRequest(withoutVia)).not.toContain('Submitted via');
+  });
+
+  it('omits the channel line when via carries no channel', () => {
+    expect(formatRequest({ ...MOCK_REQUEST, via: {} })).not.toContain('Submitted via');
+  });
+
+  it('omits the optional lines a request may not carry', () => {
+    const text = formatRequest({
+      ...MOCK_REQUEST,
+      priority: null,
+      type: null,
+      ticket_form_id: null,
+      via: {},
+      description: '',
+    });
+    expect(text).toMatchInlineSnapshot(`
+      "## Request #5001: The export button does nothing
+      - **Status**: open
+      - **Can you mark it solved**: yes
+      - **Created**: 2026-01-05T09:00:00Z | **Updated**: 2026-01-06T11:30:00Z"
+    `);
+  });
+});
+
+describe('formatRequestComment', () => {
+  const authors = new Map(MOCK_REQUEST_COMMENTS.users.map((user) => [user.id, user]));
+
+  it('names the customer and does not label them an agent', () => {
+    const comment = MOCK_REQUEST_COMMENTS.comments[0];
+    if (!comment) throw new Error('fixture missing');
+    expect(formatRequestComment(comment, authors)).toMatchInlineSnapshot(`
+      "### Comment by Dana Customer
+      *2026-01-05T09:00:00Z*
+
+      Clicking export spins forever and no file arrives."
+    `);
+  });
+
+  it('marks a support agent and lists the attachment by name', () => {
+    const comment = MOCK_REQUEST_COMMENTS.comments[1];
+    if (!comment) throw new Error('fixture missing');
+    expect(formatRequestComment(comment, authors)).toMatchInlineSnapshot(`
+      "### Comment by Sam Support (support agent)
+      *2026-01-06T11:30:00Z*
+      Attachments: diagnostic.txt (#4242, text/plain)
+
+      Thanks for the report — which browser are you on?"
+    `);
+  });
+
+  // Two attachments, so the separator itself is asserted rather than just the
+  // presence of a file name.
+  it('comma-separates several attachments on one comment', () => {
+    const comment = MOCK_REQUEST_COMMENTS.comments[1];
+    if (!comment) throw new Error('fixture missing');
+    const text = formatRequestComment(
+      {
+        ...comment,
+        attachments: [
+          ...(comment.attachments ?? []),
+          {
+            id: 4243,
+            file_name: 'screenshot.png',
+            content_url: 'https://example.test/screenshot.png',
+            content_type: 'image/png',
+            size: 2048,
+          },
+        ],
+      },
+      authors,
+    );
+    expect(text).toContain(
+      'Attachments: diagnostic.txt (#4242, text/plain), screenshot.png (#4243, image/png)',
+    );
+  });
+
+  it('falls back to the author id when the sideload does not carry them', () => {
+    const comment = MOCK_REQUEST_COMMENTS.comments[0];
+    if (!comment) throw new Error('fixture missing');
+    expect(formatRequestComment(comment, new Map())).toContain('Comment by user 456');
   });
 });


### PR DESCRIPTION
## Summary

End users become a supported audience of this server, alongside agents. A
customer can pick the kind of request they want to open, be walked through the
questions that form actually asks, submit it with attachments, then follow the
ticket — read the agent replies, reply back, mark it solved when it is.

Seven tools in a new **opt-in `requests` namespace**, speaking
`/api/v2/requests` — the path Zendesk reserves for requesters, since
`/api/v2/tickets` answers 403 for an end user. The agent surface is untouched.

## Linked issue

Closes #48

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [x] Documentation
- [ ] Tooling / CI

## Design decisions

**No new configuration axis.** The issue proposed `--profile end-user`. Instead
the tools land in a namespace selected with the existing `--namespace requests`.
`--namespace` / `--tool` pick the inventory, `--mode` packages it,
`--read-only` narrows it — one axis for the inventory, not two overlapping ones.
This also matches the ecosystem: the GitHub MCP server puts its `default` /
`all` keywords *inside* its `toolsets` axis rather than beside it. "End-user
mode" survives as an audience in the README, not as a flag. Full reasoning and
the rejected alternative: `docs/decisions/end-user-namespace.md`.

**`--print-tools`** answers the question the profile was really answering —
"what do I get if I combine these flags?" — for every axis at once, with no
credential and no network call.

**`requests` is opt-in on evidence, not taste.** Under an agent token part of
this surface silently misbehaves rather than failing (table below), so
registering it for every agent install would ship an operation that reports
success on a no-op.

**Opt-in is not a lower quality bar.** Glama scores the flat surface and the
server score is `60% mean + 40% min`, so a thin definition behind a flag drags
everything down exactly as much. All seven clear the full
`docs/mcp-metadata.md` bar; the deterministic floor passed on the first run.

## What the API probe changed

Every behavioural claim here is measured against the live instance, not read
off the documentation. Three assumptions in the original framing were wrong and
are corrected in the code:

| Assumption | Reality |
|---|---|
| A failed solve returns an error worth dressing up | **200, and nothing happens.** So the tool reads the request first, refuses when `can_be_solved_by_me` is false, and verifies the resulting status. The risk was never a raw error — it was reporting a success that never happened. |
| `required_in_portal` validation applies uniformly | Enforced **only against end users**; an agent token gets 201 with an empty subject. Validating locally is what makes the tool behave the same for both identities. |
| Multiple ticket forms need Suite Growth+ | The probed instance is **Support Professional with six forms**. Nothing gates on a plan name; capability is read from what `/ticket_forms` returns. |

And the constraint that shaped every handler: **silent ignoring is this API's
house style.** An unrecognised `status` filter returns *everything*; an unknown
`ticket_form_id` returns 201 having substituted the default form;
`priority`/`type` from an end user are dropped; a write to a non-portal field is
dropped. All 2xx, no diagnostic. Hence enums validated through Zod before
sending, unknown form ids refused rather than guessed, and post-conditions read
back from the response body instead of inferred from the status code.

Neither `/ticket_forms` nor `/ticket_fields` can be trusted to say when a
listing is done — `count` can be a pre-filter total (measured: 27 while
returning 8 rows with `next_page: null`) and a short page can still be followed
by another — so both are walked following `next_page` alone, and a truncated
walk raises rather than returning a partial list. `GET /ticket_fields/{id}` is
403 for an end user, so the list is the only way in.

## Privacy properties worth knowing

Private notes never reach this surface: Zendesk filters them **by path, not by
role**, so `/requests/{id}/comments` hides them even from an admin. Correctness
here does not depend on getting the caller's role right. The `users` sideload
that endpoint returns carries an `agent` flag and only five keys, so replies are
attributed by name without leaking agent contact details.

## Review history

Two review passes, both of which found real defects. Details in the PR
comments; the short version:

- **A Claude Code review** found six, one blocking: `create_request` could
  never have succeeded on a real Zendesk, because portal-required validation
  ran over the *system* subject and description fields and demanded them in
  `custom_fields`. My fixtures hid it by omitting fields every real form
  carries. Also: `--tool` had silently lost its reach into non-default
  namespaces, `--print-tools` lied about `--no-promoted-articles`,
  `get_request` truncated long conversations, a truncated field scan degraded
  into the failure it guards, and `--print-tools` printed a `[RO]`-prefixed name
  no client sees.
- **CodeRabbit** found that `GET /ticket_forms` was unpaginated, which could
  make `resolveForm` reject a valid form id — a *confident* wrong answer from
  the very check that exists to stop Zendesk substituting the default form.

## Functional validation plan

### Context

The change is observable at MCP runtime in three places: the **tool surface**
(seven new tools, and their absence by default), the **behaviour of those
tools** against live Zendesk, and a **CLI diagnostic**. Your session is already
on this branch with the server running, authenticated, `--mode all`, tools as
`mcp__zendesk-local__*`.

One thing to know before you start: `.mcp.json` on this branch now names all
four namespaces explicitly, because `--mode all` alone no longer means "every
namespace". If your running server predates that commit, the
`mcp__zendesk-local__*` tool list will **not** contain the new tools — report
that as `BLOCKED` on V1 rather than working around it.

`--print-tools` and the capture probe are the only scenarios needing a
terminal. Everything else is tool calls.

**Commit under test: `fb8ae37`.**

### V0 — ground truth (do this first; it gates the rest)

`src/types.ts` declares `ZendeskTicketForm`, `ZendeskFormCondition` and
`ZendeskRequestCommentAuthor` from a written report rather than from payloads
anyone on this branch saw. The MCP tools cannot close that gap — they return
rendered text, so a field named wrongly renders as a silently missing line
rather than an error.

```bash
pnpm tsx scripts/probe-request-shapes.ts
```

Read-only: three GETs, no writes, and it prints keys and runtime types only —
no subject, body, name or email — so paste the **whole output** into your
report. What matters:

- Do `visible_in_portal`, `required_in_portal`, `editable_in_portal` and
  `title_in_portal` appear on the ticket-field objects, under those exact names?
- Does the form object carry `display_name`, `ticket_field_ids` and
  `end_user_conditions`?
- Does `/requests/{id}/comments` return a `users` sideload, and does each entry
  carry `agent`?
- Does `count` disagree with the number of rows returned? (Expected — record it.)

A mismatch on any of these is a **FAIL on V0** and means the types need
aligning before the rest of the plan is trusted. `end_user_conditions` is
expected to be `[]` on every form; that shape stays unverifiable here and
should be reported as such, not as a pass.

### Scenarios

| id | Validates | Do this | Expect |
|---|---|---|---|
| **V1** | The opt-in gate, positively | List the `mcp__zendesk-local__*` tools available in your session | All seven present: `list_request_forms`, `get_request_form`, `create_request`, `list_requests`, `get_request`, `add_request_comment`, `mark_request_solved` |
| **V2** | The opt-in gate, negatively | `node dist/index.js "$ZENDESK_SUBDOMAIN" --print-tools` (after `pnpm build`) | Three proxies, and **no** `zendesk_requests`. This is the load-bearing assertion of the whole design |
| **V3** | The diagnostic, and that it needs no auth | `node dist/index.js "$ZENDESK_SUBDOMAIN" --print-tools --namespace requests` | `zendesk_requests` with its seven operations, three marked `(write)`. **No browser window opens and it does not block** — if it prompts for OAuth, that is a FAIL |
| **V4** | Read-only composes with the namespace | same as V3 plus `--read-only` | `zendesk_requests` with only the four reads, and `Read-only: yes` in the header |
| **V5** | Form discovery | `list_request_forms` with `{}` | The real forms on `fruggr`, by their customer-facing names, with ids, one marked default |
| **V6** | The cross-call join | `get_request_form` with a form id from V5 | That form's fields in portal order, each with a label and required/optional, dropdowns listing their accepted values. It should also say a subject and a description are always needed, and must **not** list Subject or Description as fields to send. Cross-check one label against the Zendesk admin UI if you can |
| **V7** | Agent-visible fields are filtered out | Same output as V6 | No field the Help Center does not show (e.g. an agent-only priority or internal field) |
| **V8** | Unknown form id is refused, not substituted | `get_request_form` with `{"form_id": 999999}` | An error naming the forms that *do* exist. Zendesk would have answered 201 on a submit — the refusal is the point |
| **V9** | Local required-field validation | `create_request` with a valid `form_id` but omitting a *custom* field V6 marked required | Refused **before** any request is sent, naming the missing field and its id. This is the path the blocking review finding broke, so read the error text: it must name the custom field and **not** "Subject (field id 1)" |
| **V10** | Submitting for real | `create_request`, subject prefixed `[MCP validation #264]`, all required fields, one small text attachment | A request number back, and the request visible in Zendesk with that form and that attachment. **Record the id for cleanup** |
| **V11** | Listing | `list_requests` with `{}` | Your own requests, including V10's, with status and a "can you mark it solved" line |
| **V12** | Search path | `list_requests` with a `query` matching V10's subject | Header says it searched; V10's request found. Also confirm a `query` matching nothing says so rather than returning everything |
| **V13** | Status filter | `list_requests` with `{"status": ["closed"]}` | Only closed ones — **not** everything. Zendesk returns everything for an unrecognised status, so this proves the enum is doing its job |
| **V14** | Reading a thread | `get_request` on V10's id with `include_comments: true` | The conversation, each comment attributed by name, agent replies marked `(support agent)` |
| **V15** | No internal note leaks | Ask an agent to add an **internal note** to V10's request, then repeat V14 | The note is absent. If it appears, that is a serious FAIL — stop and report immediately |
| **V16** | Replying | `add_request_comment` on V10's id | Confirmation naming the resulting status |
| **V17** | The phantom solve | `mark_request_solved` on an **unassigned** request (V10's, before anyone picks it up) | A refusal explaining an agent must be assigned first, suggesting `add_request_comment`. **Verify in Zendesk that the status did not change.** A "solved" claim here is a FAIL |
| **V18** | A real solve | Have an agent assign V10's request, confirm `get_request` now says solvable, then `mark_request_solved` | Status reads back as solved, and Zendesk agrees |
| **V19** | Reopen on reply | `add_request_comment` on the now-solved V10 | Confirmation says the request is **open** again |
| **V20** | Proxy scoping | `pnpm tsx scripts/mcp-live.ts call zendesk_requests '{"operation":"create_ticket","params":{"subject":"x","description":"y"}}' -- --mode namespace --namespace requests` | `Unknown operation "create_ticket"` — the end-user proxy must not be a back door to the agent surface |

### Priorities

**V0 first** — a type mismatch invalidates the rest. Then **V9, V2, V17, V15**:
the required-field path (which a review found broken), the opt-in gate, the
phantom solve, and the private-note boundary are the four things that would be
genuinely damaging if wrong. Then the journey V5→V19. V20 and V4 last.

### Not to re-prove

Covered by unit and integration tests, no need to re-derive: pagination walking
across pages, strict-schema rejection of unknown params, and the formatter
output (inline snapshots). If V0 shows a type mismatch, though, those mocks are
wrong too — say so.

### Cleanup

Delete the `[MCP validation #264]` request(s) you created and list their ids in
your report.

### Reporting

Post a PR comment in English: per-id verdict (`OK` / `FAIL` / `BLOCKED`) with
the observed evidence — tool output, what Zendesk showed, the probe payload for
V0 — plus a one-line overall summary and the commit SHA you tested.

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally (1055 tests)
- [x] `pnpm test:coverage` meets the thresholds (statements 98.15 / branches 89.05 / functions 99.42 / lines 98.54)
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
- [x] If the change has **MCP-runtime-observable** behaviour: this PR carries a `## Functional validation plan` above, to be executed by an independent validator whose report goes in a PR comment

`pnpm test:mutation:diff origin/main HEAD` is green: **141 mutants in the
changed lines, 141 killed, 0 escaped.** Getting there required tightening real
gaps rather than relaxing anything — an unasserted proxy-label map, a join
separator exercised with only one element, a `via?.` guard tested with
`via: {}` instead of `via` absent, and a schema default that `loadConfig`
happened to bypass.

## Notes for the reviewer (human or AI)

**The decision worth challenging** is dropping `--profile` for an opt-in
namespace. It trades a self-documenting flag for one fewer configuration axis.
The cost is discoverability: "run it for your customers" is now
`--namespace requests --namespace help_center`, which reads as plumbing rather
than as choosing an audience, and the README's End-user mode section has to
carry that weight. The ADR records the alternative.

**A behaviour change to be aware of.** `namespaces` no longer defaults to every
member of the enum. Anyone relying on "no `--namespace` means everything" gets
the three agent namespaces instead. Two things in this repo already depended on
the old reading and are fixed here: `.mcp.json`, and `--tool` (which could no
longer name a tool outside the default set). Worth a thought about whether
anything downstream does too.

**Two things I could not verify** and did not pretend to:
- A form's `end_user_conditions` shape. No form on the instance carries any, so
  `ZendeskFormCondition` is declared from a report. The tool surfaces conditions
  as data and hard-validates only unconditionally-required fields, so a wrong
  guess degrades to a missing hint rather than a refused submission — but it is
  a guess. V0 captures what can be captured.
- Whether the Requests API enforces conditional requirements server-side, or
  leaves them to the web widget. Untested for the same reason.

**One deliberate deviation from the issue.** It asks for role detection "at
startup". That is not implementable: auth is lazy and under stdio no token
exists before the first tool call. What replaced it is stronger where it counts
— the 403 rewrite names the end-user surface and points at the agent-side
tools, and the private-note boundary holds by path rather than by role, so it
does not depend on classifying the caller at all. If you want an explicit role
check as well, say so and I will add the memoized `users/me` probe (it must
assert `id !== null`: unauthenticated, that endpoint returns 200 with
`role: "end-user"` and a null id, so the obvious version of that check would
classify a missing token as a valid customer).

https://claude.ai/code/session_01G6tKD4qfYp8hQKWrjrEFh2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an opt-in end-user Requests toolset for browsing forms and requests, creating requests, adding comments, and marking eligible requests as solved.
  - Added support for conditional form rules, required-field validation, portal fields, and file attachments.
  - Added `--print-tools` to preview available tools without credentials or network access.
  - Requests tools remain separate from the default tool set and can be enabled explicitly.

- **Documentation**
  - Added customer onboarding guidance and clarified end-user capabilities, configuration, workflows, and tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->