### PR TITLE
perf(zod): compile schemas at runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,13 +45,6 @@ Zod schema. Each proxy dispatches only within its own scoped handler map, so a
 `--read-only` / `--tool` are applied by `filterTools` *before* the mode switch;
 `--tool` also forces `mode: all` (`config.ts`).
 
-`src/index.ts` opens with `import 'zod/compile'`, which compiles schemas on their first
-**synchronous** parse. Two constraints, both silent when broken: keep it the *first* import
-(schemas built before it keep the runtime parser), and keep our own parses synchronous — the
-compiler never touches an async one, which is why the SDK's `safeParseAsync` tool-argument
-validation is unaffected. What it is worth (2–7x on the parses it does reach, ~nil end to
-end) and what would reverse it: `docs/decisions/zod-compile.md`.
-
 Every Zendesk API request goes through `performFetch` in `client/zendesk-api.ts`
 (the OAuth token exchange in `auth/browser-oauth.ts` deliberately does not), so retry and
 network-error wrapping are decided once, in `client/retry.ts`: a new client method must

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,12 @@ Zod schema. Each proxy dispatches only within its own scoped handler map, so a
 `--read-only` / `--tool` are applied by `filterTools` *before* the mode switch;
 `--tool` also forces `mode: all` (`config.ts`).
 
-`src/index.ts` opens with `import 'zod/compile'`, so every schema built afterwards
-compiles itself on first parse. Keep it the **first** import — schemas from modules that
-evaluate before it silently keep the runtime parser. What it's worth (2–7x on validation,
-~nil end to end) and what would reverse it: `docs/decisions/zod-compile.md`.
+`src/index.ts` opens with `import 'zod/compile'`, which compiles schemas on their first
+**synchronous** parse. Two constraints, both silent when broken: keep it the *first* import
+(schemas built before it keep the runtime parser), and keep our own parses synchronous — the
+compiler never touches an async one, which is why the SDK's `safeParseAsync` tool-argument
+validation is unaffected. What it is worth (2–7x on the parses it does reach, ~nil end to
+end) and what would reverse it: `docs/decisions/zod-compile.md`.
 
 Every Zendesk API request goes through `performFetch` in `client/zendesk-api.ts`
 (the OAuth token exchange in `auth/browser-oauth.ts` deliberately does not), so retry and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,11 @@ Zod schema. Each proxy dispatches only within its own scoped handler map, so a
 `--read-only` / `--tool` are applied by `filterTools` *before* the mode switch;
 `--tool` also forces `mode: all` (`config.ts`).
 
+`src/index.ts` opens with `import 'zod/compile'`, so every schema built afterwards
+compiles itself on first parse. Keep it the **first** import — schemas from modules that
+evaluate before it silently keep the runtime parser. What it's worth (2–7x on validation,
+~nil end to end) and what would reverse it: `docs/decisions/zod-compile.md`.
+
 Every Zendesk API request goes through `performFetch` in `client/zendesk-api.ts`
 (the OAuth token exchange in `auth/browser-oauth.ts` deliberately does not), so retry and
 network-error wrapping are decided once, in `client/retry.ts`: a new client method must

--- a/docs/decisions/zod-compile.md
+++ b/docs/decisions/zod-compile.md
@@ -1,0 +1,155 @@
+# zod compilation: adopted because it is free, not because it is fast
+
+> **Build documentation, not user documentation.** This records why `src/index.ts`
+> opens with `import 'zod/compile'` and what the optimisation is actually worth on
+> this server. Nothing here changes how the MCP server behaves for a client — the
+> exposed tool surface is byte-for-byte identical with and without it.
+
+| | |
+| --- | --- |
+| **Status** | Decided and applied |
+| **Date** | 2026-09-08 |
+| **Applied in** | [#273](https://github.com/fruggr/zendesk-mcp-server/pull/273) |
+| **Question** | Should the server opt into zod 4.5's AOT schema compiler, globally and transparently? |
+| **Answer** | **Yes** — but on the strength of costing nothing, not of making anything measurably faster. Validation gets 2–7x cheaper; that is ~2 µs against a 100–500 ms Zendesk round-trip. |
+
+## What it is
+
+zod 4.5 added [`z.compile()`](https://zod.dev/blog/introducing-z-compile): it walks a
+schema once and emits a flat, loop-free `new Function()` fast path, keeping the
+original parser as a fallback so error reporting is unchanged. `import 'zod/compile'`
+is the transparent form — a side-effect import that installs a global post-processor,
+so every schema built afterwards compiles itself on its first `parse`, with no call
+site opting in.
+
+## The argument that does *not* justify this
+
+The zod blog leads with "~9x faster". Quoting that as a user-visible win here would be
+wrong, and this section exists so nobody reaches for it later.
+
+Every tool call in this server is one or more HTTPS round-trips to Zendesk
+(`src/client/zendesk-api.ts`), i.e. 100–500 ms. The zod work on that path is one
+`safeParse` of the tool's input schema plus the SDK's validation of two JSON-RPC
+messages — **~2 µs saved per call, about 0.001% of it.** No zod schema parses Zendesk
+*responses*: those are plain TypeScript interfaces (`src/types.ts`), so there is no
+hidden hot path. The server's real CPU cost is the unified/cheerio HTML↔Markdown
+pipeline in `src/tools/help-center.ts`, which the compiler does not touch.
+
+This was adopted because it is one line, needs a zod bump that was due anyway
+([#263](https://github.com/fruggr/zendesk-mcp-server/pull/263)), adds nothing to the
+bundle, and was proven not to change the exposed surface. If any of those stops being
+true, the justification is gone — see *What would reverse this*.
+
+## What was measured
+
+On this repo's own schemas and this repo's SDK version, Node 22, 200k iterations after
+warm-up (see *Reproducing*).
+
+| Path | Runtime parser | Compiled | Ratio |
+| --- | --- | --- | --- |
+| `search_tickets` input, valid | 0.31 µs | 0.12 µs | 2.6x |
+| `update_ticket` input, valid | 0.35 µs | 0.12 µs | 2.9x |
+| `list_articles` input, valid | 0.54 µs | 0.25 µs | 2.2x |
+| `get_article` input, valid | 0.17 µs | 0.09 µs | 1.9x |
+| `search_tickets` input, **rejected** (unknown key) | 2.78 µs | 3.21 µs | **0.87x — slower** |
+| SDK `JSONRPCMessageSchema`, request | 0.69 µs | 0.28 µs | 2.5x |
+| SDK `JSONRPCMessageSchema`, response | 1.37 µs | 0.19 µs | 7.2x |
+
+Costs:
+
+| | |
+| --- | --- |
+| Compiling all 53 tool schemas | 32.9 ms total — mean 0.62 ms, median 0.27 ms, worst `update_ticket` 1.31 ms |
+| First JSON-RPC message of a process | 2.5 ms → 6.7 ms (compiling the SDK's message union); every message after: 0.13 ms → 0.02 ms |
+| `dist/index.js` | 242.03 kB → 242.05 kB. zod is an external runtime dependency, not bundled, so the blog's "+7 kB gzipped" does not apply here |
+
+Three things follow, and they are the honest shape of this change:
+
+1. **The error path is not accelerated, and is marginally slower.** A rejected input
+   falls back to the runtime parser to build its issues, having paid for the fast path
+   first. `createStrictParamsParser` (`src/utils/validation.ts`) turns those issues into
+   the "Unknown parameter(s): …" message, so the message itself is unchanged — the
+   `unrecognized_keys` issues come through verbatim.
+2. **Compilation is lazy and per schema instance.** The HTTP transport builds a
+   *per-session* `McpServer` (`src/transports/http.ts`), so each session constructs its
+   own tool schemas and pays ~0.27–1.31 ms the first time it parses each one. A session
+   would need roughly 1350 parses of the *same* tool's schema to earn that back, which
+   never happens. **For tool input schemas under HTTP, global mode is therefore
+   marginally net-negative** — a few milliseconds per session, and only for the tools
+   actually called. What stays positive is the SDK's module-level protocol schemas:
+   compiled once per process, hit by every message.
+3. Under stdio (one process, one session) both effects are once-per-launch and the
+   break-even on protocol messages arrives after ~35 messages.
+
+## Why it is still adopted
+
+Because the *cost* side is as small as the benefit: no bundle growth, no API change, no
+call-site churn, no new dependency. The measurements above are the reason to describe
+it accurately, not a reason to skip it.
+
+Compatibility was verified rather than assumed, and this is what makes the change safe
+to leave in place:
+
+- `z.toJSONSchema()` output identical, compiled vs not.
+- The real `tools/list` payload across all three modes (`all`, `namespace`, `single` —
+  132 kB of JSON) is **identical byte for byte**.
+- `unrecognized_keys` issues preserved verbatim, so `createStrictParamsParser` still
+  produces its exact message; the SDK's `-32602` text is unchanged too.
+- The full test suite runs with compilation active — `tests/setup.ts` carries the same
+  import, deliberately, so the suite exercises what ships. The trade-off is real: no
+  test now covers the uncompiled path. That is the right way round, since no user runs
+  it.
+
+## Ordering is load-bearing
+
+The post-processor only reaches schemas built by modules that evaluate **after** the
+import, so `import 'zod/compile'` must be the first import of the entrypoint. Demote it
+and everything still works — `tools/list` unchanged, tests green — the compilation just
+silently stops happening. `src/index.ts` is outside both the coverage scope
+(`vitest.config.ts`) and the mutation scope (`stryker.config.mjs`), so nothing else
+would notice. Hence `tests/unit/index-compile.test.ts`, which asserts the position in
+both `src/index.ts` and `tests/setup.ts`.
+
+The same silence applies per schema: a schema whose semantics the fast path cannot model
+is returned *unchanged*, still on the runtime parser, with no signal.
+`tests/unit/tools/schema-compile.test.ts` compiles every tool's `.strict()` schema under
+`{ strict: true }`, which turns that fallback into a thrown error. All 53 compile today.
+
+## What would reverse this
+
+- **A runtime without `new Function`** (a CSP-restricted or edge deployment). zod
+  degrades gracefully via its `jitless` config, so nothing breaks — but the import would
+  be dead weight and should be dropped rather than left as decoration.
+- **A schema feature we need that the fast path cannot model.** The guard test will say
+  so. Expressing the constraint differently is preferable; accepting the fallback is
+  fine too, but then say which tool and why, here.
+- **The fallback becoming observable** — a zod release where a compiled schema's errors,
+  coercions or key handling differ from the runtime parser's. The byte-identical
+  `tools/list` check and the full suite running compiled are what would catch it.
+
+## Reproducing
+
+Numbers above, from the repo root on the branch under test.
+
+Per-message and cold-start cost, baseline vs compiled:
+
+```js
+// coldstart.mjs — run: node coldstart.mjs   /   node coldstart.mjs compile
+if (process.argv[2] === 'compile') await import('zod/compile');
+const { JSONRPCMessageSchema } = await import('@modelcontextprotocol/sdk/types.js');
+const init = { jsonrpc: '2.0', id: 0, method: 'initialize',
+  params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'c', version: '1' } } };
+const t1 = process.hrtime.bigint(); JSONRPCMessageSchema.safeParse(init);
+const first = Number(process.hrtime.bigint() - t1) / 1e6;
+const t2 = process.hrtime.bigint(); JSONRPCMessageSchema.safeParse(init);
+console.log(`first=${first.toFixed(2)}ms second=${(Number(process.hrtime.bigint() - t2) / 1e6).toFixed(3)}ms`);
+```
+
+Per-schema throughput: put a throwaway test under `tests/unit/`, build the schemas with
+`createAllTools({ subdomain: 'testsubdomain', getToken: () => 'test-token' })`, and run
+it twice — once normally (compiled, via `tests/setup.ts`) and once against a config with
+`setupFiles: []` (the baseline). Compile cost is `z.compile()` timed over freshly built,
+never-parsed schemas.
+
+Surface identity: boot `createMcpServer` over `InMemoryTransport` for each mode, dump
+`listTools()`, and diff the two runs.

--- a/docs/decisions/zod-compile.md
+++ b/docs/decisions/zod-compile.md
@@ -121,9 +121,10 @@ to leave in place:
 - `unrecognized_keys` issues preserved verbatim, so `createStrictParamsParser` still
   produces its exact message; the SDK's `-32602` text is unchanged too.
 - The full test suite runs with compilation active — `tests/setup.ts` carries the same
-  import, deliberately, so the suite exercises what ships. The trade-off is real: no
-  test now covers the uncompiled path. That is the right way round, since no user runs
-  it.
+  import, deliberately, so the suite exercises what ships. That would leave the
+  uncompiled path untested, so `tests/unit/zod-jitless.test.ts` covers it explicitly:
+  under `z.config({ jitless: true })` nothing compiles, and params, defaults, the
+  "Unknown parameter(s)" message and the exposed JSON Schema come out the same.
 
 ## Ordering is load-bearing
 
@@ -146,8 +147,9 @@ synchronous parse leaves the schema compiled and an asynchronous one does not.
 ## What would reverse this
 
 - **A runtime without `new Function`** (a CSP-restricted or edge deployment). zod
-  degrades gracefully via its `jitless` config, so nothing breaks — but the import would
-  be dead weight and should be dropped rather than left as decoration.
+  degrades gracefully via its `jitless` config — `tests/unit/zod-jitless.test.ts` proves
+  the behaviour is identical there — but the import would be dead weight and should be
+  dropped rather than left as decoration.
 - **A schema feature we need that the fast path cannot model.** The guard test will say
   so. Expressing the constraint differently is preferable; accepting the fallback is
   fine too, but then say which tool and why, here.

--- a/docs/decisions/zod-compile.md
+++ b/docs/decisions/zod-compile.md
@@ -11,7 +11,7 @@
 | **Date** | 2026-09-08 |
 | **Applied in** | [#273](https://github.com/fruggr/zendesk-mcp-server/pull/273) |
 | **Question** | Should the server opt into zod 4.5's AOT schema compiler, globally and transparently? |
-| **Answer** | **Yes** — but on the strength of costing nothing, not of making anything measurably faster. Validation gets 2–7x cheaper; that is ~2 µs against a 100–500 ms Zendesk round-trip. |
+| **Answer** | **Yes** — but on the strength of costing nothing, not of making anything measurably faster. The synchronous parses it reaches get 2–7x cheaper; that is ~2 µs against a 100–500 ms Zendesk round-trip. |
 
 ## What it is
 
@@ -19,8 +19,29 @@ zod 4.5 added [`z.compile()`](https://zod.dev/blog/introducing-z-compile): it wa
 schema once and emits a flat, loop-free `new Function()` fast path, keeping the
 original parser as a fallback so error reporting is unchanged. `import 'zod/compile'`
 is the transparent form — a side-effect import that installs a global post-processor,
-so every schema built afterwards compiles itself on its first `parse`, with no call
+so schemas built afterwards compile themselves on their first `parse`, with no call
 site opting in.
+
+## Which parses it actually reaches
+
+Less than "everything", and the difference is invisible from the outside, so it is worth
+stating precisely. The global shim **bypasses the fast path for any asynchronous parse —
+and does not compile the schema at all** while doing so. Probed on a live server over
+`InMemoryTransport`, one real `tools/call` per mode:
+
+| Parse | Compiled? |
+| --- | --- |
+| Every JSON-RPC message — `JSONRPCMessageSchema.parse`, synchronous in stdio, SSE and streamable HTTP alike | **yes** |
+| `createStrictParamsParser`'s params parse (`src/utils/validation.ts`) — the proxy dispatch path, i.e. `namespace` and `single`, the default modes | **yes** |
+| `ConfigSchema.parse` at startup (`src/config.ts`) | yes, once |
+| The SDK's tool-argument validation — the registered schema in `all` mode, the proxy's `{operation, params}` schema in the others | **no**: `mcp.js` uses `safeParseAsync` |
+
+So in `all` mode no tool input schema is ever compiled, and in the default mode the
+*inner* params parse is compiled while the SDK's outer one is not. Nothing can be done
+about it from here: `compile()` is forward-and-synchronous by construction, and the
+choice of `safeParseAsync` belongs to the SDK. `tests/unit/tools/schema-compile.test.ts`
+pins both halves — that the sync path really compiles, and that the async one really
+does not — so this table cannot quietly go stale.
 
 ## The argument that does *not* justify this
 
@@ -30,8 +51,9 @@ wrong, and this section exists so nobody reaches for it later.
 Every tool call in this server is one or more HTTPS round-trips to Zendesk
 (`src/client/zendesk-api.ts`), i.e. 100–500 ms. The zod work on that path is one
 `safeParse` of the tool's input schema plus the SDK's validation of two JSON-RPC
-messages — **~2 µs saved per call, about 0.001% of it.** No zod schema parses Zendesk
-*responses*: those are plain TypeScript interfaces (`src/types.ts`), so there is no
+messages — **~2 µs saved per call, about 0.001% of it**, and less than that in `all`
+mode, where the tool-input parse is the SDK's async one and is not compiled at all. No
+zod schema parses Zendesk *responses*: those are plain TypeScript interfaces (`src/types.ts`), so there is no
 hidden hot path. The server's real CPU cost is the unified/cheerio HTML↔Markdown
 pipeline in `src/tools/help-center.ts`, which the compiler does not touch.
 
@@ -43,7 +65,8 @@ true, the justification is gone — see *What would reverse this*.
 ## What was measured
 
 On this repo's own schemas and this repo's SDK version, Node 22, 200k iterations after
-warm-up (see *Reproducing*).
+warm-up (see *Reproducing*). Every row is a **synchronous** parse, i.e. one of the paths
+the compiler actually reaches; the tool-input rows are the proxy params parse.
 
 | Path | Runtime parser | Compiled | Ratio |
 | --- | --- | --- | --- |
@@ -59,11 +82,11 @@ Costs:
 
 | | |
 | --- | --- |
-| Compiling all 53 tool schemas | 32.9 ms total — mean 0.62 ms, median 0.27 ms, worst `update_ticket` 1.31 ms |
+| Compiling a tool schema | mean 0.62 ms, median 0.27 ms, worst `update_ticket` 1.31 ms (32.9 ms for all 53 — a ceiling nothing actually pays, since only the tools a session calls get compiled, and only in the default modes) |
 | First JSON-RPC message of a process | 2.5 ms → 6.7 ms (compiling the SDK's message union); every message after: 0.13 ms → 0.02 ms |
 | `dist/index.js` | 242.03 kB → 242.05 kB. zod is an external runtime dependency, not bundled, so the blog's "+7 kB gzipped" does not apply here |
 
-Three things follow, and they are the honest shape of this change:
+Four things follow, and they are the honest shape of this change:
 
 1. **The error path is not accelerated, and is marginally slower.** A rejected input
    falls back to the runtime parser to build its issues, having paid for the fast path
@@ -72,14 +95,16 @@ Three things follow, and they are the honest shape of this change:
    `unrecognized_keys` issues come through verbatim.
 2. **Compilation is lazy and per schema instance.** The HTTP transport builds a
    *per-session* `McpServer` (`src/transports/http.ts`), so each session constructs its
-   own tool schemas and pays ~0.27–1.31 ms the first time it parses each one. A session
-   would need roughly 1350 parses of the *same* tool's schema to earn that back, which
-   never happens. **For tool input schemas under HTTP, global mode is therefore
-   marginally net-negative** — a few milliseconds per session, and only for the tools
-   actually called. What stays positive is the SDK's module-level protocol schemas:
-   compiled once per process, hit by every message.
+   own tool schemas and pays ~0.27–1.31 ms the first time the proxy parser touches each
+   one. A session would need roughly 1350 parses of the *same* tool's schema to earn that
+   back, which never happens. **For tool input schemas under HTTP, global mode is
+   therefore marginally net-negative** — a few milliseconds per session, and only for the
+   tools actually called in the default modes. What stays positive everywhere is the
+   SDK's module-level protocol schemas: compiled once per process, hit by every message.
 3. Under stdio (one process, one session) both effects are once-per-launch and the
    break-even on protocol messages arrives after ~35 messages.
+4. In `all` mode there is neither cost nor gain on tool inputs: that validation is the
+   SDK's async one, so nothing there is ever compiled.
 
 ## Why it is still adopted
 
@@ -92,7 +117,7 @@ to leave in place:
 
 - `z.toJSONSchema()` output identical, compiled vs not.
 - The real `tools/list` payload across all three modes (`all`, `namespace`, `single` —
-  132 kB of JSON) is **identical byte for byte**.
+  128 kB of JSON) is **identical byte for byte**.
 - `unrecognized_keys` issues preserved verbatim, so `createStrictParamsParser` still
   produces its exact message; the SDK's `-32602` text is unchanged too.
 - The full test suite runs with compilation active — `tests/setup.ts` carries the same
@@ -110,10 +135,13 @@ silently stops happening. `src/index.ts` is outside both the coverage scope
 would notice. Hence `tests/unit/index-compile.test.ts`, which asserts the position in
 both `src/index.ts` and `tests/setup.ts`.
 
-The same silence applies per schema: a schema whose semantics the fast path cannot model
-is returned *unchanged*, still on the runtime parser, with no signal.
-`tests/unit/tools/schema-compile.test.ts` compiles every tool's `.strict()` schema under
-`{ strict: true }`, which turns that fallback into a thrown error. All 53 compile today.
+The same silence applies twice more, and `tests/unit/tools/schema-compile.test.ts` covers
+both. A schema whose semantics the fast path cannot model is returned *unchanged*, still
+on the runtime parser, with no signal — so the test compiles every tool's `.strict()`
+schema under `{ strict: true }`, turning that fallback into a thrown error (all 53 compile
+today). And a parse that moves from `safeParse` to `safeParseAsync` stops being compiled
+with nothing else changing — so the test also asserts, on the real proxy path, that a
+synchronous parse leaves the schema compiled and an asynchronous one does not.
 
 ## What would reverse this
 
@@ -123,6 +151,9 @@ is returned *unchanged*, still on the runtime parser, with no signal.
 - **A schema feature we need that the fast path cannot model.** The guard test will say
   so. Expressing the constraint differently is preferable; accepting the fallback is
   fine too, but then say which tool and why, here.
+- **The SDK dropping `safeParseAsync`** — the reverse of a reversal: tool-argument
+  validation would start being compiled, and the *Which parses it actually reaches* table
+  above would need redoing. The guard test's async assertion is what would notice.
 - **The fallback becoming observable** — a zod release where a compiled schema's errors,
   coercions or key handling differ from the runtime parser's. The byte-identical
   `tools/list` check and the full suite running compiled are what would catch it.

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "remark-rehype": "11.1.2",
     "remark-stringify": "11.0.0",
     "unified": "11.0.5",
-    "zod": "4.4.3"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.30.0
-        version: 1.30.0(supports-color@7.2.0)(zod@4.4.3)
+        version: 1.30.0(supports-color@7.2.0)(zod@4.5.4)
       cheerio:
         specifier: 1.2.0
         version: 1.2.0
@@ -56,8 +56,8 @@ importers:
         specifier: 11.0.5
         version: 11.0.5
       zod:
-        specifier: 4.4.3
-        version: 4.4.3
+        specifier: 4.5.4
+        version: 4.5.4
     devDependencies:
       '@biomejs/biome':
         specifier: 2.5.11
@@ -3954,8 +3954,8 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4478,7 +4478,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.6.0
 
-  '@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.5.4)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.5)
       ajv: 8.20.0
@@ -4495,8 +4495,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod: 4.5.4
+      zod-to-json-schema: 3.25.2(zod@4.5.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -6725,7 +6725,7 @@ snapshots:
 
   mutation-server-protocol@0.4.1:
     dependencies:
-      zod: 4.4.3
+      zod: 4.5.4
 
   mutation-testing-elements@3.8.4: {}
 
@@ -7848,10 +7848,10 @@ snapshots:
       '@yuku-parser/binding-win32-arm64': 0.8.7
       '@yuku-parser/binding-win32-x64': 0.8.7
 
-  zod-to-json-schema@3.25.2(zod@4.4.3):
+  zod-to-json-schema@3.25.2(zod@4.5.4):
     dependencies:
-      zod: 4.4.3
+      zod: 4.5.4
 
-  zod@4.4.3: {}
+  zod@4.5.4: {}
 
   zwitch@2.0.4: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,6 @@
-// Compile zod schemas on their first parse (zod >= 4.5). The import is side-effect only:
-// it installs a global post-processor, so no call site changes and no schema opts in.
-// Order is load-bearing — schemas built by modules that evaluate BEFORE this import keep
-// the runtime parser, so it must stay the FIRST import of the entrypoint. It reaches only
-// SYNCHRONOUS parses: every JSON-RPC message (`JSONRPCMessageSchema.parse`, all transports)
-// and the proxy params parse in `utils/validation.ts`. The SDK validates tool arguments with
-// `safeParseAsync`, which the compiler never accelerates. Guarded by
-// tests/unit/index-compile.test.ts and tests/unit/tools/schema-compile.test.ts; measurements
-// and what would reverse this: docs/decisions/zod-compile.md.
+// Compiles zod schemas on their first synchronous parse. Must stay the FIRST import:
+// schemas built before it keep the runtime parser, silently. Why, and what it is worth:
+// docs/decisions/zod-compile.md.
 import 'zod/compile';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
+// Compile every zod schema built below on its first parse (zod >= 4.5). The import is
+// side-effect only: it installs a global post-processor, so no call site changes and no
+// schema opts in. Order is load-bearing — schemas constructed by modules that evaluate
+// BEFORE this import keep the runtime parser, so it must stay the FIRST import of the
+// entrypoint. Guarded by tests/unit/index-compile.test.ts; rationale, measurements and
+// what would reverse this: docs/decisions/zod-compile.md.
+import 'zod/compile';
+
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createTokenStore } from './auth/token-store';
 import type { Config } from './config';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
-// Compile every zod schema built below on its first parse (zod >= 4.5). The import is
-// side-effect only: it installs a global post-processor, so no call site changes and no
-// schema opts in. Order is load-bearing — schemas constructed by modules that evaluate
-// BEFORE this import keep the runtime parser, so it must stay the FIRST import of the
-// entrypoint. Guarded by tests/unit/index-compile.test.ts; rationale, measurements and
-// what would reverse this: docs/decisions/zod-compile.md.
+// Compile zod schemas on their first parse (zod >= 4.5). The import is side-effect only:
+// it installs a global post-processor, so no call site changes and no schema opts in.
+// Order is load-bearing — schemas built by modules that evaluate BEFORE this import keep
+// the runtime parser, so it must stay the FIRST import of the entrypoint. It reaches only
+// SYNCHRONOUS parses: every JSON-RPC message (`JSONRPCMessageSchema.parse`, all transports)
+// and the proxy params parse in `utils/validation.ts`. The SDK validates tool arguments with
+// `safeParseAsync`, which the compiler never accelerates. Guarded by
+// tests/unit/index-compile.test.ts and tests/unit/tools/schema-compile.test.ts; measurements
+// and what would reverse this: docs/decisions/zod-compile.md.
 import 'zod/compile';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,10 @@
+// Run the suite against what actually ships: the entrypoint compiles every zod schema on
+// its first parse (src/index.ts), so the tests do too. Setup files evaluate before the test
+// modules, which is what makes the schemas they build compile — the same ordering constraint
+// the entrypoint has. Deliberate trade-off: nothing here covers the uncompiled path anymore.
+// See docs/decisions/zod-compile.md.
+import 'zod/compile';
+
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { handlers } from './msw-handlers';

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,8 +1,8 @@
-// Run the suite against what actually ships: the entrypoint compiles every zod schema on
-// its first parse (src/index.ts), so the tests do too. Setup files evaluate before the test
-// modules, which is what makes the schemas they build compile — the same ordering constraint
-// the entrypoint has. Deliberate trade-off: nothing here covers the uncompiled path anymore.
-// See docs/decisions/zod-compile.md.
+// Run the suite against what actually ships: the entrypoint compiles zod schemas on their
+// first synchronous parse (src/index.ts), so the tests do too. Setup files evaluate before
+// the test modules, which is what makes the schemas they build compile — the same ordering
+// constraint the entrypoint has. Deliberate trade-off: nothing here covers the uncompiled
+// path anymore. See docs/decisions/zod-compile.md.
 import 'zod/compile';
 
 import { setupServer } from 'msw/node';

--- a/tests/unit/index-compile.test.ts
+++ b/tests/unit/index-compile.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guard for the zod compilation opt-in.
+ *
+ * `import 'zod/compile'` installs a global post-processor that compiles each schema on its
+ * first parse. It only reaches schemas built by modules that evaluate *after* it, so its
+ * position is load-bearing: demote it below any other import in the entrypoint and every
+ * schema constructed by the imported module graph silently keeps the runtime parser.
+ *
+ * Nothing else would catch that. The server keeps working, `tools/list` is unchanged, every
+ * test still passes — the compilation just stops happening, several files away from the
+ * symptom. `src/index.ts` is out of both the coverage scope (`vitest.config.ts`) and the
+ * mutation scope (`stryker.config.mjs`), so this file is the only gate looking at it.
+ * Background: `docs/decisions/zod-compile.md`.
+ */
+
+const SIDE_EFFECT_IMPORT = /^import\s+['"]zod\/compile['"];?$/;
+
+const firstCodeLine = (relative: string): string => {
+  const source = readFileSync(new URL(relative, import.meta.url), 'utf8');
+  const line = source
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l !== '' && !l.startsWith('//') && !l.startsWith('*') && !l.startsWith('/*'));
+  return line ?? '';
+};
+
+describe('zod/compile opt-in', () => {
+  it.each([
+    ['src/index.ts', '../../src/index.ts'],
+    ['tests/setup.ts', '../setup.ts'],
+  ])('%s starts with the zod/compile side-effect import', (label, relative) => {
+    const first = firstCodeLine(relative);
+    expect(
+      SIDE_EFFECT_IMPORT.test(first),
+      `${label} must begin with \`import 'zod/compile';\` (comments aside) — found \`${first}\`. ` +
+        'Schemas built by modules that evaluate before it are never compiled, so moving or ' +
+        'dropping this import silently disables the optimisation. See docs/decisions/zod-compile.md.',
+    ).toBe(true);
+  });
+});

--- a/tests/unit/index-compile.test.ts
+++ b/tests/unit/index-compile.test.ts
@@ -18,13 +18,18 @@ import { describe, expect, it } from 'vitest';
 
 const SIDE_EFFECT_IMPORT = /^import\s+['"]zod\/compile['"];?$/;
 
+// Strip comments before looking for the first statement, so reformatting the header from
+// `//` lines into a `/* … */` block doesn't fail the guard on a correctly placed import.
 const firstCodeLine = (relative: string): string => {
-  const source = readFileSync(new URL(relative, import.meta.url), 'utf8');
-  const line = source
-    .split('\n')
-    .map((l) => l.trim())
-    .find((l) => l !== '' && !l.startsWith('//') && !l.startsWith('*') && !l.startsWith('/*'));
-  return line ?? '';
+  const source = readFileSync(new URL(relative, import.meta.url), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+  return (
+    source
+      .split('\n')
+      .find((l) => l.trim() !== '')
+      ?.trim() ?? ''
+  );
 };
 
 describe('zod/compile opt-in', () => {

--- a/tests/unit/index-compile.test.ts
+++ b/tests/unit/index-compile.test.ts
@@ -16,7 +16,9 @@ import { describe, expect, it } from 'vitest';
  * Background: `docs/decisions/zod-compile.md`.
  */
 
-const SIDE_EFFECT_IMPORT = /^import\s+['"]zod\/compile['"];?$/;
+// A trailing `//` comment on the import line is tolerated: the stripper below only removes
+// whole-line comments, and annotating the import is not the failure this guards against.
+const SIDE_EFFECT_IMPORT = /^import\s+['"]zod\/compile['"];?\s*(?:\/\/.*)?$/;
 
 // Strip comments before looking for the first statement, so reformatting the header from
 // `//` lines into a `/* … */` block doesn't fail the guard on a correctly placed import.

--- a/tests/unit/tools/schema-compile.test.ts
+++ b/tests/unit/tools/schema-compile.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod/v4';
+import { createAllTools, type ToolContext } from '../../../src/tools';
+
+// Every tool's input schema must be compilable by zod's AOT compiler.
+//
+// The compiler is deliberately silent: hand it a schema whose semantics the fast path can't
+// model and it returns the schema unchanged, still on the runtime parser. Parsing stays
+// correct, so nothing fails — the tool just quietly stops being covered by the optimisation
+// the entrypoint opted the whole server into (`import 'zod/compile'`, src/index.ts).
+//
+// `{ strict: true }` turns that silence into a thrown ZodCompileUnsupportedError, which is
+// the only way to notice. A failure here is not "the schema is wrong": it means the schema
+// grew a feature the fast path can't take (an async refinement, a transform it can't model),
+// and the choice is to express the constraint differently or to accept the fallback and say
+// so in docs/decisions/zod-compile.md.
+
+const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
+const tools = createAllTools(ctx);
+
+describe('tool input schemas compile', () => {
+  it('every tool: the strict input schema compiles without falling back', () => {
+    const violations = tools
+      .filter((tool) => {
+        try {
+          // `.strict()` is what actually ships — registered in `all` mode (src/server.ts)
+          // and used by createStrictParamsParser on the proxy path (src/utils/validation.ts).
+          z.compile(tool.inputSchema.strict(), { strict: true });
+          return false;
+        } catch {
+          return true;
+        }
+      })
+      .map((tool) => tool.name);
+
+    expect(
+      violations,
+      `These tools' input schemas fall back to the runtime parser instead of compiling: ` +
+        `${violations.join(', ')}. See docs/decisions/zod-compile.md.`,
+    ).toEqual([]);
+  });
+
+  it('a schema the fast path cannot model is reported, not ignored', () => {
+    // Pins the mechanism the check above relies on: without `{ strict: true }` an
+    // unsupported schema comes back uncompiled and indistinguishable from a compiled one.
+    const asyncRefined = z.object({ id: z.number() }).refine(async () => true);
+
+    expect(() => z.compile(asyncRefined, { strict: true })).toThrow();
+    expect(z.compile(asyncRefined)).toBeDefined();
+  });
+});

--- a/tests/unit/tools/schema-compile.test.ts
+++ b/tests/unit/tools/schema-compile.test.ts
@@ -1,22 +1,33 @@
 import { describe, expect, it } from 'vitest';
 import * as z from 'zod/v4';
 import { createAllTools, type ToolContext } from '../../../src/tools';
+import { createStrictParamsParser } from '../../../src/utils/validation';
 
-// Every tool's input schema must be compilable by zod's AOT compiler.
+// Two things have to hold for `import 'zod/compile'` (src/index.ts) to be worth its line,
+// and both fail silently:
 //
-// The compiler is deliberately silent: hand it a schema whose semantics the fast path can't
-// model and it returns the schema unchanged, still on the runtime parser. Parsing stays
-// correct, so nothing fails — the tool just quietly stops being covered by the optimisation
-// the entrypoint opted the whole server into (`import 'zod/compile'`, src/index.ts).
+//  1. Every tool schema must be *compilable*. Hand the compiler a schema whose semantics
+//     the fast path can't model and it returns it unchanged, still on the runtime parser.
+//     Parsing stays correct, so nothing fails — the tool just stops being covered.
+//     `{ strict: true }` turns that silence into a thrown ZodCompileUnsupportedError.
 //
-// `{ strict: true }` turns that silence into a thrown ZodCompileUnsupportedError, which is
-// the only way to notice. A failure here is not "the schema is wrong": it means the schema
-// grew a feature the fast path can't take (an async refinement, a transform it can't model),
-// and the choice is to express the constraint differently or to accept the fallback and say
-// so in docs/decisions/zod-compile.md.
+//  2. The path that actually runs must be the *synchronous* one. The global shim bypasses
+//     the fast path entirely for async parses, and never compiles the schema at all — so a
+//     switch from `safeParse` to `safeParseAsync` anywhere in our own code would disable
+//     compilation there with no other symptom. That is not hypothetical: it is exactly why
+//     the MCP SDK's own tool-argument validation (`safeParseAsync`) is never compiled.
+//     See docs/decisions/zod-compile.md.
 
 const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
 const tools = createAllTools(ctx);
+
+// The shim records `bag.fallbackRun` when (and only when) it has installed a compiled fast
+// path on the instance. Reaching into `_zod` is the only way to observe compilation —
+// nothing about it is visible in the parse result, which is the whole problem.
+const isCompiled = (schema: z.ZodType): boolean =>
+  Boolean(
+    (schema as unknown as { _zod?: { bag?: { fallbackRun?: unknown } } })._zod?.bag?.fallbackRun,
+  );
 
 describe('tool input schemas compile', () => {
   it('every tool: the strict input schema compiles without falling back', () => {
@@ -24,7 +35,7 @@ describe('tool input schemas compile', () => {
       .filter((tool) => {
         try {
           // `.strict()` is what actually ships — registered in `all` mode (src/server.ts)
-          // and used by createStrictParamsParser on the proxy path (src/utils/validation.ts).
+          // and re-derived by createStrictParamsParser on the proxy path.
           z.compile(tool.inputSchema.strict(), { strict: true });
           return false;
         } catch {
@@ -40,9 +51,42 @@ describe('tool input schemas compile', () => {
     ).toEqual([]);
   });
 
+  it('the proxy dispatch path really compiles, it does not merely could-compile', () => {
+    // The default mode (namespace/single) validates params through this parser, so this is
+    // the one tool-schema parse in the server that the compiler actually reaches.
+    const tool = tools.find((t) => t.name === 'get_ticket');
+    if (!tool) throw new Error('get_ticket is gone — repoint this test at another read tool');
+
+    const schema = tool.inputSchema.strict();
+    expect(isCompiled(schema), 'a freshly built schema is not compiled until first parsed').toBe(
+      false,
+    );
+
+    createStrictParamsParser(tool.inputSchema)({ ticket_id: 1 });
+    schema.safeParse({ ticket_id: 1 });
+
+    expect(
+      isCompiled(schema),
+      'a synchronous safeParse must leave the schema compiled. If this fails, either the ' +
+        'parse moved to safeParseAsync (which the shim never compiles) or zod changed how ' +
+        'the global post-processor installs the fast path. See docs/decisions/zod-compile.md.',
+    ).toBe(true);
+  });
+
+  it('an async parse is never compiled — the limitation this rests on', () => {
+    // Pins the mechanism behind the SDK caveat in the decision doc: the shim returns the
+    // runtime parser for async calls without ever compiling, so async-only schemas stay
+    // uncompiled forever. If this ever starts passing as compiled, that caveat is stale.
+    const schema = z.object({ id: z.number() });
+
+    return schema.safeParseAsync({ id: 1 }).then(() => {
+      expect(isCompiled(schema)).toBe(false);
+    });
+  });
+
   it('a schema the fast path cannot model is reported, not ignored', () => {
-    // Pins the mechanism the check above relies on: without `{ strict: true }` an
-    // unsupported schema comes back uncompiled and indistinguishable from a compiled one.
+    // Without `{ strict: true }` an unsupported schema comes back uncompiled and
+    // indistinguishable from a compiled one — which is what makes the first test necessary.
     const asyncRefined = z.object({ id: z.number() }).refine(async () => true);
 
     expect(() => z.compile(asyncRefined, { strict: true })).toThrow();

--- a/tests/unit/tools/schema-compile.test.ts
+++ b/tests/unit/tools/schema-compile.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as z from 'zod/v4';
 import { createAllTools, type ToolContext } from '../../../src/tools';
 import { createStrictParamsParser } from '../../../src/utils/validation';
@@ -57,19 +57,30 @@ describe('tool input schemas compile', () => {
     const tool = tools.find((t) => t.name === 'get_ticket');
     if (!tool) throw new Error('get_ticket is gone — repoint this test at another read tool');
 
-    const schema = tool.inputSchema.strict();
-    expect(isCompiled(schema), 'a freshly built schema is not compiled until first parsed').toBe(
-      false,
-    );
-
-    createStrictParamsParser(tool.inputSchema)({ ticket_id: 1 });
-    schema.safeParse({ ticket_id: 1 });
+    // `.strict()` clones, so the parser holds a schema instance nobody else can reach.
+    // Asserting on a clone of our own would pass even if the parser went async; spying on
+    // the call the parser itself makes is the narrowest way to get *its* instance.
+    const strictSpy = vi.spyOn(tool.inputSchema, 'strict');
+    const parse = createStrictParamsParser(tool.inputSchema);
+    const parserSchema = strictSpy.mock.results[0]?.value as z.ZodType | undefined;
+    strictSpy.mockRestore();
 
     expect(
-      isCompiled(schema),
-      'a synchronous safeParse must leave the schema compiled. If this fails, either the ' +
-        'parse moved to safeParseAsync (which the shim never compiles) or zod changed how ' +
-        'the global post-processor installs the fast path. See docs/decisions/zod-compile.md.',
+      parserSchema,
+      'createStrictParamsParser no longer derives its schema via .strict()',
+    ).toBeDefined();
+    expect(
+      isCompiled(parserSchema as z.ZodType),
+      'the parser schema is not compiled until it first parses something',
+    ).toBe(false);
+
+    parse({ ticket_id: 1 });
+
+    expect(
+      isCompiled(parserSchema as z.ZodType),
+      'the proxy parser must leave its schema compiled. If this fails, either that parse ' +
+        'moved to safeParseAsync (which the shim never compiles) or zod changed how the ' +
+        'global post-processor installs the fast path. See docs/decisions/zod-compile.md.',
     ).toBe(true);
   });
 

--- a/tests/unit/tools/schema-compile.test.ts
+++ b/tests/unit/tools/schema-compile.test.ts
@@ -101,6 +101,10 @@ describe('tool input schemas compile', () => {
     const asyncRefined = z.object({ id: z.number() }).refine(async () => true);
 
     expect(() => z.compile(asyncRefined, { strict: true })).toThrow();
-    expect(z.compile(asyncRefined)).toBeDefined();
+    // The non-strict call cannot fail: it hands back the *same instance*, still on the
+    // runtime parser. Asserting only that it returns something would pass no matter what
+    // zod did here, so pin both halves of the silence.
+    expect(z.compile(asyncRefined)).toBe(asyncRefined);
+    expect(isCompiled(asyncRefined)).toBe(false);
   });
 });

--- a/tests/unit/zod-jitless.test.ts
+++ b/tests/unit/zod-jitless.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import * as z from 'zod/v4';
+import { createAllTools, type ToolContext } from '../../src/tools';
+import { createStrictParamsParser } from '../../src/utils/validation';
+
+/**
+ * The uncompiled path, which the rest of the suite no longer exercises.
+ *
+ * `tests/setup.ts` opts the whole suite into `zod/compile`, matching what ships. That leaves
+ * zod's own escape hatch untested: `z.config({ jitless: true })` is how a runtime without
+ * `new Function()` (a CSP-restricted host) stands the compiler down, and the shim honours it
+ * by permanently restoring the runtime parser. `docs/decisions/zod-compile.md` states that
+ * this degrades gracefully — nothing but this file backs that claim.
+ *
+ * Vitest isolates test files in their own workers, so flipping the global config here does
+ * not reach any other file; `afterAll` restores it regardless.
+ */
+
+z.config({ jitless: true });
+afterAll(() => z.config({ jitless: false }));
+
+const ctx: ToolContext = { subdomain: 'testsubdomain', getToken: () => 'test-token' };
+
+const isCompiled = (schema: z.ZodType): boolean =>
+  Boolean(
+    (schema as unknown as { _zod?: { bag?: { fallbackRun?: unknown } } })._zod?.bag?.fallbackRun,
+  );
+
+describe('jitless: the server behaves identically with compilation stood down', () => {
+  const tools = createAllTools(ctx);
+  const getTicket = tools.find((t) => t.name === 'get_ticket');
+  if (!getTicket) throw new Error('get_ticket is gone — repoint this test at another read tool');
+
+  it('no schema is compiled', () => {
+    const schema = getTicket.inputSchema.strict();
+    schema.safeParse({ ticket_id: 1 });
+    expect(isCompiled(schema)).toBe(false);
+  });
+
+  it('valid params still parse, and defaults still apply', () => {
+    const parse = createStrictParamsParser(getTicket.inputSchema);
+    expect(parse({ ticket_id: 1 })).toEqual({ ticket_id: 1, include_comments: false });
+  });
+
+  it('an unknown parameter still fails with the exact same message', () => {
+    const parse = createStrictParamsParser(getTicket.inputSchema);
+    // Byte-identical to what the compiled path produces (tests/unit/utils/validation.test.ts
+    // asserts the same wording) — a client cannot tell the two runtimes apart.
+    expect(() => parse({ ticket_id: 1, per_page: 10 })).toThrow(
+      /^Unknown parameter\(s\): per_page\. Valid parameters: /,
+    );
+  });
+
+  it('the exposed JSON Schema is unaffected', () => {
+    // toJSONSchema reads the schema definition, never the parse path, so a jitless host
+    // advertises the same tool surface. Asserted structurally rather than as a snapshot:
+    // the descriptions are load-bearing elsewhere (docs/mcp-metadata.md, the tool-quality
+    // gate) and re-pinning their prose here would break this test on every wording edit.
+    const json = z.toJSONSchema(getTicket.inputSchema.strict()) as {
+      type: string;
+      additionalProperties: boolean;
+      required: string[];
+      properties: Record<string, { type?: string; description?: string }>;
+    };
+
+    expect(json.type).toBe('object');
+    expect(json.additionalProperties).toBe(false);
+    const byName = (a: string, b: string) => a.localeCompare(b);
+    expect(Object.keys(json.properties).sort(byName)).toEqual(['include_comments', 'ticket_id']);
+    expect([...json.required].sort(byName)).toEqual(['include_comments', 'ticket_id']);
+    expect(json.properties.ticket_id?.type).toBe('integer');
+    expect(json.properties.include_comments?.type).toBe('boolean');
+    for (const [name, prop] of Object.entries(json.properties)) {
+      expect(prop.description, `${name} lost its description`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Opts the server into zod 4.5's AOT schema compiler with a single side-effect import at the top of `src/index.ts`: schemas built afterwards compile themselves on their first **synchronous** parse, with no call site changes and no schema opting in. The parses it reaches get 1.9–7.2x cheaper; end to end that is ~2 µs against a 100–500 ms Zendesk round-trip, i.e. **nothing a user can see**. Adopted because it costs nothing, not because it fixes a performance problem — [`docs/decisions/zod-compile.md`](https://github.com/fruggr/zendesk-mcp-server/blob/claude/zod-type-compilation-study-fuvchc/docs/decisions/zod-compile.md) says so explicitly, so nobody later mistakes it for one.

## Linked issue

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no external behavior change)
- [x] Documentation
- [x] Tooling / CI — plus a runtime dependency bump (`zod` `4.4.3` → `4.5.4`)

## Which parses it actually reaches

Not all of them, and the difference is invisible from the outside. The global shim bypasses the fast path for any **asynchronous** parse — and does not compile the schema at all while doing so. Probed on a live server over `InMemoryTransport`, one real `tools/call` per mode:

| Parse | Compiled? |
| --- | --- |
| Every JSON-RPC message — `JSONRPCMessageSchema.parse`, synchronous in stdio, SSE and streamable HTTP alike | **yes** |
| `createStrictParamsParser`'s params parse (`src/utils/validation.ts`) — the proxy path, i.e. the default `namespace` / `single` modes | **yes** |
| `ConfigSchema.parse` at startup | yes, once |
| The SDK's tool-argument validation — the registered schema in `all` mode, the proxy's `{operation, params}` schema in the others | **no**: `mcp.js` uses `safeParseAsync` |

So in `all` mode no tool input schema is ever compiled. Nothing can be done about that from here — `compile()` is forward-and-synchronous by construction and the `safeParseAsync` choice is the SDK's — so it is documented and pinned by a test instead.

## What was measured

Repo's own schemas and SDK version, Node 22, 200k iterations after warm-up. Every row is a synchronous parse; the tool-input rows are the proxy params path.

| Path | Runtime parser | Compiled | Ratio |
| --- | --- | --- | --- |
| `search_tickets` input, valid | 0.31 µs | 0.12 µs | 2.6x |
| `update_ticket` input, valid | 0.35 µs | 0.12 µs | 2.9x |
| `list_articles` input, valid | 0.54 µs | 0.25 µs | 2.2x |
| `get_article` input, valid | 0.17 µs | 0.09 µs | 1.9x |
| `search_tickets` input, **rejected** (unknown key) | 2.78 µs | 3.21 µs | **0.87x — slower** |
| SDK `JSONRPCMessageSchema`, request | 0.69 µs | 0.28 µs | 2.5x |
| SDK `JSONRPCMessageSchema`, response | 1.37 µs | 0.19 µs | 7.2x |

Costs: compiling a tool schema is mean 0.62 ms / median 0.27 ms / worst `update_ticket` 1.31 ms, paid only for the tools a session actually calls, and only where compilation happens at all; the first JSON-RPC message of a process goes 2.5 ms → 6.7 ms, every message after 0.13 ms → 0.02 ms. `dist/index.js` 242.03 kB → 242.05 kB — zod is external, so the blog's "+7 kB gzipped" does not apply here.

Two caveats, both documented rather than glossed: the **error path is not accelerated and is marginally slower** (it pays for the fast path, then falls back to build its issues), and the HTTP transport builds a **per-session** `McpServer`, so each session recompiles the tool schemas it touches and never reaches the ~1350 parses needed to break even. What stays positive everywhere is the protocol schemas: compiled once per process, hit by every message.

## Why the bump rides along

`z.compile` needs zod ≥ 4.5.0, so the pin move is a prerequisite of this change rather than an unrelated cleanup. This supersedes #263 (Renovate, same target version) — that PR should auto-close once this lands.

## Functional validation plan

**None — the exemption is claimed deliberately, and the repository owner made that call.** Stating it plainly rather than leaving a box unticked: no third-party validation pass was authored or run for this PR. The reasoning, and the evidence it rests on:

`AGENTS.md` requires the plan for changes to *MCP-runtime-observable* behaviour. Here that is not asserted, it is demonstrated:

- `tools/list` across all three modes (`all` / `namespace` / `single`, 128 kB of JSON) diffs **identical byte for byte** with and without compilation — boot `createMcpServer` over `InMemoryTransport` per mode, dump `listTools()`, diff.
- `z.toJSONSchema()` output identical; the SDK's `-32602` text unchanged.
- `unrecognized_keys` issues reach `createStrictParamsParser` verbatim, so the "Unknown parameter(s): …" message is untouched.
- `tests/setup.ts` carries the same import, so the whole suite runs against compiled schemas — what actually ships. The uncompiled (`jitless`) path is covered separately by `tests/unit/zod-jitless.test.ts`.

CodeRabbit's pre-merge check disagrees with this reading and wants the section filled in regardless. Recorded here rather than argued away; the owner can overrule and a plan will be authored and executed. Timing is the one client-observable dimension that does move — by microseconds, in the direction of faster, except the error path noted above.

## Author checklist

- [x] I checked no open or merged PR already addresses this — #263 (Renovate, same zod bump) is superseded and named above
- [ ] Closing keyword — N/A, no linked issue
- [x] `pnpm test` passes locally (1013 passed)
- [x] `pnpm test:coverage` meets the thresholds (98.1% statements)
- [x] `pnpm check` is clean
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings (twice — see *Review rounds*)
- [x] Documentation is updated where needed
- [ ] Adds an MCP tool — N/A, the tool surface is unchanged
- [ ] Functional validation plan — deliberately waived, see the section above

Also run, beyond the checklist: `pnpm build`, `node scripts/smoke-test.mjs` (stdio + http), and `pnpm test:mutation:diff origin/main HEAD` (reports no changed lines in the mutate scope, as expected for a diff touching only `src/index.ts`, tests and docs).

## Notes for the reviewer

**Three guards, because every failure mode here is silent.** `tests/unit/index-compile.test.ts` pins the import's *position* — demote it below any other import and compilation stops with nothing failing, and `src/index.ts` is outside both the coverage and the mutation scope, so nothing else is looking. `tests/unit/tools/schema-compile.test.ts` compiles every tool's `.strict()` schema under `{ strict: true }` (turning the compiler's silent "return it uncompiled" fallback into an error; all 53 compile today) **and** asserts, on the instance the proxy parser itself holds, that a synchronous parse leaves it compiled while an async one does not — so a `safeParse` → `safeParseAsync` change in our own code cannot silently disable this. `tests/unit/zod-jitless.test.ts` covers the `z.config({ jitless: true })` degradation the decision doc promises: nothing compiles, and params, defaults, the error message and the JSON Schema come out the same.

**Review rounds.**

1. The author-side AI review (`CONTRIBUTING.md` §Author-side AI review) caught an over-broad claim — the first draft said "every schema compiles on first parse", false for the SDK's async validation path — fixed in `b96570b` with a `firstCodeLine` block-comment bug.
2. CodeRabbit found that the proxy guard asserted on the wrong `.strict()` clone (they do differ per call in 4.5.4, verified) and that the jitless path was uncovered; both fixed in `9761848`, both threads confirmed and resolved.
3. A second author-side pass found two guards that could not fail — a tautological `toBeDefined()`, and a matcher that would have rejected a correctly placed import carrying a trailing `//` comment; both fixed in `aedc857`. That pass also re-verified the load-bearing claims independently: the import survives bundling as line 2 of `dist/index.js`, the SDK resolves to the same single `zod@4.5.4` instance the entrypoint patches, and `z.config({ jitless: true })` cannot leak between test files (vitest isolates, and the Stryker runner does not disable that).
4. Owner nitpicks: the nine-line header on the import and the `AGENTS.md` paragraph both restated the decision doc — trimmed to the one rule that has to be obeyed at the import, and removed from `AGENTS.md`, in `9d7c63c`.

The branch is up to date with `main` as of `d445638` (#274 biome, #275 tsdown), merged in rather than rebased.

https://claude.ai/code/session_01N2gngNxVh3twhym7iXBCcW