### PR TITLE
feat(tickets): add list_ticket_comments and make truncation advice tool-aware

### DIFF
--- a/.claude/skills/functional-validation-plan/SKILL.md
+++ b/.claude/skills/functional-validation-plan/SKILL.md
@@ -30,7 +30,11 @@ omitting the plan.
 - **Independent validator.** Write the plan FOR someone other than the
   implementer — another agent (e.g. the local executor) or a human. Don't assume
   it shares your conversation context: spell out the state to manipulate and how
-  to observe results.
+  to observe results. Independence is about *context*, not identity: every agent
+  here posts under the same human's GitHub account, so a report is not the
+  author's just because it carries the author's login. Judge it on its evidence,
+  and leave the "does this count" call to the repository owner — stating the role
+  behind a run once is enough.
 - **Assume a fully ready environment — don't make the validator build it.** The
   validator's session is already **on the PR branch, in a live checkout, with the
   MCP server running and authenticated** and its tools loaded as `mcp__<server>__*`
@@ -110,13 +114,16 @@ it as a PR-activity event if subscribed):
 
 1. **Read the report** (`mcp__github__pull_request_read` / the comment body) and
    confirm it tested the right commit SHA. If it's stale (predates your last
-   push), ask for a re-run.
+   push), ask for a re-run. A stale SHA is a reason to re-run; the account it was
+   posted from never is.
 2. **Re-verify each scenario — don't trust the verdict blindly.** Check the
    reported evidence against the plan's expected observable yourself: a validator
    can misread a log line or mislabel a pass. Where the evidence is too thin to
    confirm, ask them to re-capture that scenario.
-3. **On all OK:** the loop is closed. Note the outcome (a short confirming PR
-   comment, or tell the user) — that green report is the deliverable, not a no-op.
+3. **On all OK:** the loop is closed. Note the outcome **once** — a short
+   confirming PR comment, or just tell the user — and stop there. That green
+   report is the deliverable, not a no-op, and not a prompt to re-argue whether
+   the pass was independent enough.
 4. **On any FAIL/BLOCKED:** diagnose the root cause. If it's a real bug, fix it on
    the branch in a separate commit, push, and ask the validator to re-run the
    affected ids against the new SHA. If it's a `BLOCKED` (missing creds/egress),

--- a/.claude/skills/run-validation-plan/SKILL.md
+++ b/.claude/skills/run-validation-plan/SKILL.md
@@ -11,6 +11,17 @@ test, and you must not get attached to it passing. Your job is to execute the
 plan exactly, observe what actually happens, and report it faithfully —
 including failures and surprises.
 
+**You are independent because of your context, not your login.** Every agent in
+this repo acts under the same human's GitHub account, so the author shown on a
+PR comment — including comments from earlier runs, which are *not* yours — tells
+you nothing about which session wrote it. What makes you the independent
+validator is that this session did not write the code: you were handed the
+branch and the plan, not the implementer's reasoning. So don't try to work out
+whether you might secretly be the author, don't hedge verdicts with doubt about
+your own identity, and don't stack disclaimers. State your role once, in the
+report's `Run by:` line, and let the repository owner judge it — the call is
+theirs, not yours.
+
 ## Input & environment
 
 - **The plan is the verbatim `## Functional validation plan` section of the PR
@@ -85,6 +96,8 @@ GitHub MCP is connected, `mcp__github__add_issue_comment`. If neither is availab
 ```markdown
 ## Functional validation report — <commit SHA>
 
+Run by: independent validator session (did not write the code)
+
 | ID | Verdict | Evidence |
 | -- | ------- | -------- |
 | S1 | OK      | log `oauth_token_refreshed_cached`; file accessToken old→new, expiresAt now future |
@@ -129,6 +142,9 @@ paste real data into it**.
 - Faithful reporting over a green result. A wrong "OK" is worse than an honest FAIL.
 - Independent: validate behaviour against the plan's expectations, not against the
   implementer's explanation of why it should work.
+- Report the run, nothing else. No meta-commentary on who you are, on whether
+  the pass "counts", or on what the author should now do — one `Run by:` line
+  covers it and the owner decides the rest.
 - Real tools only (`mcp__<server>__*`), throwaway copies of any mutable state.
 - The tenant is **production**: never let a real value (PII, org, ticket
   content, subdomain) reach the report or any other output — redact to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,16 @@ posts their report as a PR comment (English). Author the plan with the
 `functional-validation-plan` skill; the validator executes it with the
 `run-validation-plan` skill — don't inline either here.
 
+**Independence is about context, not identity.** Every agent here acts under the
+same human's GitHub account, so the author shown on a PR comment says nothing
+about which session wrote it. A validator is independent when it did not write
+the code: a separate session handed the branch and the plan, without the
+implementer's conversation. Sharing the account, the machine or the tenant does
+not make it the implementer, and a report is judged on its evidence, not on its
+login. State the role behind a run once, in one line; the repository owner
+decides whether it counts, and that decision is not reopened comment after
+comment.
+
 **Pure tooling / dev-tooling changes are exempt** — build scripts, the
 typecheck/lint/format setup, dev-only scripts, CI and release automation change
 nothing a client observes at runtime, so the standard gates (`pnpm typecheck` /

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,6 +209,17 @@ connected to several servers.
 
 Log verbosity (`debug` surfaces the full OAuth flow trace).
 
+### `ZENDESK_CHARACTER_LIMIT`
+**Required:** no · **Default:** `25000`
+
+Ceiling on the characters a single tool response may carry. Past it the text is cut and a notice says what to do about it — the notice names a lever the tool in question actually accepts (a page parameter, a narrower filter, or the tool that pages the same data), so it differs per tool.
+
+Raising it is rarely what you want: the default exists to protect the client's own context budget, and a larger response mostly moves the problem downstream. **Lowering it is the useful direction** — it is how the truncation paths get exercised on a tenant whose real data never reaches 25 000 characters. Set it to a few hundred and any ordinary response trips the notice:
+
+```bash
+ZENDESK_CHARACTER_LIMIT=2000 pnpm dev -- <your-subdomain> --mode all
+```
+
 ### `ZENDESK_MAX_ATTACHMENT_BYTES`
 **Required:** no · **Default:** `5242880` (5 MB)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,7 +134,7 @@ applying the default there would boot a server whose config silently disagrees
 with the deployment. Every single-value variable below therefore fails at
 startup when set but empty, naming the variable. Unset it to get the default.
 
-Two deliberate exceptions:
+Three deliberate exceptions:
 
 - `CORS_ORIGIN` is a *list*, where an empty value legitimately means "no extra
   origins" on top of the built-in allowlist.
@@ -142,6 +142,15 @@ Two deliberate exceptions:
   8080` alongside a stray `PORT=` still boots, and so does the positional
   `<subdomain>` alongside an empty `ZENDESK_SUBDOMAIN`. Validation applies to
   the value the server actually uses.
+- The **numeric tuning caps** — `ZENDESK_CHARACTER_LIMIT`,
+  `ZENDESK_MAX_ATTACHMENT_BYTES`, `ZENDESK_MAX_EMBEDDED_IMAGES`,
+  `ZENDESK_MAX_COMMENT_PAGES`, `ZENDESK_REORDER_CONFIRM_THRESHOLD` and
+  `ZENDESK_ARTICLE_RESOURCES_SCAN_MAX_PAGES` — read through a shared parser that
+  treats an empty value as unset and falls back to the default, along with any
+  value that is not a positive safe integer. They bound response sizes and scan
+  depth rather than describing the deployment, so a typo there degrades a
+  guardrail instead of misrouting traffic, and refusing to boot over one would
+  be the harsher failure.
 
 ### `ZENDESK_SUBDOMAIN`
 **Required:** yes (or the CLI `<subdomain>` argument) · **Default:** none

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -14,7 +14,8 @@ out every `write` tool before the proxies are built.
 
 | Tool | Description | Mode |
 |------|-------------|------|
-| `get_ticket` | Retrieve a ticket by ID with optional comments and its live SLA state (resolved via a scoped search) | read |
+| `get_ticket` | Retrieve a ticket by ID with optional comments and its live SLA state (resolved via a scoped search); the thread comes back whole, so reach for `list_ticket_comments` on a long one | read |
+| `list_ticket_comments` | Read a ticket's conversation (public replies and internal notes, full bodies) newest-first and cursor-paginated, with comment ids and authors resolved to names — the paged alternative to `get_ticket(include_comments=true)` on a long thread | read |
 | `get_ticket_history` | Read a ticket's change history (audit trail) as a chronological, oldest-first timeline of who changed what and when: field changes as before → after with actor names, comment presence (not bodies), system noise filtered; cursor-paginated | read |
 | `get_ticket_attachments` | Download ticket attachments. Images are delivered as native multimodal content for the client's own model to analyze; oversize/over-limit images and non-images come back as text references | read |
 | `search_tickets` | Search tickets using Zendesk query syntax, with per-result SLA state | read |

--- a/scripts/probe-ticket-comments.ts
+++ b/scripts/probe-ticket-comments.ts
@@ -91,7 +91,11 @@ const base = {
 };
 
 const first = await fetchPage(base);
-const authorIds = new Set((first.comments ?? []).map((c) => c.author_id));
+// The system actor (-1) has no user record, so it can never be side-loaded and
+// resolveCommentAuthors skips it — counting it here would fake a "NO".
+const authorIds = new Set(
+  (first.comments ?? []).map((c) => c.author_id).filter((id): id is number => (id ?? 0) > 0),
+);
 const sideloaded = new Set((first.users ?? []).map((u) => u.id));
 console.log(
   `\nQ2 — authors ${[...authorIds].join(', ')} covered by the side-load? ` +

--- a/scripts/probe-ticket-comments.ts
+++ b/scripts/probe-ticket-comments.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env tsx
+/**
+ * Read-only ground-truth probe for GET /tickets/{id}/comments (#265).
+ *
+ * The formatted tool output cannot answer two questions this feature rests on,
+ * because both live in the raw upstream payload:
+ *
+ *   1. Does Zendesk accept `sort=-created_at` alongside cursor pagination
+ *      (`page[size]`/`page[after]`)? Its docs make `sort_order` offset-only and
+ *      point cursor callers at `sort`, but only a live call proves it.
+ *   2. Does the `include=users` side-load carry the *comment authors*? The docs
+ *      only promise email CCs, which is why list_ticket_comments falls back to a
+ *      batched /users/show_many.
+ *
+ * It performs GETs only, prints the query it sent, the response's top-level
+ * keys, `meta`, and a redacted per-comment/per-user summary (ids, timestamps,
+ * body length — never body text), then follows one cursor page.
+ *
+ * Usage (auth is the one the running server already uses):
+ *   ZENDESK_SUBDOMAIN=<subdomain> ZENDESK_OAUTH_TOKEN=<token> \
+ *     pnpm tsx scripts/probe-ticket-comments.ts <ticket_id>
+ */
+import { getBaseUrl } from '../src/constants';
+
+const ticketId = process.argv[2];
+const subdomain = process.env['ZENDESK_SUBDOMAIN'];
+const token = process.env['ZENDESK_OAUTH_TOKEN'];
+
+const fail = (message: string): never => {
+  console.error(message);
+  process.exit(1);
+};
+
+if (!ticketId) fail('Usage: pnpm tsx scripts/probe-ticket-comments.ts <ticket_id>');
+if (!subdomain) fail('ZENDESK_SUBDOMAIN is not set.');
+if (!token) fail('ZENDESK_OAUTH_TOKEN is not set (see docs/live-testing.md).');
+
+interface ProbeComment {
+  id?: number;
+  author_id?: number;
+  public?: boolean;
+  created_at?: string;
+  body?: string;
+}
+interface ProbeUser {
+  id?: number;
+  name?: string;
+}
+interface ProbeResponse {
+  comments?: ProbeComment[];
+  users?: ProbeUser[];
+  meta?: { has_more?: boolean; after_cursor?: string };
+}
+
+const fetchPage = async (params: Record<string, string>): Promise<ProbeResponse> => {
+  const url = new URL(`${getBaseUrl(subdomain as string)}/tickets/${ticketId}/comments`);
+  for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+  console.log(`\nGET ${url.pathname}${url.search}`);
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+  });
+  const text = await response.text();
+  console.log(`  status: ${response.status} ${response.statusText}`);
+  if (!response.ok) {
+    // A 400 here is the answer to question 1, so print the body rather than throw.
+    console.log(`  body: ${text.slice(0, 500)}`);
+    return {};
+  }
+  const json = JSON.parse(text) as ProbeResponse;
+  console.log(`  top-level keys: ${Object.keys(json).join(', ')}`);
+  console.log(`  meta: ${JSON.stringify(json.meta ?? null)}`);
+  console.log(
+    `  comments: ${(json.comments ?? [])
+      .map(
+        (c) =>
+          `{id:${c.id}, author:${c.author_id}, public:${c.public}, at:${c.created_at}, body_len:${c.body?.length ?? 0}}`,
+      )
+      .join('\n            ')}`,
+  );
+  console.log(
+    `  users side-load: ${json.users ? `${json.users.length} → ids ${json.users.map((u) => u.id).join(', ')}` : 'ABSENT'}`,
+  );
+  return json;
+};
+
+const base = {
+  'page[size]': '2',
+  sort: '-created_at',
+  include: 'users',
+  include_inline_images: 'true',
+};
+
+const first = await fetchPage(base);
+const authorIds = new Set((first.comments ?? []).map((c) => c.author_id));
+const sideloaded = new Set((first.users ?? []).map((u) => u.id));
+console.log(
+  `\nQ2 — authors ${[...authorIds].join(', ')} covered by the side-load? ` +
+    `${[...authorIds].every((id) => sideloaded.has(id)) ? 'YES' : 'NO (batched show_many fallback fires)'}`,
+);
+
+const cursor = first.meta?.after_cursor;
+if (first.meta?.has_more && cursor) {
+  await fetchPage({ ...base, 'page[after]': cursor });
+  console.log(
+    '\nQ1 — sort + cursor paging: both pages returned above; check the ids walk backward in time.',
+  );
+} else {
+  console.log(
+    '\nQ1 — only one page for this ticket; pick a ticket with more comments to exercise page[after].',
+  );
+}

--- a/scripts/probe-ticket-comments.ts
+++ b/scripts/probe-ticket-comments.ts
@@ -17,23 +17,59 @@
  * body length — never body text), then follows one cursor page.
  *
  * Usage (auth is the one the running server already uses):
- *   ZENDESK_SUBDOMAIN=<subdomain> ZENDESK_OAUTH_TOKEN=<token> \
- *     pnpm tsx scripts/probe-ticket-comments.ts <ticket_id>
+ *   pnpm tsx scripts/probe-ticket-comments.ts <ticket_id>
+ *
+ * Auth is the one the running server already uses, so a session that can call
+ * the MCP tools can run this with no setup: the subdomain comes from
+ * ZENDESK_SUBDOMAIN or, failing that, from the committed .mcp.json; the token
+ * from ZENDESK_OAUTH_TOKEN or, failing that, from the same cached token file
+ * the stdio server reads (docs/live-testing.md).
  */
+import { readFileSync } from 'node:fs';
+import { loadToken, resolveTokenPath } from '../src/auth/token-persistence';
 import { getBaseUrl } from '../src/constants';
-
-const ticketId = process.argv[2];
-const subdomain = process.env['ZENDESK_SUBDOMAIN'];
-const token = process.env['ZENDESK_OAUTH_TOKEN'];
 
 const fail = (message: string): never => {
   console.error(message);
   process.exit(1);
 };
 
+// The project-scoped MCP config names the tenant the local server points at, so
+// it is the right fallback when the shell has no ZENDESK_SUBDOMAIN.
+const subdomainFromMcpConfig = (): string | undefined => {
+  try {
+    const raw: unknown = JSON.parse(readFileSync('.mcp.json', 'utf8'));
+    const servers = (raw as { mcpServers?: Record<string, { env?: Record<string, string> }> })
+      .mcpServers;
+    for (const server of Object.values(servers ?? {})) {
+      const value = server.env?.['ZENDESK_SUBDOMAIN'];
+      if (value) return value;
+    }
+  } catch {
+    // absent or malformed → no subdomain from here
+  }
+  return undefined;
+};
+
+const ticketId = process.argv[2];
 if (!ticketId) fail('Usage: pnpm tsx scripts/probe-ticket-comments.ts <ticket_id>');
-if (!subdomain) fail('ZENDESK_SUBDOMAIN is not set.');
-if (!token) fail('ZENDESK_OAUTH_TOKEN is not set (see docs/live-testing.md).');
+
+const subdomain = process.env['ZENDESK_SUBDOMAIN'] ?? subdomainFromMcpConfig();
+if (!subdomain) {
+  fail('No subdomain: set ZENDESK_SUBDOMAIN, or run from a checkout whose .mcp.json declares one.');
+}
+
+const token =
+  process.env['ZENDESK_OAUTH_TOKEN'] ??
+  loadToken(resolveTokenPath(subdomain as string))?.accessToken;
+if (!token) {
+  fail(
+    `No token: set ZENDESK_OAUTH_TOKEN, or sign in once so the store at ${resolveTokenPath(subdomain as string)} is populated (docs/live-testing.md).`,
+  );
+}
+console.log(
+  `Probing ${subdomain} with the ${process.env['ZENDESK_OAUTH_TOKEN'] ? 'ZENDESK_OAUTH_TOKEN' : 'cached token store'} credential.`,
+);
 
 interface ProbeComment {
   id?: number;

--- a/scripts/probe-ticket-comments.ts
+++ b/scripts/probe-ticket-comments.ts
@@ -51,24 +51,32 @@ const subdomainFromMcpConfig = (): string | undefined => {
   return undefined;
 };
 
+// An exported-but-empty variable is what `FOO="$UNSET"` produces in a shell or a
+// compose file. Treating it as configured would strand the probe on `''` instead
+// of falling through to the source that does have the value — the same reading
+// positiveIntEnv applies to the numeric caps.
+const env = (name: string): string | undefined => {
+  const raw = process.env[name];
+  return raw !== undefined && raw.trim() !== '' ? raw : undefined;
+};
+
 const ticketId = process.argv[2];
 if (!ticketId) fail('Usage: pnpm tsx scripts/probe-ticket-comments.ts <ticket_id>');
 
-const subdomain = process.env['ZENDESK_SUBDOMAIN'] ?? subdomainFromMcpConfig();
+const subdomain = env('ZENDESK_SUBDOMAIN') ?? subdomainFromMcpConfig();
 if (!subdomain) {
   fail('No subdomain: set ZENDESK_SUBDOMAIN, or run from a checkout whose .mcp.json declares one.');
 }
 
-const token =
-  process.env['ZENDESK_OAUTH_TOKEN'] ??
-  loadToken(resolveTokenPath(subdomain as string))?.accessToken;
+const envToken = env('ZENDESK_OAUTH_TOKEN');
+const token = envToken ?? loadToken(resolveTokenPath(subdomain as string))?.accessToken;
 if (!token) {
   fail(
     `No token: set ZENDESK_OAUTH_TOKEN, or sign in once so the store at ${resolveTokenPath(subdomain as string)} is populated (docs/live-testing.md).`,
   );
 }
 console.log(
-  `Probing ${subdomain} with the ${process.env['ZENDESK_OAUTH_TOKEN'] ? 'ZENDESK_OAUTH_TOKEN' : 'cached token store'} credential.`,
+  `Probing ${subdomain} with the ${envToken ? 'ZENDESK_OAUTH_TOKEN' : 'cached token store'} credential.`,
 );
 
 interface ProbeComment {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,23 @@
-export const CHARACTER_LIMIT = 25_000;
+// Read a positive-integer override from the environment, falling back to a safe
+// default. Unchecked Number() coercion is unsafe here: an empty string yields 0
+// and a typo yields NaN, either of which would silently break the guardrail that
+// relies on the value. Missing/empty/non-positive values and anything that is not
+// a positive safe integer (fractions like "1.5", values beyond 2^53) fall back —
+// these constants are all counts/sizes, so a fractional or unsafe value is a typo.
+const positiveIntEnv = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+// Ceiling on the characters a single tool response may carry; past it the text is
+// cut and a notice explains what to do about it (see truncateIfNeeded). The
+// default protects the client's own context budget, so raising it is rarely what
+// you want. It is overridable mainly so the truncation paths can be exercised on
+// a tenant whose real data never reaches 25 000 characters: lower it and any
+// ordinary response will trip the notice. Override via ZENDESK_CHARACTER_LIMIT.
+export const CHARACTER_LIMIT = positiveIntEnv('ZENDESK_CHARACTER_LIMIT', 25_000);
 export const DEFAULT_PAGE_SIZE = 100;
 export const MAX_PAGE_SIZE = 100;
 
@@ -15,19 +34,6 @@ export const CONTENT_TAGS_MAX_PAGE_SIZE = 30;
 // to fix (#265). Callers who want more follow the cursor.
 export const DEFAULT_TICKET_COMMENT_PAGE_SIZE = 20;
 export const TOKEN_CACHE_TTL_MS = 5 * 60 * 1000;
-
-// Read a positive-integer override from the environment, falling back to a safe
-// default. Unchecked Number() coercion is unsafe here: an empty string yields 0
-// and a typo yields NaN, either of which would silently break the guardrail that
-// relies on the value. Missing/empty/non-positive values and anything that is not
-// a positive safe integer (fractions like "1.5", values beyond 2^53) fall back —
-// these constants are all counts/sizes, so a fractional or unsafe value is a typo.
-const positiveIntEnv = (name: string, fallback: number): number => {
-  const raw = process.env[name];
-  if (raw === undefined || raw.trim() === '') return fallback;
-  const parsed = Number(raw);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
-};
 
 // TTL for the per-session Help Center topology cache (zendesk-hc://topology).
 // The tenant's structure (locales, category/section tree, segments) changes

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,13 @@ export const MAX_PAGE_SIZE = 100;
 // allow up to 100. Reusing the shared MAX_PAGE_SIZE (100) here always failed
 // (issue #162), so list_content_tags gets its own limit.
 export const CONTENT_TAGS_MAX_PAGE_SIZE = 30;
+
+// Default page size for list_ticket_comments. Unlike CONTENT_TAGS_MAX_PAGE_SIZE
+// this is not an API cap (the endpoint allows 100): the binding constraint is
+// CHARACTER_LIMIT, because comment bodies are long. A default of 100 would make
+// almost every first page truncate, which is the very failure this tool exists
+// to fix (#265). Callers who want more follow the cursor.
+export const DEFAULT_TICKET_COMMENT_PAGE_SIZE = 20;
 export const TOKEN_CACHE_TTL_MS = 5 * 60 * 1000;
 
 // Read a positive-integer override from the environment, falling back to a safe

--- a/src/guidance/article-resources.ts
+++ b/src/guidance/article-resources.ts
@@ -101,7 +101,10 @@ export const fetchArticleMarkdown = async (
   const path = locale ? `/${locale}/articles/${id}` : `/articles/${id}`;
   const { article } = await helpCenterGet<{ article: ZendeskArticle }>(subdomain, token, path);
   const text = [formatArticleSummary(article), '', htmlToMarkdown(article.body)].join('\n');
-  return truncateIfNeeded(text);
+  return truncateIfNeeded(
+    text,
+    'This resource takes no parameters; read a long article one part at a time with get_article_outline then get_article_section.',
+  );
 };
 
 export interface ArticleResourcesProvider {

--- a/src/guidance/topology.ts
+++ b/src/guidance/topology.ts
@@ -192,7 +192,10 @@ export const formatTopology = (data: TopologyData): string => {
     ),
   ].join('\n');
 
-  return truncateIfNeeded(text);
+  return truncateIfNeeded(
+    text,
+    'This resource takes no parameters; walk the tree with list_categories and list_sections instead.',
+  );
 };
 
 export interface TopologyProvider {

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -345,6 +345,20 @@ const renderGapVerdict = (report: GapReport, gapCount: number, unclassified: num
     : allClear;
 };
 
+// find_translation_gaps takes no pagination parameter, so a truncated report has
+// to name a lever that exists. Which one depends on the scope: an unscoped audit
+// narrows with category_id; a scoped one that saw every section is simply done;
+// a scoped one whose section listing spilled past a page is neither, and saying
+// "re-run it" there would hide the sections the scan never reached (#265).
+const gapAdvice = (report: GapReport): string => {
+  if (!report.categoryScoped) {
+    return 'find_translation_gaps takes no pagination parameter; narrow the audit to one branch of the tree with category_id instead.';
+  }
+  return report.listingIncomplete
+    ? 'find_translation_gaps takes no pagination parameter and this category holds more sections than one page, so the section listing is incomplete: list the rest with list_sections (category_id, following its cursor) and read them with list_section_translations.'
+    : 'find_translation_gaps takes no pagination parameter, and this audit is already scoped to one category: fix the nodes above with set_category_translation / set_section_translation, then re-run it.';
+};
+
 const renderGapReport = (report: GapReport): string => {
   const { locale, categoryGaps, sectionGaps, scanned, found } = report;
   const gapCount = categoryGaps.length + sectionGaps.length;
@@ -376,13 +390,13 @@ const renderGapReport = (report: GapReport): string => {
       ...(report.listingIncomplete
         ? [
             '',
-            `_Note: this Help Center has more than ${MAX_PAGE_SIZE} categories or sections, so only the first page of each was considered. Narrow the scan with category_id to audit the rest._`,
+            report.categoryScoped
+              ? `_Note: this category holds more than ${MAX_PAGE_SIZE} sections, so only the first page was considered. List the rest with list_sections (category_id, following its cursor) and read them with list_section_translations._`
+              : `_Note: this Help Center has more than ${MAX_PAGE_SIZE} categories or sections, so only the first page of each was considered. Narrow the scan with category_id to audit the rest._`,
           ]
         : []),
     ].join('\n'),
-    report.categoryScoped
-      ? 'find_translation_gaps takes no pagination parameter, and this audit is already scoped to one category: fix the nodes above with set_category_translation / set_section_translation, then re-run it.'
-      : 'find_translation_gaps takes no pagination parameter; narrow the audit to one branch of the tree with category_id instead.',
+    gapAdvice(report),
   );
 };
 

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -1004,7 +1004,15 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         const cost = `${pagesScanned} Zendesk API request${pagesScanned === 1 ? '' : 's'}`;
         const note = scanCostNote(truncated, pagesScanned, cost);
         return {
-          content: [{ type: 'text', text: truncateIfNeeded(`${header}\n\n${body}${note}`) }],
+          content: [
+            {
+              type: 'text',
+              text: truncateIfNeeded(
+                `${header}\n\n${body}${note}`,
+                'list_promoted_articles takes no parameters, so this listing cannot be narrowed from the call; read a single article with get_article.',
+              ),
+            },
+          ],
         };
       },
     },
@@ -1463,7 +1471,12 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           content: [
             {
               type: 'text',
-              text: formatList(response.permission_groups ?? [], formatPermissionGroup),
+              text: formatList(
+                response.permission_groups ?? [],
+                formatPermissionGroup,
+                undefined,
+                'list_permission_groups takes no parameters, so this listing cannot be narrowed from the call.',
+              ),
             },
           ],
         };
@@ -1971,7 +1984,17 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           '/articles/labels',
         );
         return {
-          content: [{ type: 'text', text: formatList(response.labels ?? [], formatLabel) }],
+          content: [
+            {
+              type: 'text',
+              text: formatList(
+                response.labels ?? [],
+                formatLabel,
+                undefined,
+                'list_labels takes no parameters, so this listing cannot be narrowed from the call.',
+              ),
+            },
+          ],
         };
       },
     },
@@ -2011,7 +2034,15 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         }
         return {
           content: [
-            { type: 'text', text: formatList(response.user_segments ?? [], formatUserSegment) },
+            {
+              type: 'text',
+              text: formatList(
+                response.user_segments ?? [],
+                formatUserSegment,
+                undefined,
+                'list_user_segments takes no parameters, so this listing cannot be narrowed from the call.',
+              ),
+            },
           ],
         };
       },

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -254,6 +254,8 @@ interface GapReport {
   found: { categories: number; sections: number };
   /** True when the category or section listing itself spilled past one page. */
   listingIncomplete: boolean;
+  /** True when the caller already scoped the audit to one category. */
+  categoryScoped: boolean;
 }
 
 /**
@@ -378,7 +380,9 @@ const renderGapReport = (report: GapReport): string => {
           ]
         : []),
     ].join('\n'),
-    'find_translation_gaps takes no pagination parameter; narrow the audit to one branch of the tree with category_id instead.',
+    report.categoryScoped
+      ? 'find_translation_gaps takes no pagination parameter, and this audit is already scoped to one category: fix the nodes above with set_category_translation / set_section_translation, then re-run it.'
+      : 'find_translation_gaps takes no pagination parameter; narrow the audit to one branch of the tree with category_id instead.',
   );
 };
 
@@ -1037,7 +1041,17 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         const token = await getToken();
         const translations = await listTranslations(subdomain, token, article_id);
         return {
-          content: [{ type: 'text', text: formatList(translations, formatTranslationSummary) }],
+          content: [
+            {
+              type: 'text',
+              text: formatList(
+                translations,
+                formatTranslationSummary,
+                undefined,
+                'list_article_translations takes only article_id, so this listing cannot be narrowed from the call; read one locale in full with get_article.',
+              ),
+            },
+          ],
         };
       },
     },
@@ -1179,7 +1193,17 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
         const token = await getToken();
         const translations = await listNodeTranslations(subdomain, token, 'sections', section_id);
         return {
-          content: [{ type: 'text', text: formatList(translations, formatNodeTranslationSummary) }],
+          content: [
+            {
+              type: 'text',
+              text: formatList(
+                translations,
+                formatNodeTranslationSummary,
+                undefined,
+                'list_section_translations takes only section_id, so this listing cannot be narrowed from the call; write one locale with set_section_translation.',
+              ),
+            },
+          ],
         };
       },
     },
@@ -1214,7 +1238,17 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           category_id,
         );
         return {
-          content: [{ type: 'text', text: formatList(translations, formatNodeTranslationSummary) }],
+          content: [
+            {
+              type: 'text',
+              text: formatList(
+                translations,
+                formatNodeTranslationSummary,
+                undefined,
+                'list_category_translations takes only category_id, so this listing cannot be narrowed from the call; write one locale with set_category_translation.',
+              ),
+            },
+          ],
         };
       },
     },
@@ -1285,6 +1319,7 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
                 listingIncomplete:
                   categoryScope.hasMore ||
                   extractPaginationMeta(sectionsRes, allSections.length).has_more,
+                categoryScoped: category_id !== undefined,
               }),
             },
           ],
@@ -2083,7 +2118,12 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           content: [
             {
               type: 'text',
-              text: formatList(attachments, formatAttachment),
+              text: formatList(
+                attachments,
+                formatAttachment,
+                undefined,
+                'list_article_attachments takes only article_id, so this listing cannot be narrowed from the call.',
+              ),
             },
           ],
         };

--- a/src/tools/help-center.ts
+++ b/src/tools/help-center.ts
@@ -378,6 +378,7 @@ const renderGapReport = (report: GapReport): string => {
           ]
         : []),
     ].join('\n'),
+    'find_translation_gaps takes no pagination parameter; narrow the audit to one branch of the tree with category_id instead.',
   );
 };
 
@@ -733,7 +734,17 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           (hint ?? '') +
           formatArticle(article) +
           `\n\n**Available translations**: ${translations.map((t) => t.locale).join(', ')}`;
-        return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
+        return {
+          content: [
+            {
+              type: 'text',
+              text: truncateIfNeeded(
+                text,
+                'get_article takes no pagination parameter; read a long article one part at a time with get_article_outline then get_article_section.',
+              ),
+            },
+          ],
+        };
       },
     },
     {
@@ -2167,7 +2178,13 @@ export const createHelpCenterTools = (ctx: ToolContext): ToolDefinition[] => {
           '',
           content,
         ].join('\n');
-        return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
+        // No pagination here either, and there is nothing narrower than a
+        // section — but the Markdown rendering of the same content is smaller.
+        const advice =
+          format === 'markdown'
+            ? 'get_article_section takes no pagination parameter, and this single section already exceeds the limit.'
+            : 'get_article_section takes no pagination parameter; request this section as format="markdown", which renders the same content more compactly than HTML.';
+        return { content: [{ type: 'text', text: truncateIfNeeded(text, advice) }] };
       },
     },
     {

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -130,13 +130,16 @@ const commentPageMeta = (response: TicketCommentsResponse, itemCount: number): P
 
 // Zendesk documents cursor pagination on this endpoint, so this is a defensive
 // path. If it ever answered offset-style, `next_page` says more comments exist
-// while no cursor comes with them — and this tool accepts only a cursor. Saying
-// nothing would report a truncated thread as complete, and faking a cursor would
-// send the caller nowhere, so the page carries this note and both levers that do
-// still work.
-const offsetPageNote = (response: TicketCommentsResponse, pageSize: number): string =>
+// while no cursor comes with them — and this tool sends and accepts only a
+// cursor. Nothing it exposes reaches those comments: `page_size` goes out as
+// `page[size]`, which an offset response has already ignored, and
+// get_ticket(include_comments=true) sends no paging at all, so it lands on the
+// same default page. Naming either would be advice that cannot work — the defect
+// this whole change is about (#265) — so the note says plainly that the
+// continuation is out of reach here and points at the one place that is not.
+const offsetPageNote = (response: TicketCommentsResponse): string =>
   response.meta?.after_cursor == null && response.next_page != null
-    ? `\n\n> ⚠ Zendesk paginated this response by offset rather than by cursor, so more comments exist beyond this page and no cursor leads to them. Re-read with a larger page_size (up to ${MAX_PAGE_SIZE}, currently ${pageSize}), or with get_ticket(include_comments=true).`
+    ? '\n\n> ⚠ Zendesk paginated this response by offset rather than by cursor, so more comments exist beyond this page and no cursor leads to them. This tool pages by cursor only, and no parameter it accepts reaches the rest: read the remaining comments in Zendesk directly.'
     : '';
 
 // How the page actually came back, read off the data rather than off what was
@@ -893,7 +896,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         );
         const comments = response.comments ?? [];
         const meta = commentPageMeta(response, comments.length);
-        const offsetNote = offsetPageNote(response, page_size);
+        const offsetNote = offsetPageNote(response);
         if (comments.length === 0) {
           const text = meta.has_more
             ? `No comments on this page of ticket #${ticket_id}. More available (cursor: ${meta.after_cursor}).`

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -115,17 +115,29 @@ const fetchAllTicketComments = async (
 // The pagination fields of a comments page, narrowed out of the response: the
 // whole object cannot be passed as ZendeskListResponse<ZendeskComment>, whose
 // `users?: T[]` would clash with the side-load (see TicketCommentsResponse).
-// `next_page` is carried through so extractPaginationMeta's fallback still fires
-// if Zendesk ever answered this endpoint with offset pagination.
+// `next_page` is deliberately NOT forwarded: extractPaginationMeta would raise
+// `has_more` from it while leaving `after_cursor` null, and the footer would
+// then offer "More available (cursor: null)" — a continuation this cursor-only
+// tool cannot follow. offsetPageNote reports that case in words instead.
 const commentPageMeta = (response: TicketCommentsResponse, itemCount: number): PaginationMeta =>
   extractPaginationMeta<ZendeskComment>(
     {
       ...(response.meta && { meta: response.meta }),
       ...(response.count !== undefined && { count: response.count }),
-      ...(response.next_page !== undefined && { next_page: response.next_page }),
     },
     itemCount,
   );
+
+// Zendesk documents cursor pagination on this endpoint, so this is a defensive
+// path. If it ever answered offset-style, `next_page` says more comments exist
+// while no cursor comes with them — and this tool accepts only a cursor. Saying
+// nothing would report a truncated thread as complete, and faking a cursor would
+// send the caller nowhere, so the page carries this note and both levers that do
+// still work.
+const offsetPageNote = (response: TicketCommentsResponse, pageSize: number): string =>
+  response.meta?.after_cursor == null && response.next_page != null
+    ? `\n\n> ⚠ Zendesk paginated this response by offset rather than by cursor, so more comments exist beyond this page and no cursor leads to them. Re-read with a larger page_size (up to ${MAX_PAGE_SIZE}, currently ${pageSize}), or with get_ticket(include_comments=true).`
+    : '';
 
 // How the page actually came back, read off the data rather than off what was
 // asked for — a header that describes the wrong end is worse than none, and the
@@ -881,11 +893,12 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         );
         const comments = response.comments ?? [];
         const meta = commentPageMeta(response, comments.length);
+        const offsetNote = offsetPageNote(response, page_size);
         if (comments.length === 0) {
           const text = meta.has_more
             ? `No comments on this page of ticket #${ticket_id}. More available (cursor: ${meta.after_cursor}).`
             : `No comments to show for ticket #${ticket_id}.`;
-          return { content: [{ type: 'text', text }] };
+          return { content: [{ type: 'text', text: `${text}${offsetNote}` }] };
         }
         const authors = await resolveCommentAuthors(subdomain, token, comments, response.users);
         const body = comments.map((comment) => formatComment(comment, authors)).join('\n\n');
@@ -894,11 +907,11 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         // misreports its own size. The cursor is no way back to what the cut
         // dropped — it points past this whole page — so the advice names the
         // only recovery there is.
-        const text = [
+        const text = `${[
           `# Comments on ticket #${ticket_id} (${commentPageOrder(comments, sort_order)})`,
           formatPagination(meta),
           body,
-        ].join('\n\n');
+        ].join('\n\n')}${offsetNote}`;
         return {
           content: [
             {

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -906,7 +906,9 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         // character budget, or the response overshoots the limit and the notice
         // misreports its own size. The cursor is no way back to what the cut
         // dropped — it points past this whole page — so the advice names the
-        // only recovery there is.
+        // only recovery there is. At page_size 1 there is no smaller page to
+        // ask for: the cut is inside one over-long comment, and recommending
+        // "smaller than 1" would itself be advice the schema rejects (#265).
         const text = `${[
           `# Comments on ticket #${ticket_id} (${commentPageOrder(comments, sort_order)})`,
           formatPagination(meta),
@@ -918,7 +920,9 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
               type: 'text',
               text: truncateIfNeeded(
                 text,
-                `The comments cut here are not reachable through the cursor, which points past this whole page: re-issue with a page_size smaller than ${page_size} to read them.`,
+                page_size > 1
+                  ? `The comments cut here are not reachable through the cursor, which points past this whole page: re-issue with a page_size smaller than ${page_size} to read them.`
+                  : 'This single comment is longer than the response character limit, so no page small enough exists: read it in Zendesk directly.',
               ),
             },
           ],

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -638,7 +638,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Get Zendesk Ticket',
       description:
-        'Retrieve a Zendesk ticket by ID, including its live SLA state (per-metric stage and breach countdown) when an SLA policy applies, plus its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The per-ticket Show endpoint exposes no SLA, so the SLA block is resolved via a scoped search and may be absent for a very high-volume requester or a just-updated ticket; SLA targets and policy conditions live in list_sla_policies. This returns the ticket as it stands now; for the history of changes behind that state (who changed what, and when), use get_ticket_history. The comment thread is returned whole and is cut past the response character limit, so on a long ticket read it with list_ticket_comments, which pages the comments and returns the newest first.',
+        'Retrieve a Zendesk ticket by ID, including its live SLA state (per-metric stage and breach countdown) when an SLA policy applies, plus its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The per-ticket Show endpoint exposes no SLA, so the SLA block is resolved via a scoped search and may be absent for a very high-volume requester or a just-updated ticket; SLA targets and policy conditions live in list_sla_policies. This returns the ticket as it stands now; for the history of changes behind that state (who changed what, and when), use get_ticket_history. The comment thread is appended in one block — the first page of comments Zendesk returns, cut past the response character limit — so on a long ticket read it with list_ticket_comments, which pages the comments and returns the newest first.',
       inputSchema: z.object({
         ticket_id: z
           .number()
@@ -650,7 +650,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           .boolean()
           .default(false)
           .describe(
-            'When true, appends the full public comment and internal note thread to the response. Defaults to false to keep the payload small; enable it when you need the conversation, not just the ticket fields. On a long thread prefer list_ticket_comments — this flag returns the entire thread in one message.',
+            "When true, appends the full public comment and internal note thread to the response. Defaults to false to keep the payload small; enable it when you need the conversation, not just the ticket fields. On a long thread prefer list_ticket_comments — this flag appends one unpaginated block, so comments past Zendesk's first page are absent and the rest is cut at the response character limit.",
           ),
       }),
       annotations: {
@@ -688,8 +688,8 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         // This tool takes no page or filter, so the default truncation advice
         // would send the caller in circles (#265). Name the tool that does.
         const advice = include_comments
-          ? `The whole thread is returned in one message; read it page by page with list_ticket_comments (ticket_id: ${ticket_id}, sort_order: "desc") to get the newest comments first.`
-          : "get_ticket takes no pagination parameters — this ticket's own fields exceed the limit.";
+          ? `get_ticket appends the thread as one unpaginated block; read it page by page with list_ticket_comments (ticket_id: ${ticket_id}, sort_order: "desc") to get the newest comments first.`
+          : 'get_ticket takes no pagination or filter parameters, so this response cannot be narrowed from the call.';
         return { content: [{ type: 'text', text: truncateIfNeeded(text, advice) }] };
       },
     },
@@ -860,10 +860,16 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           return { content: [{ type: 'text', text }] };
         }
         const authors = await resolveCommentAuthors(subdomain, token, comments, response.users);
-        // The page is rendered in the order Zendesk returned it: under "desc"
-        // that puts the newest comments first, so a page that still overflows
-        // loses its oldest end rather than its newest (#265).
-        const order = sort_order === 'desc' ? 'newest first' : 'oldest first';
+        // The page is rendered in the order Zendesk returned it, so a page that
+        // still overflows loses its trailing end (#265). The header therefore
+        // describes the *returned* order, read off the data rather than off what
+        // was asked for: a single comment has no order to read, so it falls back
+        // to the request.
+        const newestFirst =
+          comments.length > 1
+            ? (comments[0]?.created_at ?? '') >= (comments.at(-1)?.created_at ?? '')
+            : sort_order === 'desc';
+        const order = newestFirst ? 'newest first' : 'oldest first';
         const list = formatList(comments, (comment) => formatComment(comment, authors), meta);
         return {
           content: [
@@ -1328,7 +1334,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
               type: 'text',
               text: truncateIfNeeded(
                 text,
-                `get_linked_incidents takes no pagination parameters: problem #${problem_id} has more linked incidents than fit in one response.`,
+                'get_linked_incidents takes no pagination or filter parameters, so this response cannot be narrowed from the call.',
               ),
             },
           ],
@@ -1753,7 +1759,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
               type: 'text',
               text: truncateIfNeeded(
                 formatMacroPreviewDiff(ticket_id, macro_id, before, result),
-                'preview_macro_diff takes no pagination parameters: this macro rewrites more of the ticket than fits in one response. Read the macro on its own with list_macros to see every action it carries.',
+                'preview_macro_diff takes no pagination or filter parameters; read the macro on its own with list_macros to see every action it carries.',
               ),
             },
           ],

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -45,6 +45,7 @@ import {
   formatFieldValue,
   formatList,
   formatMacro,
+  formatPagination,
   formatSlaBlock,
   formatSlaPolicy,
   formatTagDiff,
@@ -109,6 +110,36 @@ const fetchAllTicketComments = async (
     cursor = response.meta.after_cursor;
   }
   return all;
+};
+
+// The pagination fields of a comments page, narrowed out of the response: the
+// whole object cannot be passed as ZendeskListResponse<ZendeskComment>, whose
+// `users?: T[]` would clash with the side-load (see TicketCommentsResponse).
+// `next_page` is carried through so extractPaginationMeta's fallback still fires
+// if Zendesk ever answered this endpoint with offset pagination.
+const commentPageMeta = (response: TicketCommentsResponse, itemCount: number): PaginationMeta =>
+  extractPaginationMeta<ZendeskComment>(
+    {
+      ...(response.meta && { meta: response.meta }),
+      ...(response.count !== undefined && { count: response.count }),
+      ...(response.next_page !== undefined && { next_page: response.next_page }),
+    },
+    itemCount,
+  );
+
+// How the page actually came back, read off the data rather than off what was
+// asked for — a header that describes the wrong end is worse than none, and the
+// truncation cut always lands on the trailing end (#265). Equal timestamps say
+// nothing about the order (a one-comment page, or several posted within the same
+// second), so those fall back to what was requested rather than guessing.
+const commentPageOrder = (
+  comments: ZendeskComment[],
+  sortOrder: 'asc' | 'desc',
+): 'newest first' | 'oldest first' => {
+  const first = comments[0]?.created_at ?? '';
+  const last = comments.at(-1)?.created_at ?? '';
+  const newestFirst = first === last ? sortOrder === 'desc' : first > last;
+  return newestFirst ? 'newest first' : 'oldest first';
 };
 
 // Fetch specific attachments by id. A 404 is swallowed: attachment ids come
@@ -383,12 +414,10 @@ const collectAuditIds = (audits: ZendeskAudit[]): { userIds: number[]; groupIds:
   return { userIds: [...userIds], groupIds: [...groupIds] };
 };
 
-// Resolve user and group ids to names via batched show_many look-ups (chunked to
-// the 100-id endpoint cap). Best-effort: a failed look-up degrades to id-only
-// rendering rather than failing the whole history — names are supplementary.
-// Resolve one entity kind to an id->name map via batched show_many (chunked to
-// the 100-id endpoint cap). Best-effort: a failed batch leaves those ids
-// unresolved (rendered as bare ids) rather than failing the whole response.
+// Resolve one entity kind to an id->name map via batched show_many look-ups
+// (chunked to the 100-id endpoint cap). Best-effort: a failed batch leaves those
+// ids unresolved (rendered as bare ids) rather than failing the whole response —
+// names are supplementary.
 const resolveEntityNames = async <T extends { id: number; name: string }>(
   subdomain: string,
   token: string,
@@ -417,6 +446,7 @@ const resolveUserNames = (
 ): Promise<Map<number, string>> =>
   resolveEntityNames<ZendeskUser>(subdomain, token, '/users/show_many', 'users', ids);
 
+// The user and group names a rendered audit timeline needs, resolved together.
 const resolveAuditNames = async (
   subdomain: string,
   token: string,
@@ -439,6 +469,10 @@ interface TicketCommentsResponse {
   users?: ZendeskUser[];
   meta?: { has_more: boolean; after_cursor: string };
   count?: number;
+  // Present only if Zendesk answers this endpoint with offset pagination
+  // (ignoring `page[size]`). Forwarded so extractPaginationMeta's `next_page`
+  // fallback still fires and a further page is never reported as "none left".
+  next_page?: string | null;
 }
 
 // Resolve the authors of a comment page to display names. The `include=users`
@@ -674,14 +708,14 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
         let text =
           formatTicket(ticket) + formatSlaBlock(await fetchTicketSla(subdomain, token, ticket));
         if (include_comments) {
-          const { comments } = await zendeskGet<{ comments: ZendeskComment[] }>(
+          const { comments, users } = await zendeskGet<TicketCommentsResponse>(
             subdomain,
             token,
             `/tickets/${ticket_id}/comments`,
-            { include_inline_images: 'true' },
+            { include: 'users', include_inline_images: 'true' },
           );
-          const authors = await resolveCommentAuthors(subdomain, token, comments);
-          text += `\n\n---\n# Comments\n\n${comments
+          const authors = await resolveCommentAuthors(subdomain, token, comments ?? [], users);
+          text += `\n\n---\n# Comments\n\n${(comments ?? [])
             .map((comment) => formatComment(comment, authors))
             .join('\n\n')}`;
         }
@@ -787,7 +821,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'List Zendesk Ticket Comments',
       description:
-        'Read a ticket\'s conversation — public replies and internal notes with their full bodies — one cursor-paginated page at a time, newest comment first. Each entry carries the comment id, the author resolved to a name, the timestamp, whether it is public or internal, and the ids of any attached files. Prefer this over get_ticket(include_comments=true) whenever a thread is long or you only need the latest exchange: get_ticket returns the entire thread in a single message and cuts it past the response character limit, which drops the most recent comments first. Keep sort_order "desc" (the default) to read the latest reply first and follow the returned cursor to walk further back in time, or pass "asc" to replay the conversation forward from the ticket\'s opening description. For who changed which field and when — without comment bodies — use get_ticket_history; to download the attached files themselves, pass the attachment ids shown here to get_ticket_attachments.',
+        'Read a ticket\'s conversation — public replies and internal notes with their full bodies — one cursor-paginated page at a time, newest comment first. Each entry carries the comment id, the author resolved to a name, the timestamp, whether it is public or internal, and the ids of any attached files. Prefer this over get_ticket(include_comments=true) whenever a thread is long or you only need the latest exchange: get_ticket appends the thread as one unpaginated block and cuts it past the response character limit, which drops the most recent comments first. Keep sort_order "desc" (the default) to read the latest reply first and follow the returned cursor to walk further back in time, or pass "asc" to replay the conversation forward from the ticket\'s opening description. For who changed which field and when — without comment bodies — use get_ticket_history; to download the attached files themselves, pass the attachment ids shown here to get_ticket_attachments.',
       inputSchema: z.object({
         ticket_id: z
           .number()
@@ -845,14 +879,8 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
             include_inline_images: 'true',
           },
         );
-        const { comments = [], meta: page, count } = response;
-        // Narrowed to the pagination fields: the full response cannot be passed
-        // as ZendeskListResponse<ZendeskComment>, whose `users?: T[]` would
-        // clash with the side-load (see TicketCommentsResponse).
-        const meta = extractPaginationMeta<ZendeskComment>(
-          { ...(page && { meta: page }), ...(count !== undefined && { count }) },
-          comments.length,
-        );
+        const comments = response.comments ?? [];
+        const meta = commentPageMeta(response, comments.length);
         if (comments.length === 0) {
           const text = meta.has_more
             ? `No comments on this page of ticket #${ticket_id}. More available (cursor: ${meta.after_cursor}).`
@@ -860,20 +888,26 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           return { content: [{ type: 'text', text }] };
         }
         const authors = await resolveCommentAuthors(subdomain, token, comments, response.users);
-        // The page is rendered in the order Zendesk returned it, so a page that
-        // still overflows loses its trailing end (#265). The header therefore
-        // describes the *returned* order, read off the data rather than off what
-        // was asked for: a single comment has no order to read, so it falls back
-        // to the request.
-        const newestFirst =
-          comments.length > 1
-            ? (comments[0]?.created_at ?? '') >= (comments.at(-1)?.created_at ?? '')
-            : sort_order === 'desc';
-        const order = newestFirst ? 'newest first' : 'oldest first';
-        const list = formatList(comments, (comment) => formatComment(comment, authors), meta);
+        const body = comments.map((comment) => formatComment(comment, authors)).join('\n\n');
+        // Assembled and truncated in one go: the title has to be inside the
+        // character budget, or the response overshoots the limit and the notice
+        // misreports its own size. The cursor is no way back to what the cut
+        // dropped — it points past this whole page — so the advice names the
+        // only recovery there is.
+        const text = [
+          `# Comments on ticket #${ticket_id} (${commentPageOrder(comments, sort_order)})`,
+          formatPagination(meta),
+          body,
+        ].join('\n\n');
         return {
           content: [
-            { type: 'text', text: `# Comments on ticket #${ticket_id} (${order})\n\n${list}` },
+            {
+              type: 'text',
+              text: truncateIfNeeded(
+                text,
+                `The comments cut here are not reachable through the cursor, which points past this whole page: re-issue with a page_size smaller than ${page_size} to read them.`,
+              ),
+            },
           ],
         };
       },

--- a/src/tools/tickets.ts
+++ b/src/tools/tickets.ts
@@ -9,6 +9,7 @@ import {
 } from '../client/zendesk-api';
 import {
   DEFAULT_PAGE_SIZE,
+  DEFAULT_TICKET_COMMENT_PAGE_SIZE,
   MAX_ATTACHMENT_BYTES,
   MAX_COMMENT_PAGES,
   MAX_EMBEDDED_IMAGE_COUNT,
@@ -385,39 +386,81 @@ const collectAuditIds = (audits: ZendeskAudit[]): { userIds: number[]; groupIds:
 // Resolve user and group ids to names via batched show_many look-ups (chunked to
 // the 100-id endpoint cap). Best-effort: a failed look-up degrades to id-only
 // rendering rather than failing the whole history — names are supplementary.
+// Resolve one entity kind to an id->name map via batched show_many (chunked to
+// the 100-id endpoint cap). Best-effort: a failed batch leaves those ids
+// unresolved (rendered as bare ids) rather than failing the whole response.
+const resolveEntityNames = async <T extends { id: number; name: string }>(
+  subdomain: string,
+  token: string,
+  path: string,
+  key: 'users' | 'groups',
+  ids: number[],
+): Promise<Map<number, string>> => {
+  const map = new Map<number, string>();
+  for (const batch of chunk(ids, 100)) {
+    try {
+      const res = await zendeskGet<Record<string, T[]>>(subdomain, token, path, {
+        ids: batch.join(','),
+      });
+      for (const entity of res[key] ?? []) map.set(entity.id, entity.name);
+    } catch {
+      // Best-effort: leave these ids unresolved.
+    }
+  }
+  return map;
+};
+
+const resolveUserNames = (
+  subdomain: string,
+  token: string,
+  ids: number[],
+): Promise<Map<number, string>> =>
+  resolveEntityNames<ZendeskUser>(subdomain, token, '/users/show_many', 'users', ids);
+
 const resolveAuditNames = async (
   subdomain: string,
   token: string,
   userIds: number[],
   groupIds: number[],
 ): Promise<AuditNames> => {
-  // Resolve one entity kind to an id->name map via batched show_many (chunked to
-  // the 100-id endpoint cap). Best-effort: a failed batch leaves those ids
-  // unresolved (rendered as bare ids) rather than failing the whole history.
-  const resolve = async <T extends { id: number; name: string }>(
-    path: string,
-    key: 'users' | 'groups',
-    ids: number[],
-  ): Promise<Map<number, string>> => {
-    const map = new Map<number, string>();
-    for (const batch of chunk(ids, 100)) {
-      try {
-        const res = await zendeskGet<Record<string, T[]>>(subdomain, token, path, {
-          ids: batch.join(','),
-        });
-        for (const entity of res[key] ?? []) map.set(entity.id, entity.name);
-      } catch {
-        // Best-effort: leave these ids unresolved.
-      }
-    }
-    return map;
-  };
   // The two look-ups hit independent endpoints — run them concurrently.
   const [users, groups] = await Promise.all([
-    resolve<ZendeskUser>('/users/show_many', 'users', userIds),
-    resolve<ZendeskGroup>('/groups/show_many', 'groups', groupIds),
+    resolveUserNames(subdomain, token, userIds),
+    resolveEntityNames<ZendeskGroup>(subdomain, token, '/groups/show_many', 'groups', groupIds),
   ]);
   return { users, groups };
+};
+
+// The List Comments response. Deliberately *not* ZendeskListResponse<ZendeskComment>:
+// that generic declares `users?: T[]`, which would silently type the `include=users`
+// side-load as an array of comments.
+interface TicketCommentsResponse {
+  comments?: ZendeskComment[];
+  users?: ZendeskUser[];
+  meta?: { has_more: boolean; after_cursor: string };
+  count?: number;
+}
+
+// Resolve the authors of a comment page to display names. The `include=users`
+// side-load is documented for email CCs, so it is treated as an optimisation
+// rather than the mechanism: whatever it returns is used as-is, and the author
+// ids it left out cost one batched show_many. The system actor (-1) has no user
+// record and is labelled by the formatter, so it is never looked up.
+const resolveCommentAuthors = async (
+  subdomain: string,
+  token: string,
+  comments: ZendeskComment[],
+  sideloaded: ZendeskUser[] = [],
+): Promise<Map<number, string>> => {
+  const authors = new Map(sideloaded.map((user) => [user.id, user.name]));
+  const missing = [...new Set(comments.map((comment) => comment.author_id))].filter(
+    (id) => id > 0 && !authors.has(id),
+  );
+  if (missing.length === 0) return authors;
+  for (const [id, name] of await resolveUserNames(subdomain, token, missing)) {
+    authors.set(id, name);
+  }
+  return authors;
 };
 
 // Keys the generic field diff must not emit. Two reasons, both in this set:
@@ -595,7 +638,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Get Zendesk Ticket',
       description:
-        'Retrieve a Zendesk ticket by ID, including its live SLA state (per-metric stage and breach countdown) when an SLA policy applies, plus its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The per-ticket Show endpoint exposes no SLA, so the SLA block is resolved via a scoped search and may be absent for a very high-volume requester or a just-updated ticket; SLA targets and policy conditions live in list_sla_policies. This returns the ticket as it stands now; for the history of changes behind that state (who changed what, and when), use get_ticket_history.',
+        'Retrieve a Zendesk ticket by ID, including its live SLA state (per-metric stage and breach countdown) when an SLA policy applies, plus its comments if requested. Returns ticket details (subject, status, priority, assignee, tags, description) and optionally all comments/internal notes. The per-ticket Show endpoint exposes no SLA, so the SLA block is resolved via a scoped search and may be absent for a very high-volume requester or a just-updated ticket; SLA targets and policy conditions live in list_sla_policies. This returns the ticket as it stands now; for the history of changes behind that state (who changed what, and when), use get_ticket_history. The comment thread is returned whole and is cut past the response character limit, so on a long ticket read it with list_ticket_comments, which pages the comments and returns the newest first.',
       inputSchema: z.object({
         ticket_id: z
           .number()
@@ -607,7 +650,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           .boolean()
           .default(false)
           .describe(
-            'When true, appends the full public comment and internal note thread to the response. Defaults to false to keep the payload small; enable it when you need the conversation, not just the ticket fields.',
+            'When true, appends the full public comment and internal note thread to the response. Defaults to false to keep the payload small; enable it when you need the conversation, not just the ticket fields. On a long thread prefer list_ticket_comments — this flag returns the entire thread in one message.',
           ),
       }),
       annotations: {
@@ -637,9 +680,17 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
             `/tickets/${ticket_id}/comments`,
             { include_inline_images: 'true' },
           );
-          text += `\n\n---\n# Comments\n\n${comments.map(formatComment).join('\n\n')}`;
+          const authors = await resolveCommentAuthors(subdomain, token, comments);
+          text += `\n\n---\n# Comments\n\n${comments
+            .map((comment) => formatComment(comment, authors))
+            .join('\n\n')}`;
         }
-        return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
+        // This tool takes no page or filter, so the default truncation advice
+        // would send the caller in circles (#265). Name the tool that does.
+        const advice = include_comments
+          ? `The whole thread is returned in one message; read it page by page with list_ticket_comments (ticket_id: ${ticket_id}, sort_order: "desc") to get the newest comments first.`
+          : "get_ticket takes no pagination parameters — this ticket's own fields exceed the limit.";
+        return { content: [{ type: 'text', text: truncateIfNeeded(text, advice) }] };
       },
     },
     {
@@ -648,7 +699,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       readOnly: true,
       title: 'Get Zendesk Ticket History',
       description:
-        'Read a ticket\'s change history — its audit trail — as a chronological, oldest-first timeline of who changed what and when. Each entry shows the actor (name and id) and the channel, then the field changes that update carried (status, priority, assignee, group, tags, custom fields) as before → after, with assignee/requester/group ids resolved to names. Comments appear as one-line presence markers (public comment vs internal note added), not their text — fetch the bodies with get_ticket(include_comments=true). Purely system-generated notification events (trigger emails, collaborator/CC notifications, pushes) are filtered out — note this filters notification delivery, not CC-list edits, which are shown as changes — and an update carrying only such events produces no entry, so the timeline stays a readable narrative rather than a raw log. Use it to answer "what happened on this ticket?", "why was it reassigned?" or "when did it go to pending?", reading oldest-first so the founding context is not missed. Read-only, and cursor-paginated oldest-first: pass the returned cursor to page a long-lived ticket toward its most recent changes.',
+        'Read a ticket\'s change history — its audit trail — as a chronological, oldest-first timeline of who changed what and when. Each entry shows the actor (name and id) and the channel, then the field changes that update carried (status, priority, assignee, group, tags, custom fields) as before → after, with assignee/requester/group ids resolved to names. Comments appear as one-line presence markers (public comment vs internal note added), not their text — fetch the bodies with list_ticket_comments (or get_ticket(include_comments=true) for a short thread). Purely system-generated notification events (trigger emails, collaborator/CC notifications, pushes) are filtered out — note this filters notification delivery, not CC-list edits, which are shown as changes — and an update carrying only such events produces no entry, so the timeline stays a readable narrative rather than a raw log. Use it to answer "what happened on this ticket?", "why was it reassigned?" or "when did it go to pending?", reading oldest-first so the founding context is not missed. Read-only, and cursor-paginated oldest-first: pass the returned cursor to page a long-lived ticket toward its most recent changes.',
       inputSchema: z.object({
         ticket_id: z
           .number()
@@ -731,6 +782,97 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
       },
     },
     {
+      name: 'list_ticket_comments',
+      namespace: 'tickets',
+      readOnly: true,
+      title: 'List Zendesk Ticket Comments',
+      description:
+        'Read a ticket\'s conversation — public replies and internal notes with their full bodies — one cursor-paginated page at a time, newest comment first. Each entry carries the comment id, the author resolved to a name, the timestamp, whether it is public or internal, and the ids of any attached files. Prefer this over get_ticket(include_comments=true) whenever a thread is long or you only need the latest exchange: get_ticket returns the entire thread in a single message and cuts it past the response character limit, which drops the most recent comments first. Keep sort_order "desc" (the default) to read the latest reply first and follow the returned cursor to walk further back in time, or pass "asc" to replay the conversation forward from the ticket\'s opening description. For who changed which field and when — without comment bodies — use get_ticket_history; to download the attached files themselves, pass the attachment ids shown here to get_ticket_attachments.',
+      inputSchema: z.object({
+        ticket_id: z
+          .number()
+          .int()
+          .describe(
+            'Ticket ID — the numeric id of the ticket whose conversation to read. Obtain it from search_tickets or list_tickets.',
+          ),
+        sort_order: z
+          .enum(['asc', 'desc'])
+          .default('desc')
+          .describe(
+            'Chronological direction of the page. "desc" (the default) starts at the most recent comment and walks backward in time, which is what you want to see the latest reply; "asc" replays the conversation forward, starting from the ticket\'s opening description — that first comment therefore lands on the last page under "desc".',
+          ),
+        page_size: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_TICKET_COMMENT_PAGE_SIZE)
+          .describe(
+            'Comments per page (1-100, default 20). The default is deliberately small because comment bodies are long and a bigger page risks being cut short by the response character limit; follow the returned cursor rather than raising it.',
+          ),
+        cursor: z
+          .string()
+          .optional()
+          .describe(
+            'Pagination cursor from a previous response; omit for the first page. Zendesk issues it for the ordering that response used, so after changing sort_order drop the cursor and start again from the first page.',
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      handler: async (params) => {
+        const { ticket_id, sort_order, page_size, cursor } = params as {
+          ticket_id: number;
+          sort_order: 'asc' | 'desc';
+          page_size: number;
+          cursor?: string;
+        };
+        const token = await getToken();
+        const response = await zendeskGet<TicketCommentsResponse>(
+          subdomain,
+          token,
+          `/tickets/${ticket_id}/comments`,
+          {
+            ...buildCursorParams(page_size, cursor),
+            // `sort_order` is offset-only on this endpoint; cursor pagination
+            // takes `sort` instead. The tool exposes the friendlier name and
+            // maps it here.
+            sort: sort_order === 'desc' ? '-created_at' : 'created_at',
+            include: 'users',
+            include_inline_images: 'true',
+          },
+        );
+        const { comments = [], meta: page, count } = response;
+        // Narrowed to the pagination fields: the full response cannot be passed
+        // as ZendeskListResponse<ZendeskComment>, whose `users?: T[]` would
+        // clash with the side-load (see TicketCommentsResponse).
+        const meta = extractPaginationMeta<ZendeskComment>(
+          { ...(page && { meta: page }), ...(count !== undefined && { count }) },
+          comments.length,
+        );
+        if (comments.length === 0) {
+          const text = meta.has_more
+            ? `No comments on this page of ticket #${ticket_id}. More available (cursor: ${meta.after_cursor}).`
+            : `No comments to show for ticket #${ticket_id}.`;
+          return { content: [{ type: 'text', text }] };
+        }
+        const authors = await resolveCommentAuthors(subdomain, token, comments, response.users);
+        // The page is rendered in the order Zendesk returned it: under "desc"
+        // that puts the newest comments first, so a page that still overflows
+        // loses its oldest end rather than its newest (#265).
+        const order = sort_order === 'desc' ? 'newest first' : 'oldest first';
+        const list = formatList(comments, (comment) => formatComment(comment, authors), meta);
+        return {
+          content: [
+            { type: 'text', text: `# Comments on ticket #${ticket_id} (${order})\n\n${list}` },
+          ],
+        };
+      },
+    },
+    {
       name: 'get_ticket_attachments',
       namespace: 'tickets',
       readOnly: true,
@@ -748,7 +890,7 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           .array(z.number().int())
           .optional()
           .describe(
-            'Attachment IDs to fetch directly (e.g. extracted from a previous get_ticket(include_comments=true) call). When provided, skips the comments fetch entirely. When omitted, all attachments of the ticket are returned.',
+            'Attachment IDs to fetch directly (e.g. extracted from a previous list_ticket_comments or get_ticket(include_comments=true) call). When provided, skips the comments fetch entirely. When omitted, all attachments of the ticket are returned.',
           ),
       }),
       annotations: {
@@ -1180,7 +1322,17 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           incidents.length > 0
             ? `# Incidents linked to problem #${problem_id}\n\n${incidents.map(formatTicket).join('\n\n')}`
             : `No incidents linked to problem #${problem_id}.`;
-        return { content: [{ type: 'text', text: truncateIfNeeded(text) }] };
+        return {
+          content: [
+            {
+              type: 'text',
+              text: truncateIfNeeded(
+                text,
+                `get_linked_incidents takes no pagination parameters: problem #${problem_id} has more linked incidents than fit in one response.`,
+              ),
+            },
+          ],
+        };
       },
     },
     {
@@ -1599,7 +1751,10 @@ export const createTicketTools = (ctx: ToolContext): ToolDefinition[] => {
           content: [
             {
               type: 'text',
-              text: truncateIfNeeded(formatMacroPreviewDiff(ticket_id, macro_id, before, result)),
+              text: truncateIfNeeded(
+                formatMacroPreviewDiff(ticket_id, macro_id, before, result),
+                'preview_macro_diff takes no pagination parameters: this macro rewrites more of the ticket than fits in one response. Read the macro on its own with list_macros to see every action it carries.',
+              ),
             },
           ],
         };

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -38,7 +38,10 @@ export const truncateIfNeeded = (
   return `${text.slice(0, CHARACTER_LIMIT)}\n\n--- Response truncated (${text.length} chars, limit ${CHARACTER_LIMIT}). ${advice} ---`;
 };
 
-const formatPagination = (meta: PaginationMeta): string => {
+// Exported so a caller that prefixes its own title can assemble header + body
+// itself and truncate the whole thing once, instead of truncating through
+// formatList and then prepending a title the character budget never saw.
+export const formatPagination = (meta: PaginationMeta): string => {
   const parts = [`Results: ${meta.count}`];
   if (meta.has_more) {
     parts.push(`More available (cursor: ${meta.after_cursor})`);

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -26,9 +26,16 @@ import type {
   ZendeskViewCount,
 } from '../types.js';
 
-export const truncateIfNeeded = (text: string): string => {
+// The advice closing the truncation notice is the caller's, because only the
+// call site knows what the caller can actually do about it: telling an agent to
+// paginate a tool that takes no pagination parameter sends it in circles (#265).
+// The default serves the paginated list renderers, which are the majority.
+export const truncateIfNeeded = (
+  text: string,
+  advice = 'Use pagination or filters to reduce results.',
+): string => {
   if (text.length <= CHARACTER_LIMIT) return text;
-  return `${text.slice(0, CHARACTER_LIMIT)}\n\n--- Response truncated (${text.length} chars, limit ${CHARACTER_LIMIT}). Use pagination or filters to reduce results. ---`;
+  return `${text.slice(0, CHARACTER_LIMIT)}\n\n--- Response truncated (${text.length} chars, limit ${CHARACTER_LIMIT}). ${advice} ---`;
 };
 
 const formatPagination = (meta: PaginationMeta): string => {
@@ -193,9 +200,22 @@ export const formatSlaBlock = (entry: ZendeskSlaSideloadEntry | undefined): stri
   return `\n\n${lines.join('\n')}`;
 };
 
-export const formatComment = (comment: ZendeskComment): string => {
+const withName = (id: unknown, names: Map<number, string>): string => {
+  const n = Number(id);
+  // Zendesk attributes automation/trigger-driven updates to the system actor
+  // (author_id -1), which has no user record to resolve — label it plainly.
+  if (n === -1) return 'System (-1)';
+  const name = names.get(n);
+  return name ? `${name} (${id})` : String(id);
+};
+
+// `authors` is the id -> name map the caller resolved (side-load or batched
+// look-up); an id it does not carry renders as the bare id rather than failing
+// the whole thread. The comment id is rendered because it is the only read path
+// that exposes it (#265).
+export const formatComment = (comment: ZendeskComment, authors?: Map<number, string>): string => {
   const lines = [
-    `### ${comment.public ? 'Public comment' : 'Internal note'} by ${comment.author_id}`,
+    `### ${comment.public ? 'Public comment' : 'Internal note'} (id ${comment.id}) by ${withName(comment.author_id, authors ?? new Map())}`,
     `*${comment.created_at}*`,
   ];
   if (comment.attachments?.length) {
@@ -256,15 +276,6 @@ export interface AuditNames {
   groups: Map<number, string>;
 }
 
-const withName = (id: unknown, names: Map<number, string>): string => {
-  const n = Number(id);
-  // Zendesk attributes automation/trigger-driven updates to the system actor
-  // (author_id -1), which has no user record to resolve — label it plainly.
-  if (n === -1) return 'System (-1)';
-  const name = names.get(n);
-  return name ? `${name} (${id})` : String(id);
-};
-
 // A Change/Create field value rendered for the timeline: user/group ids resolved
 // to "Name (id)", SLA-metric objects reduced to their minutes, everything else via
 // formatFieldValue. Returns '' for an empty/absent side.
@@ -322,7 +333,7 @@ const renderAuditEvent = (event: ZendeskAuditEvent, names: AuditNames): string |
       return renderChangeEvent(event, names);
     case 'Comment':
     case 'VoiceComment':
-      // Presence only — the body lives on get_ticket(include_comments), so the
+      // Presence only — the body lives on list_ticket_comments, so the
       // timeline attributes the reply without duplicating (or bloating with) it.
       return `- ${event.public === false ? 'Internal note' : 'Public comment'} added`;
     case 'CommentPrivacyChange':

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -481,5 +481,6 @@ export const formatList = <T>(
   const header = meta ? formatPagination(meta) : '';
   const body = items.map(formatter).join('\n\n');
   const text = [header, body].filter(Boolean).join('\n\n');
-  return advice === undefined ? truncateIfNeeded(text) : truncateIfNeeded(text, advice);
+  // `undefined` falls through to truncateIfNeeded's own default sentence.
+  return truncateIfNeeded(text, advice);
 };

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -469,13 +469,17 @@ export const formatUserSegment = (segment: ZendeskUserSegment): string =>
 export const formatAttachment = (attachment: ZendeskArticleAttachment): string =>
   `- **${attachment.file_name}** (${attachment.id}) — ${attachment.content_type} — ${attachment.size} bytes`;
 
+// `advice` overrides the truncation notice's closing sentence, for the callers
+// that render a list through this helper yet expose no pagination parameter of
+// their own (see truncateIfNeeded).
 export const formatList = <T>(
   items: T[],
   formatter: (item: T) => string,
   meta?: PaginationMeta,
+  advice?: string,
 ): string => {
   const header = meta ? formatPagination(meta) : '';
   const body = items.map(formatter).join('\n\n');
   const text = [header, body].filter(Boolean).join('\n\n');
-  return truncateIfNeeded(text);
+  return advice === undefined ? truncateIfNeeded(text) : truncateIfNeeded(text, advice);
 };

--- a/tests/functional/scenarios/04-all-baseline/expected.md
+++ b/tests/functional/scenarios/04-all-baseline/expected.md
@@ -4,7 +4,7 @@
 
 ## Expected values
 
-- **A1.** `tools.length === 44`. Breakdown: 16 ticket tools + 22 Help Center
+- **A1.** `tools.length === 53`. Breakdown: 18 ticket tools + 29 Help Center
   tools + 5 user/organization tools + 1 unified search tool. If the count
   drifts, update the documentation listed in `AGENTS.md` "Documentation
   maintenance" before running.

--- a/tests/integration/core-scenarios.ts
+++ b/tests/integration/core-scenarios.ts
@@ -320,6 +320,21 @@ export const registerCoreScenarios = (harness: IntegrationHarness): void => {
         expect(textOf(result)).toContain('**status**: new → open');
       });
 
+      it("reads a ticket's comment thread newest-first over the wire", async () => {
+        connected = await harness.connect(makeConfig({ mode: 'all' }));
+        const result = await connected.client.callTool({
+          name: 'list_ticket_comments',
+          arguments: { ticket_id: 1 },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const text = textOf(result);
+        expect(text).toContain('# Comments on ticket #1 (newest first)');
+        // Defaults applied end-to-end: newest first, author resolved to a name.
+        expect(text).toContain('### Internal note (id 3001) by User 9998 (9998)');
+        expect(text.indexOf('id 3001')).toBeLessThan(text.indexOf('id 3000'));
+      });
+
       it('uploads and attaches a file when posting a public comment', async () => {
         connected = await harness.connect(makeConfig({ mode: 'all' }));
         const result = await connected.client.callTool({

--- a/tests/msw-handlers.ts
+++ b/tests/msw-handlers.ts
@@ -433,6 +433,17 @@ export const MOCK_COMMENT = {
   ],
 };
 
+// A second, later comment by a different author: lets list_ticket_comments
+// assert both the rendered order (newest first by default) and the resolution
+// of more than one author id.
+export const MOCK_COMMENT_NOTE = {
+  id: 3001,
+  body: 'Internal analysis',
+  author_id: 9998,
+  public: false,
+  created_at: '2026-01-02T00:00:00Z',
+};
+
 // Uploads API response (POST /uploads). The token is what gets carried on a
 // comment via comment.uploads; subsequent files aggregate under it via ?token=.
 // A group, minimal shape used to resolve a group_id change to a name.
@@ -509,6 +520,30 @@ export const auditsMorePageHandler = http.get(`${BASE}/tickets/:id/audits`, () =
   HttpResponse.json({
     audits: [MOCK_AUDIT_CHANGE],
     meta: { has_more: true, after_cursor: 'next-audit-cursor' },
+  }),
+);
+
+// Opt-in via mswServer.use(): a comments page that reports more to come, so the
+// cursor/"More available" footer of list_ticket_comments can be asserted.
+export const commentsMorePageHandler = http.get(`${BASE}/tickets/:id/comments`, () =>
+  HttpResponse.json({
+    comments: [MOCK_COMMENT_NOTE],
+    meta: { has_more: true, after_cursor: 'next-comment-cursor' },
+  }),
+);
+
+// Opt-in via mswServer.use(): the same page carrying the `include=users`
+// side-load, so the "no extra show_many call" path can be asserted. The names
+// differ from the `User <id>` the show_many mock echoes, which is what makes the
+// two paths distinguishable in an assertion.
+export const commentsWithUsersSideloadHandler = http.get(`${BASE}/tickets/:id/comments`, () =>
+  HttpResponse.json({
+    comments: [MOCK_COMMENT_NOTE, MOCK_COMMENT],
+    users: [
+      { ...MOCK_USER, id: 9999, name: 'Sideloaded Agent' },
+      { ...MOCK_USER, id: 9998, name: 'Sideloaded Author' },
+    ],
+    meta: { has_more: false, after_cursor: '' },
   }),
 );
 
@@ -639,7 +674,19 @@ export const handlers = [
     // `include=slas` there, see #92), so no `slas` is ever returned here.
     return HttpResponse.json({ ticket: { ...MOCK_TICKET, id } });
   }),
-  http.get(`${BASE}/tickets/:id/comments`, () => HttpResponse.json({ comments: [MOCK_COMMENT] })),
+  // Single-page by default: fetchAllTicketComments (get_ticket_attachments)
+  // walks this endpoint in a loop, so `has_more: true` here would change how
+  // many pages those tests fetch. Cursor paging is opted into per test via
+  // commentsMorePageHandler. No `users` side-load either, so the default path
+  // exercises the batched show_many fallback.
+  http.get(`${BASE}/tickets/:id/comments`, ({ request }) => {
+    const sort = new URL(request.url).searchParams.get('sort');
+    const comments =
+      sort === '-created_at'
+        ? [MOCK_COMMENT_NOTE, MOCK_COMMENT]
+        : [MOCK_COMMENT, MOCK_COMMENT_NOTE];
+    return HttpResponse.json({ comments, meta: { has_more: false, after_cursor: '' } });
+  }),
   http.get(`${BASE}/tickets/:id/audits`, ({ params }) => {
     if (params['id'] === '404') return HttpResponse.json({}, { status: 404 });
     return HttpResponse.json({

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -34,7 +34,12 @@ describe('CHARACTER_LIMIT (positiveIntEnv)', () => {
 
   const load = async () => (await import('../../src/constants')).CHARACTER_LIMIT;
 
-  it('defaults to 25000 when unset', async () => {
+  it('defaults to 25000 when unset or empty', async () => {
+    // Stubbed rather than left to the ambient environment: positiveIntEnv reads
+    // the variable at import time, so a value set in the test process would
+    // decide this assertion. Empty is also the case the shell produces with
+    // `ZENDESK_CHARACTER_LIMIT="$UNSET"`, and it must fall back too.
+    vi.stubEnv('ZENDESK_CHARACTER_LIMIT', '');
     expect(await load()).toBe(25_000);
   });
 

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -23,6 +23,37 @@ describe('getOAuthUrls', () => {
   });
 });
 
+describe('CHARACTER_LIMIT (positiveIntEnv)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const load = async () => (await import('../../src/constants')).CHARACTER_LIMIT;
+
+  it('defaults to 25000 when unset', async () => {
+    expect(await load()).toBe(25_000);
+  });
+
+  it('honors a lower override, which is what makes truncation testable', async () => {
+    vi.stubEnv('ZENDESK_CHARACTER_LIMIT', '500');
+    expect(await load()).toBe(500);
+  });
+
+  it('falls back to the default on a non-positive value', async () => {
+    vi.stubEnv('ZENDESK_CHARACTER_LIMIT', '0');
+    expect(await load()).toBe(25_000);
+  });
+
+  it('falls back to the default on a fractional value', async () => {
+    vi.stubEnv('ZENDESK_CHARACTER_LIMIT', '1.5');
+    expect(await load()).toBe(25_000);
+  });
+});
+
 describe('REORDER_CONFIRM_THRESHOLD (positiveIntEnv)', () => {
   beforeEach(() => {
     vi.resetModules();

--- a/tests/unit/guidance/article-resources.test.ts
+++ b/tests/unit/guidance/article-resources.test.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http } from 'msw';
 import { describe, expect, it, vi } from 'vitest';
 import { ZendeskApiError } from '../../../src/client/zendesk-api';
+import { CHARACTER_LIMIT } from '../../../src/constants';
 import {
   createArticleResourcesProvider,
   fetchArticleMarkdown,
@@ -50,6 +51,20 @@ describe('fetchPromotedArticles', () => {
 });
 
 describe('fetchArticleMarkdown', () => {
+  it('points at the section tools rather than a pagination parameter when truncated', async () => {
+    mswServer.use(
+      http.get(`${HC}/articles/:id`, () =>
+        HttpResponse.json({
+          article: { ...MOCK_PROMOTED_ARTICLE, body: `<p>${'x'.repeat(CHARACTER_LIMIT)}</p>` },
+        }),
+      ),
+    );
+    const text = await fetchArticleMarkdown(SUBDOMAIN, TOKEN, 5000);
+    expect(text).toContain('Response truncated');
+    expect(text).toContain('get_article_section');
+    expect(text).not.toContain('Use pagination or filters');
+  });
+
   it('renders the article as Markdown (body converted from HTML, not a raw dump)', async () => {
     const text = await fetchArticleMarkdown(SUBDOMAIN, TOKEN, 5000);
     expect(text).toContain('## How to test (5000)');

--- a/tests/unit/guidance/topology.test.ts
+++ b/tests/unit/guidance/topology.test.ts
@@ -144,6 +144,25 @@ describe('formatTopology', () => {
     expect(text).toContain('admin');
   });
 
+  it('points at the listing tools rather than a pagination parameter when truncated', () => {
+    // The resource takes no parameters at all, so the default "use pagination"
+    // notice would be advice the caller cannot act on (#265).
+    const data = baseData();
+    const first = data.categories[0];
+    if (!first) throw new Error('baseData must seed a category');
+    const text = formatTopology({
+      ...data,
+      categories: Array.from({ length: 400 }, (_, i) => ({
+        ...first,
+        id: 800 + i,
+        name: `Category ${'x'.repeat(100)} ${i}`,
+      })),
+    });
+    expect(text).toContain('Response truncated');
+    expect(text).toContain('list_categories and list_sections');
+    expect(text).not.toContain('Use pagination or filters');
+  });
+
   it('switches to summary mode (no partial tree) when sections are truncated', () => {
     const text = formatTopology({ ...baseData(), sections: [], sectionsHasMore: true });
     expect(text).toContain('list_sections');

--- a/tests/unit/routing/registry.test.ts
+++ b/tests/unit/routing/registry.test.ts
@@ -64,7 +64,7 @@ describe('groupByNamespace', () => {
     const ticketCount = grouped.get('tickets')?.length ?? 0;
     const hcCount = grouped.get('help_center')?.length ?? 0;
     const userCount = grouped.get('users')?.length ?? 0;
-    expect(ticketCount).toBe(18); // 17 ticket tools + 1 search
+    expect(ticketCount).toBe(19); // 18 ticket tools + 1 search
     expect(hcCount).toBe(29);
     expect(userCount).toBe(5);
   });

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -265,6 +265,26 @@ describe('help center tools', () => {
       const result = await tool.handler({ article_id: 5000 });
       expect(result.content[0]?.text).not.toContain('Guide de test');
     });
+
+    it('says the listing cannot be narrowed rather than advising pagination', async () => {
+      // The schema is {article_id} alone — there is nothing to paginate (#265).
+      mswServer.use(
+        http.get(`${HC_BASE}/articles/:id/translations`, () =>
+          HttpResponse.json({
+            translations: Array.from({ length: 300 }, (_, i) => ({
+              ...MOCK_TRANSLATION,
+              id: 9000 + i,
+              title: 'x'.repeat(100),
+            })),
+            count: 300,
+          }),
+        ),
+      );
+      const tool = findTool('list_article_translations');
+      const text = (await tool.handler({ article_id: 5000 })).content[0]?.text ?? '';
+      expect(text).toContain('list_article_translations takes only article_id');
+      expect(text).not.toContain('Use pagination or filters');
+    });
   });
 
   describe('create_article_translation', () => {
@@ -522,6 +542,32 @@ describe('help center tools', () => {
   });
 
   describe('find_translation_gaps', () => {
+    it('does not advise category_id back at a caller who already passed it', async () => {
+      const many = Array.from({ length: 300 }, (_, i) => ({
+        ...MOCK_SECTION,
+        id: 9000 + i,
+        name: `Section ${'x'.repeat(100)} ${i}`,
+        translations: [],
+      }));
+      mswServer.use(
+        http.get(`${HC_BASE}/categories/:id/sections`, () =>
+          HttpResponse.json({
+            sections: many,
+            meta: { has_more: false, after_cursor: '' },
+            count: many.length,
+          }),
+        ),
+      );
+      const tool = findTool('find_translation_gaps');
+      const text = (
+        (await tool.handler({ locale: 'fr', category_id: 800 })).content[0] as { text: string }
+      ).text;
+      expect(text).toContain('Response truncated');
+      expect(text).toContain('already scoped to one category');
+      expect(text).not.toContain('narrow the audit to one branch');
+      expect(text).not.toContain('Use pagination or filters');
+    });
+
     it('points at category_id rather than a pagination parameter when truncating', async () => {
       // Every listed section is a gap (its sideloaded translations are empty),
       // and long names push the report past the response character limit.

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -1,5 +1,6 @@
 import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
+import { CHARACTER_LIMIT } from '../../../src/constants';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createHelpCenterTools } from '../../../src/tools/help-center';
 import {
@@ -104,6 +105,22 @@ describe('help center tools', () => {
   });
 
   describe('get_article', () => {
+    it('routes a truncated article to the section tools instead of advising pagination', async () => {
+      mswServer.use(
+        http.get(`${HC_BASE}/articles/:id`, () =>
+          HttpResponse.json({
+            article: { ...MOCK_ARTICLE, body: `<p>${'x'.repeat(CHARACTER_LIMIT)}</p>` },
+          }),
+        ),
+      );
+      const tool = findTool('get_article');
+      const text = tool
+        .handler({ article_id: 5000 })
+        .then((r) => (r.content[0] as { text: string }).text);
+      await expect(text).resolves.toContain('get_article_section');
+      await expect(text).resolves.not.toContain('Use pagination or filters');
+    });
+
     it('returns article with translations list', async () => {
       const tool = findTool('get_article');
       const result = await tool.handler({ article_id: 5000 });
@@ -505,6 +522,31 @@ describe('help center tools', () => {
   });
 
   describe('find_translation_gaps', () => {
+    it('points at category_id rather than a pagination parameter when truncating', async () => {
+      // Every listed section is a gap (its sideloaded translations are empty),
+      // and long names push the report past the response character limit.
+      const many = Array.from({ length: 300 }, (_, i) => ({
+        ...MOCK_SECTION,
+        id: 9000 + i,
+        name: `Section ${'x'.repeat(100)} ${i}`,
+        translations: [],
+      }));
+      mswServer.use(
+        http.get(`${HC_BASE}/sections`, () =>
+          HttpResponse.json({
+            sections: many,
+            meta: { has_more: false, after_cursor: '' },
+            count: many.length,
+          }),
+        ),
+      );
+      const tool = findTool('find_translation_gaps');
+      const text = ((await tool.handler({ locale: 'fr' })).content[0] as { text: string }).text;
+      expect(text).toContain('Response truncated');
+      expect(text).toContain('category_id');
+      expect(text).not.toContain('Use pagination or filters');
+    });
+
     // The default fixtures give category 800 a published `fr` translation and
     // section 600 a draft one, i.e. one gap of each interesting kind once the
     // listing is widened.
@@ -1343,6 +1385,49 @@ describe('help center tools', () => {
   });
 
   describe('get_article_section', () => {
+    // A single section has nothing narrower to page to, so the notice offers the
+    // one lever that exists — the more compact Markdown rendering — and never
+    // advises a parameter the tool does not accept (#265).
+    const hugeArticle = () =>
+      mswServer.use(
+        http.get(`${HC_BASE}/articles/:id/translations/:locale`, () =>
+          HttpResponse.json({
+            translation: {
+              ...MOCK_TRANSLATION,
+              body: `<h2>Setup</h2><p>${'x'.repeat(CHARACTER_LIMIT)}</p>`,
+            },
+          }),
+        ),
+      );
+
+    it('offers the markdown rendering when a truncated section was asked for as html', async () => {
+      hugeArticle();
+      const tool = findTool('get_article_section');
+      const result = await tool.handler({
+        article_id: 5000,
+        locale: 'en-us',
+        section_index: 0,
+        format: 'html',
+      });
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('format="markdown"');
+      expect(text).not.toContain('Use pagination or filters');
+    });
+
+    it('states plainly that nothing narrower exists when markdown still overflows', async () => {
+      hugeArticle();
+      const tool = findTool('get_article_section');
+      const result = await tool.handler({
+        article_id: 5000,
+        locale: 'en-us',
+        section_index: 0,
+        format: 'markdown',
+      });
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('this single section already exceeds the limit');
+      expect(text).not.toContain('Use pagination or filters');
+    });
+
     it('returns a single section as markdown', async () => {
       const tool = findTool('get_article_section');
       const result = await tool.handler({

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -1302,6 +1302,26 @@ describe('help center tools', () => {
       const result = await tool.handler({});
       expect(result.content[0]?.text).toContain('getting-started');
     });
+
+    it('states it takes no parameters rather than advising pagination when truncating', async () => {
+      // A tool whose inputSchema is z.object({}) cannot be narrowed at all, so
+      // the generic "use pagination or filters" notice is unactionable (#265).
+      mswServer.use(
+        http.get(`${HC_BASE}/articles/labels`, () =>
+          HttpResponse.json({
+            labels: Array.from({ length: 400 }, (_, i) => ({
+              id: 7000 + i,
+              name: 'x'.repeat(100),
+            })),
+            count: 400,
+          }),
+        ),
+      );
+      const tool = findTool('list_labels');
+      const text = (await tool.handler({})).content[0]?.text ?? '';
+      expect(text).toContain('list_labels takes no parameters');
+      expect(text).not.toContain('Use pagination or filters');
+    });
   });
 
   describe('list_user_segments', () => {

--- a/tests/unit/tools/help-center.test.ts
+++ b/tests/unit/tools/help-center.test.ts
@@ -542,6 +542,35 @@ describe('help center tools', () => {
   });
 
   describe('find_translation_gaps', () => {
+    it('does not call a scoped audit complete while its section listing spills over', async () => {
+      // Scoped *and* incomplete: the handler fetches only the first page, so
+      // "fix these and re-run" would hide the sections it never looked at.
+      const many = Array.from({ length: 300 }, (_, i) => ({
+        ...MOCK_SECTION,
+        id: 9000 + i,
+        name: `Section ${'x'.repeat(100)} ${i}`,
+        translations: [],
+      }));
+      mswServer.use(
+        http.get(`${HC_BASE}/categories/:id/sections`, () =>
+          HttpResponse.json({
+            sections: many,
+            meta: { has_more: true, after_cursor: 'next-section-cursor' },
+            count: many.length,
+          }),
+        ),
+      );
+      const tool = findTool('find_translation_gaps');
+      const text = (
+        (await tool.handler({ locale: 'fr', category_id: 800 })).content[0] as { text: string }
+      ).text;
+      expect(text).toContain('Response truncated');
+      expect(text).toContain('section listing is incomplete');
+      expect(text).toContain('list_sections');
+      expect(text).not.toContain('then re-run it');
+      expect(text).not.toContain('Use pagination or filters');
+    });
+
     it('does not advise category_id back at a caller who already passed it', async () => {
       const many = Array.from({ length: 300 }, (_, i) => ({
         ...MOCK_SECTION,

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -101,6 +101,21 @@ describe('ticket tools', () => {
       expect(inlineParam).toBe('true');
     });
 
+    it('side-loads users instead of paying an extra look-up round trip', async () => {
+      let showManyCalls = 0;
+      mswServer.use(
+        commentsWithUsersSideloadHandler,
+        http.get('https://testsubdomain.zendesk.com/api/v2/users/show_many', () => {
+          showManyCalls += 1;
+          return HttpResponse.json({ users: [] });
+        }),
+      );
+      const tool = findTool('get_ticket');
+      const text = getAllText(await tool.handler({ ticket_id: 1, include_comments: true }));
+      expect(text).toContain('Sideloaded Agent (9999)');
+      expect(showManyCalls).toBe(0);
+    });
+
     it('resolves comment authors to names rather than raw ids', async () => {
       const tool = findTool('get_ticket');
       const text = getAllText(await tool.handler({ ticket_id: 1, include_comments: true }));
@@ -424,6 +439,73 @@ describe('ticket tools', () => {
         await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
       );
       expect(text).toContain('next-comment-cursor');
+    });
+
+    it('keeps the title inside the character budget and names the only recovery', async () => {
+      // The title must be truncated *with* the body: prepending it afterwards
+      // overshoots the limit and makes the notice misreport its own size.
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({
+            comments: [
+              { ...MOCK_COMMENT, body: 'x'.repeat(CHARACTER_LIMIT) },
+              { ...MOCK_COMMENT, id: 3001, created_at: '2025-12-01T00:00:00Z', body: 'older' },
+            ],
+            meta: { has_more: true, after_cursor: 'next-comment-cursor' },
+          }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(text.startsWith('# Comments on ticket #1')).toBe(true);
+      // The notice sits exactly at the limit: everything before it, title
+      // included, is what the budget paid for.
+      expect(text.indexOf('\n\n--- Response truncated')).toBe(CHARACTER_LIMIT);
+      // The cursor points past the whole page, so it cannot recover what the
+      // cut dropped — only a smaller page can.
+      expect(text).toContain('re-issue with a page_size smaller than 20');
+      expect(text).not.toContain('Use pagination or filters');
+    });
+
+    it('reports a further page even when Zendesk answers with next_page', async () => {
+      // If the endpoint fell back to offset pagination there is no `meta`, and
+      // dropping next_page would report a truncated thread as complete.
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({
+            comments: [MOCK_COMMENT],
+            next_page: 'https://testsubdomain.zendesk.com/api/v2/tickets/1/comments.json?page=2',
+          }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(text).toContain('More available');
+    });
+
+    it('falls back to the requested order when every comment shares a timestamp', async () => {
+      // Zendesk timestamps are second-resolution, so a burst of comments can tie.
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({
+            comments: [MOCK_COMMENT, { ...MOCK_COMMENT, id: 3001 }],
+            meta: { has_more: false, after_cursor: '' },
+          }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const asc = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'asc', page_size: 20 }),
+      );
+      const desc = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(asc).toContain('(oldest first)');
+      expect(desc).toContain('(newest first)');
     });
 
     it('has readOnly annotation', () => {

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -136,7 +136,7 @@ describe('ticket tools', () => {
       const tool = findTool('get_ticket');
       const text = getAllText(await tool.handler({ ticket_id: 1, include_comments: false }));
       expect(text).toContain('Response truncated');
-      expect(text).toContain('takes no pagination');
+      expect(text).toContain('takes no pagination or filter parameters');
       expect(text).not.toContain('Use pagination or filters');
     });
 
@@ -295,6 +295,47 @@ describe('ticket tools', () => {
       );
       expect(text).toContain('# Comments on ticket #1 (oldest first)');
       expect(text.indexOf('id 3000')).toBeLessThan(text.indexOf('id 3001'));
+    });
+
+    it('labels the page from the returned data, not from what was asked for', async () => {
+      // If Zendesk ever ignored `sort`, a request for "desc" would come back
+      // oldest-first — the header must not claim otherwise.
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({
+            comments: [
+              MOCK_COMMENT,
+              { ...MOCK_COMMENT, id: 3001, created_at: '2026-02-01T00:00:00Z' },
+            ],
+            meta: { has_more: false, after_cursor: '' },
+          }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(text).toContain('# Comments on ticket #1 (oldest first)');
+    });
+
+    it('falls back to the requested order when a page holds a single comment', async () => {
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({
+            comments: [MOCK_COMMENT],
+            meta: { has_more: false, after_cursor: '' },
+          }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const desc = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      const asc = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'asc', page_size: 20 }),
+      );
+      expect(desc).toContain('(newest first)');
+      expect(asc).toContain('(oldest first)');
     });
 
     it('surfaces the pagination cursor when more comments remain', async () => {
@@ -1115,7 +1156,7 @@ describe('ticket tools', () => {
       );
       const tool = findTool('get_linked_incidents');
       const text = getAllText(await tool.handler({ problem_id: 1 }));
-      expect(text).toContain('takes no pagination parameters');
+      expect(text).toContain('takes no pagination or filter parameters');
       expect(text).not.toContain('Use pagination or filters');
     });
   });
@@ -1373,7 +1414,7 @@ describe('ticket tools', () => {
       );
       const tool = findTool('preview_macro_diff');
       const text = getAllText(await tool.handler({ ticket_id: 1, macro_id: 700 }));
-      expect(text).toContain('takes no pagination parameters');
+      expect(text).toContain('takes no pagination or filter parameters');
       expect(text).not.toContain('Use pagination or filters');
     });
 

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -1,9 +1,13 @@
 import { HttpResponse, http } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CHARACTER_LIMIT } from '../../../src/constants';
 import type { ToolContext } from '../../../src/tools/definitions';
 import { createTicketTools } from '../../../src/tools/tickets';
 import {
   auditsMorePageHandler,
+  commentsMorePageHandler,
+  commentsWithUsersSideloadHandler,
+  MOCK_COMMENT,
   MOCK_SLA_SIDELOAD,
   MOCK_TICKET,
   MOCK_UPLOAD,
@@ -27,9 +31,9 @@ const getAllText = (result: { content: Array<{ type: string; text?: string }> })
     .join('\n');
 
 describe('ticket tools', () => {
-  it('creates 17 tools (search_tickets lives here; the unified search is elsewhere)', () => {
+  it('creates 18 tools (search_tickets lives here; the unified search is elsewhere)', () => {
     const tools = createTicketTools(ctx);
-    expect(tools).toHaveLength(17);
+    expect(tools).toHaveLength(18);
   });
 
   describe('get_ticket', () => {
@@ -95,6 +99,45 @@ describe('ticket tools', () => {
       const tool = findTool('get_ticket');
       await tool.handler({ ticket_id: 1, include_comments: true });
       expect(inlineParam).toBe('true');
+    });
+
+    it('resolves comment authors to names rather than raw ids', async () => {
+      const tool = findTool('get_ticket');
+      const text = getAllText(await tool.handler({ ticket_id: 1, include_comments: true }));
+      expect(text).toContain('### Public comment (id 3000) by User 9999 (9999)');
+    });
+
+    it('routes a truncated thread to list_ticket_comments instead of advising pagination', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments', () =>
+          HttpResponse.json({
+            comments: [{ ...MOCK_COMMENT, body: 'x'.repeat(CHARACTER_LIMIT) }],
+          }),
+        ),
+      );
+      const tool = findTool('get_ticket');
+      const text = getAllText(await tool.handler({ ticket_id: 1, include_comments: true }));
+      expect(text).toContain('Response truncated');
+      expect(text).toContain('list_ticket_comments');
+      expect(text).toContain('sort_order');
+      // get_ticket accepts neither a page nor a filter — advising them sends
+      // the caller in circles (#265).
+      expect(text).not.toContain('Use pagination or filters');
+    });
+
+    it('does not advise pagination when the ticket alone overflows', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id', () =>
+          HttpResponse.json({
+            ticket: { ...MOCK_TICKET, id: 1, description: 'x'.repeat(CHARACTER_LIMIT) },
+          }),
+        ),
+      );
+      const tool = findTool('get_ticket');
+      const text = getAllText(await tool.handler({ ticket_id: 1, include_comments: false }));
+      expect(text).toContain('Response truncated');
+      expect(text).toContain('takes no pagination');
+      expect(text).not.toContain('Use pagination or filters');
     });
 
     it('has readOnly annotation', () => {
@@ -182,6 +225,168 @@ describe('ticket tools', () => {
 
     it('has readOnly annotation', () => {
       const tool = findTool('get_ticket_history');
+      expect(tool.annotations.readOnlyHint).toBe(true);
+    });
+  });
+
+  describe('list_ticket_comments', () => {
+    const COMMENTS_URL = 'https://testsubdomain.zendesk.com/api/v2/tickets/:id/comments';
+
+    // Capture the query the tool actually sends: the sort/cursor mapping is the
+    // whole point of the tool, and it is invisible in the rendered output.
+    const captureQuery = (): URLSearchParams[] => {
+      const seen: URLSearchParams[] = [];
+      mswServer.use(
+        http.get(COMMENTS_URL, ({ request }) => {
+          seen.push(new URL(request.url).searchParams);
+          return HttpResponse.json({ comments: [], meta: { has_more: false, after_cursor: '' } });
+        }),
+      );
+      return seen;
+    };
+
+    it('asks Zendesk for the newest comments first by default', async () => {
+      const seen = captureQuery();
+      const tool = findTool('list_ticket_comments');
+      await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 });
+      const query = seen[0];
+      // sort_order is offset-only on this endpoint; with cursor paging Zendesk
+      // takes `sort=-created_at`. That mapping is what this asserts.
+      expect(query?.get('sort')).toBe('-created_at');
+      expect(query?.get('page[size]')).toBe('20');
+      expect(query?.get('include')).toBe('users');
+      expect(query?.get('include_inline_images')).toBe('true');
+      expect(query?.has('page[after]')).toBe(false);
+    });
+
+    it('maps sort_order "asc" to the oldest-first sort', async () => {
+      const seen = captureQuery();
+      const tool = findTool('list_ticket_comments');
+      await tool.handler({ ticket_id: 1, sort_order: 'asc', page_size: 20 });
+      expect(seen[0]?.get('sort')).toBe('created_at');
+    });
+
+    it('passes the cursor through as page[after]', async () => {
+      const seen = captureQuery();
+      const tool = findTool('list_ticket_comments');
+      await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 5, cursor: 'cur-42' });
+      expect(seen[0]?.get('page[after]')).toBe('cur-42');
+      expect(seen[0]?.get('page[size]')).toBe('5');
+    });
+
+    it('renders bodies newest first, with comment ids and resolved authors', async () => {
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(text).toContain('# Comments on ticket #1 (newest first)');
+      expect(text).toContain('### Internal note (id 3001) by User 9998 (9998)');
+      expect(text).toContain('### Public comment (id 3000) by User 9999 (9999)');
+      expect(text).toContain('Internal analysis');
+      expect(text).toContain('This is a comment');
+      // The API's order is preserved: truncation must cut the oldest end.
+      expect(text.indexOf('id 3001')).toBeLessThan(text.indexOf('id 3000'));
+    });
+
+    it('labels an oldest-first page as such', async () => {
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'asc', page_size: 20 }),
+      );
+      expect(text).toContain('# Comments on ticket #1 (oldest first)');
+      expect(text.indexOf('id 3000')).toBeLessThan(text.indexOf('id 3001'));
+    });
+
+    it('surfaces the pagination cursor when more comments remain', async () => {
+      mswServer.use(commentsMorePageHandler);
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 1 }),
+      );
+      expect(text).toContain('More available');
+      expect(text).toContain('next-comment-cursor');
+    });
+
+    it('uses the users side-load and skips the extra look-up when it carries the authors', async () => {
+      let showManyCalls = 0;
+      mswServer.use(
+        commentsWithUsersSideloadHandler,
+        http.get('https://testsubdomain.zendesk.com/api/v2/users/show_many', () => {
+          showManyCalls += 1;
+          return HttpResponse.json({ users: [] });
+        }),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(text).toContain('Sideloaded Author (9998)');
+      expect(text).toContain('Sideloaded Agent (9999)');
+      expect(showManyCalls).toBe(0);
+    });
+
+    it('falls back to one batched look-up for authors the side-load omits', async () => {
+      let showManyCalls = 0;
+      let requestedIds: string | null = null;
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/users/show_many', ({ request }) => {
+          showManyCalls += 1;
+          requestedIds = new URL(request.url).searchParams.get('ids');
+          return HttpResponse.json({ users: [{ id: 9998, name: 'Looked Up' }] });
+        }),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(showManyCalls).toBe(1);
+      expect(requestedIds).toBe('9998,9999');
+      expect(text).toContain('Looked Up (9998)');
+    });
+
+    it('still renders when name resolution fails, falling back to bare ids', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/users/show_many', () =>
+          HttpResponse.json({}, { status: 500 }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const result = await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 });
+      expect(result.isError).toBeFalsy();
+      expect(getAllText(result)).toContain('### Internal note (id 3001) by 9998');
+    });
+
+    it('returns a clear message when the ticket has no comments', async () => {
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({ comments: [], meta: { has_more: false, after_cursor: '' } }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(text).toContain('No comments to show for ticket #1');
+    });
+
+    it('mentions the cursor when an empty page is not the last one', async () => {
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({
+            comments: [],
+            meta: { has_more: true, after_cursor: 'next-comment-cursor' },
+          }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(text).toContain('next-comment-cursor');
+    });
+
+    it('has readOnly annotation', () => {
+      const tool = findTool('list_ticket_comments');
       expect(tool.annotations.readOnlyHint).toBe(true);
     });
   });
@@ -899,6 +1104,20 @@ describe('ticket tools', () => {
       const result = await tool.handler({ problem_id: 1 });
       expect(result.content[0]?.text).toContain('Incidents linked to problem #1');
     });
+
+    it('does not advise pagination it cannot accept when truncating', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/incidents', () =>
+          HttpResponse.json({
+            tickets: [{ ...MOCK_TICKET, description: 'x'.repeat(CHARACTER_LIMIT) }],
+          }),
+        ),
+      );
+      const tool = findTool('get_linked_incidents');
+      const text = getAllText(await tool.handler({ problem_id: 1 }));
+      expect(text).toContain('takes no pagination parameters');
+      expect(text).not.toContain('Use pagination or filters');
+    });
   });
 
   describe('manage_tags', () => {
@@ -1141,6 +1360,23 @@ describe('ticket tools', () => {
   });
 
   describe('preview_macro_diff', () => {
+    it('does not advise pagination it cannot accept when truncating', async () => {
+      mswServer.use(
+        http.get('https://testsubdomain.zendesk.com/api/v2/tickets/:id/macros/:mid/apply', () =>
+          HttpResponse.json({
+            result: {
+              ticket: { ...MOCK_TICKET, subject: 'x'.repeat(CHARACTER_LIMIT) },
+              comment: { body: 'A reply', public: true },
+            },
+          }),
+        ),
+      );
+      const tool = findTool('preview_macro_diff');
+      const text = getAllText(await tool.handler({ ticket_id: 1, macro_id: 700 }));
+      expect(text).toContain('takes no pagination parameters');
+      expect(text).not.toContain('Use pagination or filters');
+    });
+
     it('diffs the ticket before/after the macro, showing only what changes', async () => {
       const tool = findTool('preview_macro_diff');
       const result = await tool.handler({ ticket_id: 1, macro_id: 700 });

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -506,9 +506,31 @@ describe('ticket tools', () => {
         await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
       );
       expect(text).toContain('paginated this response by offset');
-      expect(text).toContain('larger page_size (up to 100, currently 20)');
+      expect(text).toContain('read the remaining comments in Zendesk directly');
+      // page_size goes out as page[size], which an offset response has already
+      // ignored, and get_ticket sends no paging at all — naming either would be
+      // advice that cannot work (#265).
+      expect(text).not.toContain('page_size');
+      expect(text).not.toContain('get_ticket(include_comments=true)');
       expect(text).not.toContain('cursor: null');
       expect(text).not.toContain('More available');
+    });
+
+    it('says the same at page_size 100, where no larger page exists either', async () => {
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({
+            comments: [MOCK_COMMENT],
+            next_page: 'https://testsubdomain.zendesk.com/api/v2/tickets/1/comments.json?page=2',
+          }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 100 }),
+      );
+      expect(text).toContain('read the remaining comments in Zendesk directly');
+      expect(text).not.toContain('page_size');
     });
 
     it('reports the same on an empty offset-paginated page', async () => {

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -469,9 +469,9 @@ describe('ticket tools', () => {
       expect(text).not.toContain('Use pagination or filters');
     });
 
-    it('reports a further page even when Zendesk answers with next_page', async () => {
-      // If the endpoint fell back to offset pagination there is no `meta`, and
-      // dropping next_page would report a truncated thread as complete.
+    it('reports an offset-paginated answer in words, never as a cursor', async () => {
+      // Silence would report a truncated thread as complete; a `More available
+      // (cursor: null)` footer would offer a continuation the tool cannot take.
       mswServer.use(
         http.get(COMMENTS_URL, () =>
           HttpResponse.json({
@@ -484,7 +484,36 @@ describe('ticket tools', () => {
       const text = getAllText(
         await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
       );
-      expect(text).toContain('More available');
+      expect(text).toContain('paginated this response by offset');
+      expect(text).toContain('larger page_size (up to 100, currently 20)');
+      expect(text).not.toContain('cursor: null');
+      expect(text).not.toContain('More available');
+    });
+
+    it('reports the same on an empty offset-paginated page', async () => {
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({
+            comments: [],
+            next_page: 'https://testsubdomain.zendesk.com/api/v2/tickets/1/comments.json?page=2',
+          }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(text).toContain('No comments to show for ticket #1');
+      expect(text).toContain('paginated this response by offset');
+      expect(text).not.toContain('cursor: null');
+    });
+
+    it('says nothing about offset pagination on a normal cursor page', async () => {
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 20 }),
+      );
+      expect(text).not.toContain('paginated this response by offset');
     });
 
     it('falls back to the requested order when every comment shares a timestamp', async () => {

--- a/tests/unit/tools/tickets.test.ts
+++ b/tests/unit/tools/tickets.test.ts
@@ -469,6 +469,27 @@ describe('ticket tools', () => {
       expect(text).not.toContain('Use pagination or filters');
     });
 
+    it('names a reachable recovery when a single comment already fills the page', async () => {
+      // page_size has a minimum of 1, so "smaller than 1" would recommend a
+      // value the schema rejects — the very failure #265 is about.
+      mswServer.use(
+        http.get(COMMENTS_URL, () =>
+          HttpResponse.json({
+            comments: [{ ...MOCK_COMMENT, body: 'x'.repeat(CHARACTER_LIMIT) }],
+            meta: { has_more: true, after_cursor: 'next-comment-cursor' },
+          }),
+        ),
+      );
+      const tool = findTool('list_ticket_comments');
+      const text = getAllText(
+        await tool.handler({ ticket_id: 1, sort_order: 'desc', page_size: 1 }),
+      );
+      expect(text).toContain('Response truncated');
+      expect(text).toContain('longer than the response character limit');
+      expect(text).not.toContain('page_size smaller than 1');
+      expect(text).not.toContain('Use pagination or filters');
+    });
+
     it('reports an offset-paginated answer in words, never as a cursor', async () => {
       // Silence would report a truncated thread as complete; a `More available
       // (cursor: null)` footer would offer a continuation the tool cannot take.

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -1040,6 +1040,26 @@ describe('formatList', () => {
     `);
   });
 
+  it('passes a caller-supplied advice through to the truncation notice', () => {
+    const items = Array.from({ length: 400 }, (_, i) => ({
+      ...MOCK_CATEGORY,
+      id: 800 + i,
+      name: 'x'.repeat(100),
+    }));
+    const text = formatList(items, formatCategory, undefined, 'This tool takes no parameters.');
+    expect(text.endsWith('). This tool takes no parameters. ---')).toBe(true);
+  });
+
+  it('keeps the default truncation advice when the caller supplies none', () => {
+    const items = Array.from({ length: 400 }, (_, i) => ({
+      ...MOCK_CATEGORY,
+      id: 800 + i,
+      name: 'x'.repeat(100),
+    }));
+    const text = formatList(items, formatCategory);
+    expect(text.endsWith('). Use pagination or filters to reduce results. ---')).toBe(true);
+  });
+
   it('omits the header entirely when there is no pagination meta', () => {
     expect(formatList([MOCK_CATEGORY], formatCategory)).toMatchInlineSnapshot(
       `"- **General** (800) — General category"`,

--- a/tests/unit/utils/formatting.test.ts
+++ b/tests/unit/utils/formatting.test.ts
@@ -78,6 +78,21 @@ describe('truncateIfNeeded', () => {
       `\n\n--- Response truncated (${CHARACTER_LIMIT + 2} chars, limit ${CHARACTER_LIMIT}). Use pagination or filters to reduce results. ---`,
     );
   });
+
+  it('appends the caller-supplied advice in place of the default sentence', () => {
+    // A tool with no pagination parameters must not be told to paginate (#265),
+    // so the advice is per-call-site while the size/limit prefix stays shared.
+    const over = `${'x'.repeat(CHARACTER_LIMIT)}yz`;
+    const result = truncateIfNeeded(over, 'Read it with list_ticket_comments.');
+
+    expect(result.slice(CHARACTER_LIMIT)).toBe(
+      `\n\n--- Response truncated (${CHARACTER_LIMIT + 2} chars, limit ${CHARACTER_LIMIT}). Read it with list_ticket_comments. ---`,
+    );
+  });
+
+  it('ignores the advice when the text fits', () => {
+    expect(truncateIfNeeded('hello', 'Read it with list_ticket_comments.')).toBe('hello');
+  });
 });
 
 describe('formatTicket', () => {
@@ -315,9 +330,9 @@ describe('formatSlaBlock', () => {
 });
 
 describe('formatComment', () => {
-  it('renders a public comment with its attachment ids and content types', () => {
+  it('renders a public comment with its id, attachment ids and content types', () => {
     expect(formatComment(MOCK_COMMENT)).toMatchInlineSnapshot(`
-      "### Public comment by 9999
+      "### Public comment (id 3000) by 9999
       *2026-01-01T00:00:00Z*
       Attachments: #30001 (image/png), #30002 (application/pdf), #30003 (image/png)
 
@@ -329,7 +344,7 @@ describe('formatComment', () => {
     expect(
       formatComment({ ...MOCK_COMMENT, public: false, attachments: [] }),
     ).toMatchInlineSnapshot(`
-      "### Internal note by 9999
+      "### Internal note (id 3000) by 9999
       *2026-01-01T00:00:00Z*
 
       This is a comment"
@@ -339,6 +354,23 @@ describe('formatComment', () => {
   it('omits the Attachments line when the comment has none', () => {
     const result = formatComment({ ...MOCK_COMMENT, attachments: undefined });
     expect(result).not.toContain('Attachments:');
+  });
+
+  it('resolves the author to "Name (id)" when the map carries it', () => {
+    const result = formatComment(MOCK_COMMENT, new Map([[9999, 'Agent Smith']]));
+    expect(result).toContain('### Public comment (id 3000) by Agent Smith (9999)');
+  });
+
+  it('falls back to the bare id when the map lacks the author', () => {
+    const result = formatComment(MOCK_COMMENT, new Map([[1234, 'Someone Else']]));
+    expect(result).toContain('### Public comment (id 3000) by 9999');
+  });
+
+  it('labels the system actor rather than showing -1 alone', () => {
+    // Zendesk attributes trigger/automation-driven comments to author_id -1,
+    // which has no user record to resolve.
+    const result = formatComment({ ...MOCK_COMMENT, author_id: -1 }, new Map());
+    expect(result).toContain('### Public comment (id 3000) by System (-1)');
   });
 });
 


### PR DESCRIPTION
## Summary

`get_ticket(include_comments)` was the only read path to comment bodies and appended the thread as one unpaginated block, so past `CHARACTER_LIMIT` the tail — where the newest comments are — was cut, and the notice then advised pagination on a tool that accepts none. This adds `list_ticket_comments`, a cursor-paginated newest-first read over `GET /tickets/{id}/comments`, and gives `truncateIfNeeded` a per-call-site advice sentence so no truncated response advises an option its tool does not accept.

## Linked issue

Closes #265

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## What changed

**New tool `list_ticket_comments(ticket_id, sort_order, page_size, cursor)`** — `tickets` namespace, read-only.

- `sort_order` defaults to `"desc"`: the tool exists because the newest comment is the one that gets lost. Rendering the page in the order Zendesk returned it means a page that *still* overflows loses its **oldest** end, not its newest — the failure mode is inverted back to safe even before paging.
- On this endpoint `sort_order=asc|desc` is **offset-only**; with cursor pagination Zendesk takes `sort=created_at` / `sort=-created_at` ([List Comments](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_comments/)). The tool exposes the friendlier name and maps it internally. Confirmed live: the returned cursor base64-decodes to `{"o":"-created_at,-id",…}` under `desc` and `{"o":"created_at,id",…}` under `asc`.
- The `(newest first)` / `(oldest first)` header is read off the **returned timestamps**, not off the requested `sort_order`, so it cannot claim an order the API did not deliver. Equal timestamps say nothing about the order — a one-comment page, or several comments posted within the same second — so those fall back to what was requested rather than guessing.
- Title, pagination line and body are assembled and truncated **in one pass**: a title prepended after truncation would push the response past `CHARACTER_LIMIT` and leave itself out of the size the notice reports.
- When a page is cut, the cursor is no way back — it points past the whole page — so the truncation advice names the only recovery there is: re-issue with a smaller `page_size`. At `page_size: 1` there is no smaller page, so the notice says that instead of naming a value the schema rejects.
- If Zendesk ever answered this endpoint offset-style (`next_page`, no `meta.after_cursor`), there is more to read and **nothing this tool exposes reaches it**: `page_size` goes out as `page[size]`, which an offset response has already ignored, and `get_ticket(include_comments=true)` sends no paging at all and lands on the same default page. The note says exactly that and points at Zendesk itself, rather than rendering `More available (cursor: null)` or naming a parameter that cannot work.
- `page_size` defaults to a new `DEFAULT_TICKET_COMMENT_PAGE_SIZE = 20`, not the shared `DEFAULT_PAGE_SIZE` (100). The binding constraint here is the *response* budget, not an API cap: 100 comment bodies would make almost every first page truncate, which is the very failure this tool fixes.

**`formatComment` renders the comment id and resolves the author to a name.** The id is AC2 of the issue — there is no other read path that exposes it. Names come from the `include=users` side-load when it carries them, with a best-effort batched `/users/show_many` fallback otherwise: the side-load is documented only for email CCs, so it is treated as an optimisation rather than the mechanism (cf. #92, #226). Live validation confirmed the side-load does cover comment authors on a real tenant, so the fallback is the safety net rather than the usual path. `get_ticket` requests the same side-load and renders through the same path, so the two tools stay coherent and neither pays an avoidable round trip.

**`truncateIfNeeded(text, advice?)`** — the default keeps today's sentence byte-for-byte, so the genuinely paginated list renderers are unchanged. Every call site whose tool accepts no pagination now names something the caller can actually do:

| Tool | New advice |
|---|---|
| `get_ticket` | read the thread page by page with `list_ticket_comments` |
| `get_linked_incidents`, `preview_macro_diff` | states plainly that no pagination or filter parameter exists (`preview_macro_diff` also points at `list_macros`) |
| `find_translation_gaps` | narrow with `category_id`; when the caller already passed one, whether the scoped audit is complete or its section listing spilled past a page — the incomplete case points at `list_sections` + `list_section_translations` rather than claiming the audit is done |
| `get_article` | `get_article_outline` + `get_article_section` |
| `get_article_section` | request `format="markdown"` (and, when already markdown, that nothing narrower exists) |
| `list_promoted_articles`, `list_permission_groups`, `list_labels`, `list_user_segments` | these take **no parameters at all** (`inputSchema` is `z.object({})`), so the listing cannot be narrowed from the call; `formatList` gained an optional advice argument to say so |
| `list_article_translations`, `list_section_translations`, `list_category_translations`, `list_article_attachments` | these take only an id, so likewise — each points at the tool that reads or writes one item instead |
| `zendesk-hc://topology`, `zendesk-hc://article/{id}` | the listing / section tools |

**`CHARACTER_LIMIT` becomes overridable via `ZENDESK_CHARACTER_LIMIT`**, through the same `positiveIntEnv` guard the other size caps already use. This is not the "raise `CHARACTER_LIMIT`" #265 puts out of scope: the default holds at 25 000 and the docs say raising it is rarely what you want. **Lowering** it is the point — without it, the truncation branches this PR adds are unreachable on a tenant whose real data never crosses 25 000 characters, which is exactly what the first validation report hit on V12. `positiveIntEnv` moves to the top of `src/constants.ts` because `CHARACTER_LIMIT`, the first constant in the file, now calls it.

**`get_ticket` keeps its input schema unchanged.** Paging it would re-emit the ticket header and re-run the SLA scoped search on every page, and would put a `Results: N | More available` footer in the middle of a composite document. Only its description gains the pointer — and it now says accurately that it appends *one unpaginated block* (the first page of comments Zendesk returns), not the whole thread.

**`resolveAuditNames`'s inner batching helper** is lifted to a module-level `resolveEntityNames` / `resolveUserNames` and reused — no behaviour change, existing `get_ticket_history` tests are the safety net.

## Notes for the reviewer

- **The two committed inline snapshots for `formatComment` were rewritten by hand** (not `-u`): the header now carries the comment id. That is a deliberate formatter change, required by the issue's second acceptance criterion.
- **The functional baseline `tools.length` was already stale** before this PR — `04-all-baseline/expected.md` said 44 with a breakdown of 16 + 22 + 5 + 1, while the real surface was 52 (18 tickets-namespace + 29 Help Center + 5 users). It is corrected to 53 with the right breakdown; the jump is drift being paid off, not a regression from this change.
- **`docs/configuration.md`'s empty-value policy was already wrong**, independently of this PR: it claimed every single-value variable fails at startup when empty, but `requireNonEmptyEnv` covers only the deployment variables, and the five numeric caps read through `positiveIntEnv` have always fallen back instead. Documented as a third exception naming the whole class rather than singling out the new variable, which would have implied the other five do fail.
- **Known limitation, out of scope:** a single comment longer than `CHARACTER_LIMIT` still truncates at `page_size: 1`, and no page small enough exists — the notice now says so rather than advising an impossible value. Slicing bodies is adjacent to #205's payload-budget work.
- **Follow-up opened:** #271 — `get_ticket`'s header still prints requester and assignee as raw ids while the comment headers below now resolve names. Left out of this PR because `formatTicket` is shared by five tools and resolving there is a cost-profile decision.
- `scripts/probe-ticket-comments.ts` is a read-only ground-truth probe, added because two behaviours this feature rests on are invisible in the formatted output (see scenario V0 below). It performs GETs only and never prints comment text, and it authenticates the way the running server does, so a session that can call the tools can run it with no setup.
- **Review history**, since the commits read as a conversation: `9bee920` fixes five findings from a first Claude Code pass, `169ade6` nine from a second, `b3f7b64` one from CodeRabbit (a defect `169ade6` had itself introduced), `82e9e17` two more, `7dad096` the validation report's blocked probe, `c6cc5e4` its coverage gap, `7a507da` three findings from CodeRabbit's third pass, and `57cc1fe` its out-of-diff catch that the offset note named two levers that cannot work. Every finding is confirmed addressed by its reporter, except the one purity refactor CodeRabbit itself withdrew after checking the repo's conventions.
- Gates on `57cc1fe`: `pnpm test` (1003), `pnpm test:coverage` (thresholds met), `pnpm check --error-on-warnings`, `pnpm typecheck` all clean; `pnpm test:mutation:diff origin/main HEAD` → 14 mutants in changed lines, 14 killed, 0 escaped.

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings (two passes plus three CodeRabbit rounds — see *Review history* above)
- [x] Documentation is updated where needed
- [x] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md`
- [x] If the change has **MCP-runtime-observable** behaviour: this PR carries a `## Functional validation plan`, executed by a validator whose report is posted as a PR comment. Two runs are on record; the second is green across the plan, including the V0 probe and the lowered-limit scenarios V11/V12/V12b. The repository owner has accepted it.

## Functional validation plan

### Context

The change is observable entirely through the MCP tool surface. Exercise it with the live `mcp__zendesk-local__*` tools on this branch:

- `list_ticket_comments` — the new tool; it must appear in `tools/list` and behave as described.
- `get_ticket` — its schema must be **unchanged** (still exactly `ticket_id` + `include_comments`), while its rendered comments now show ids and author names, and its truncation notice now names `list_ticket_comments`.
- `get_ticket_history`, `get_ticket_attachments` — must be unaffected apart from description wording.

Not exercised by this change: auth, transports, prompts, persistence. Testing the HTTP transport specifically adds nothing here.

**Pick a target ticket first.** You need one long thread — ideally the one from the issue, ticket **7435**, whose `get_ticket` rendering is known to exceed the 25 000-character limit — and any ticket with at least 2 comments for the ordering checks.

### Setup & prerequisites

Nothing to build, start or authenticate for V0–V10; the server is already running on this branch with a valid token. Record `git rev-parse HEAD` and quote it in your report.

For **V0 only**, run the probe from the repo root:

```
pnpm tsx scripts/probe-ticket-comments.ts 7435
```

It needs no environment setup: the subdomain comes from `ZENDESK_SUBDOMAIN` or the committed `.mcp.json`, the token from `ZENDESK_OAUTH_TOKEN` or the same cached store the running server reads — empty values counting as unset in both cases — and it prints which credential it used. If it still cannot authenticate, that is a `BLOCKED` finding.

**V11, V12 and V12b need a lowered limit**, because no thread or article on a real tenant reaches 25 000 characters through these tools. Start a server on this commit with `ZENDESK_CHARACTER_LIMIT=2000` for those three, and say in your report that you did. Run them last so everything else is measured at the real default.

### Scenarios

| id | Validates | Do this | Expected observable |
|----|-----------|---------|---------------------|
| **V0** | **Ground truth (blocking)** — does Zendesk accept `sort` with cursor paging, and does `include=users` carry comment authors? | Run the probe command above | Paste the **raw output verbatim** (redact the tenant). Both `GET`s return `200` — a `400` on the first invalidates the whole parameter shape, report it loudly. Note the printed `Q1` and `Q2` verdicts. Run this first: if it fails, stop and report. |
| **V1** | The issue's headline symptom is gone | `list_ticket_comments { ticket_id: 7435 }` — no other argument | Response opens with `# Comments on ticket #7435 (newest first)`. The **most recent** comment is the **first** entry. Compare against the last `Public comment added` / `Internal note added` line of `get_ticket_history { ticket_id: 7435 }` (oldest-first, so its *last* entry): the timestamps must match. A header reading `(oldest first)` here is a **FAIL of the feature** — it means Zendesk ignored `sort`; report it with V0's output. |
| **V2** | AC2 — comment ids are reachable through a read | Same response as V1 | Every entry reads `### Public comment (id <n>) by <Name> (<id>)` or `### Internal note (id <n>) by …`. Ids present and distinct; authors are **names**, not bare ids. Quote one header line verbatim. |
| **V3** | Cursor paging walks backward in time | Take the `More available (cursor: X)` value from V1's footer, then `list_ticket_comments { ticket_id: 7435, cursor: "X" }`. If the thread fits one page, force a cursor with a smaller `page_size` first and say so. | A second, **different** page. Its newest timestamp is **older** than the oldest timestamp of page 1, and no comment id appears on both pages. |
| **V4** | `sort_order: "asc"` replays the conversation | `list_ticket_comments { ticket_id: 7435, sort_order: "asc" }` | Header says `(oldest first)`. The first entry is the ticket's **opening description** — it must match the description block of `get_ticket { ticket_id: 7435, include_comments: false }`. |
| **V5** | `page_size` is honoured, default is 20 | `list_ticket_comments { ticket_id: 7435, page_size: 3 }`, then the same with no `page_size` | With 3: at most 3 entries, footer `Results: 3`. With no `page_size`: at most 20 entries. |
| **V6** | AC3 — `get_ticket` no longer advises what it cannot do | `get_ticket { ticket_id: 7435, include_comments: true }` | Ends with `--- Response truncated (… chars, limit 25000). get_ticket appends the thread as one unpaginated block; read it page by page with list_ticket_comments (ticket_id: 7435, sort_order: "desc") to get the newest comments first. ---`. Must **not** contain `Use pagination or filters to reduce results`. |
| **V7** | `get_ticket`'s schema is untouched (multi-agent compatibility) | Read `get_ticket`'s entry in `tools/list` | `inputSchema.properties` is exactly `ticket_id` and `include_comments` — no `sort_order`, `page_size` or `cursor`. `required` unchanged. |
| **V8** | Author names in `get_ticket` too | `get_ticket { ticket_id: <a short-thread ticket>, include_comments: true }` | Comment headers show `(id <n>) by <Name> (<id>)`, matching what `list_ticket_comments` shows for the same ticket. No raw-id-only header. |
| **V9** | The tool is discoverable and correctly annotated | Read `list_ticket_comments` in `tools/list` | Present, `readOnlyHint: true`, `openWorldHint: true`. In `--mode namespace` it is an operation of the `zendesk_tickets` proxy (if your session runs `--mode all`, note that and check the proxy half separately). |
| **V10** | A ticket with no comments | `list_ticket_comments { ticket_id: <a ticket with no reply> }` | `No comments to show for ticket #<n>.` A Zendesk ticket always exposes its description as its first comment, so this is likely unreachable live: mark `N/A` rather than manufacturing one. |
| **V11** | Other truncation notices no longer misadvise | At `ZENDESK_CHARACTER_LIMIT=2000`: `get_article { article_id: <the longest article on the tenant> }` | The notice names `get_article_outline` / `get_article_section` and does **not** say `Use pagination or filters`. |
| **V12** | A truncated comment page routes to the only recovery | At `ZENDESK_CHARACTER_LIMIT=2000`: `list_ticket_comments { ticket_id: 7435, page_size: 20 }` | The response **starts** with `# Comments on ticket #7435 (newest first)` — title inside the budget, not prepended after the cut — and the notice reads `--- Response truncated (… chars, limit 2000). The comments cut here are not reachable through the cursor, which points past this whole page: re-issue with a page_size smaller than 20 to read them. ---`. Never `Use pagination or filters`. |
| **V12b** | `page_size: 1` names a reachable recovery | At `ZENDESK_CHARACTER_LIMIT=2000`: `list_ticket_comments { ticket_id: 7435, sort_order: "asc", page_size: 1 }`. **`asc` is required** — under the default `desc` the first page is the newest comment, which on this ticket is a short reply and does not overflow. `asc` puts the long opening description first. | The notice reads `… This single comment is longer than the response character limit, so no page small enough exists: read it in Zendesk directly.` and does **not** contain `page_size smaller than 1` — a value the schema rejects. If that first comment is short on your tenant, follow a cursor onto a longer one and say which. |

### Long-running behaviours

None. Nothing here is time-based; no clock lever needed.

### Priorities

**V0 first and blocking** — it decides whether the parameter shape is right at all. Then **V1, V2, V6** (the three acceptance criteria), then **V3, V4, V7**. V5, V8–V10 are confirmations. **V11, V12 and V12b last**, since they need a server at a lowered limit.

### Reporting instructions

Post one PR comment, in English, with:

- the commit SHA you tested (`git rev-parse HEAD`),
- the raw V0 probe output verbatim, tenant redacted,
- one line per scenario id: `OK` / `FAIL` / `BLOCKED` / `N/A`, with the observed evidence (actual header lines, timestamps, cursor values, notice text — not a paraphrase),
- which value of `ZENDESK_CHARACTER_LIMIT` V11/V12/V12b ran against,
- one line naming the role behind the run (`Run by:`),
- an overall verdict, and for any `FAIL` the exact call made and the full response tail.

---

https://claude.ai/code/session_01Y1q5zNrwNGc8tCdswcqFpN


---
_Generated by [Claude Code](https://claude.ai/code)_