### PR TITLE
feat(auth): request the read scope alone under --read-only

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,32 +1,6 @@
-# Worktrunk (wt) project hooks — shared with the team, checked into git.
-#
-# Goal: on every worktree switch *and* creation, bring the branch up to date
-# and (re)install dependencies.
-#
-# About node_modules: git worktrees never share or copy untracked/ignored
-# files, and `node_modules` is gitignored — so it is never copied between
-# worktrees. Each worktree gets a clean `pnpm install` instead. Do NOT add
-# `wt step copy-ignored` for node_modules; a fresh install is the intended
-# behaviour here.
-#
-# Why post-switch: it fires on all switch results — creating a new worktree,
-# switching to an existing one, and staying on the current branch — so a single
-# hook covers both "changement" and "création". It runs in the background;
-# follow progress with `wt config state logs`.
-#
-# The two [[post-switch]] blocks form a pipeline: step 1 runs, then step 2.
-# This guarantees the install always reflects the freshly pulled lockfile
-# (a single [post-switch] table would run both steps concurrently).
-
-# Step 1 — sync the branch with its remote.
-# Brand-new branches have no upstream yet, so guard the pull to avoid an error
-# (the command renders empty and is skipped when {{ upstream }} is unset).
-# --ff-only keeps it safe: it never creates a surprise merge commit during an
-# automated switch — it just no-ops if the branch has diverged. Swap for
-# `git pull --rebase` or a plain `git pull` if you want different behaviour.
 [[post-switch]]
 sync = "{% if upstream %}git pull --ff-only{% endif %}"
+deps = "pnpm install"
 
-# Step 2 — install dependencies in the destination worktree.
-[[post-switch]]
+[[pre-start]]
 deps = "pnpm install"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Signing in needs a Zendesk OAuth client, so register one first (next section).
      `ZENDESK_OAUTH_CALLBACK_PORT` / `--callback-port` if you override it; Zendesk
      accepts several redirect URLs, one per line)
 
+If the client restricts its **allowed scopes**, it needs `read` — plus `write`
+unless the server runs with [`--read-only`](docs/configuration.md), which asks
+Zendesk for the `read` scope alone.
+
 On the first tool call the server starts the sign-in flow: it opens a browser
 window and returns the authorize URL in a tool message. The call does not block
 waiting for sign-in, so authenticate in the browser and then retry the request.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,8 @@ Options:
   --mode <mode>           single | namespace (default) | all
   --namespace <ns>        Filter by namespace (repeatable): tickets, help_center, users
   --tool <name>           Filter by tool name (repeatable, forces --mode all)
-  --read-only             Only expose read operations
+  --read-only             Only expose read operations, and request the
+                          `read` OAuth scope alone
   --no-topology           Disable the Help Center structural context
                           (instructions + zendesk-hc://topology resource)
   --no-promoted-articles  Disable the promoted-article PRE-LISTING (the
@@ -47,6 +48,8 @@ Options:
 ```
 
 `--namespace` and `--read-only` are applied before the proxies are registered, so they narrow the surface in every mode. In the default `namespace` mode, `--namespace help_center` registers a single proxy (`zendesk_help_center`) instead of the full set of namespace proxies.
+
+`--read-only` also narrows the OAuth scope the server asks Zendesk for, from `read write` down to `read`, so it works with an OAuth client whose allowed scopes stop at `read` (and in HTTP mode the advertised `scopes_supported` follows the same rule). What it does *not* do is revoke a grant you already have: a broader token found in the [token cache](#zendesk_token_file) is still used as-is. Dropping the flag on a server whose cached token is `read`-only costs one browser sign-in, because OAuth cannot widen a grant on refresh.
 
 ### A malformed invocation fails at startup
 

--- a/docs/http-deployment.md
+++ b/docs/http-deployment.md
@@ -54,6 +54,12 @@ curl -s http://localhost:3000/.well-known/oauth-authorization-server
 curl -s -i http://localhost:3000/healthz   # → 200 OK
 ```
 
+Both documents carry `scopes_supported`, and both follow `--read-only`:
+`["read", "write"]` normally, `["read"]` on a read-only server. It is advice to
+the client, not a control — the server never inspects the grant behind the
+bearer it is presented, so a bearer minted with `read` alone will simply get
+`403` from Zendesk on any write.
+
 ## MCP client wiring
 
 Every major MCP client supports remote servers over Streamable HTTP and handles the OAuth 2.1 PKCE discovery flow natively: paste the URL, sign in once, you're connected. Replace `https://mcp.example.com` below with your deployed origin.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,6 +63,22 @@ so (and logs `oauth_callback_listen_failed`). Pick a free port with
 the matching `http://localhost:<port>/callback` redirect URL in your Zendesk
 OAuth client.
 
+## Sign-in fails with `invalid_scope`
+
+The Zendesk OAuth client restricts its **allowed scopes** and the server asked
+for one it does not permit. Without `--read-only` the server requests
+`read write`; a client whose allowed scopes stop at `read` rejects that outright
+and mints no token at all. Either allow `write` on the client, or run the server
+with [`--read-only`](configuration.md), which requests `read` alone.
+
+## I am asked to sign in again after dropping `--read-only`
+
+Expected, once. The cached token was granted the `read` scope, the server now
+needs `write`, and OAuth cannot widen an existing grant — a refresh only ever
+returns what was already granted. Sign in once and the new, broader token is
+cached in its place. The reverse direction costs nothing: adding `--read-only`
+keeps using a `read write` token you already have.
+
 ## I have to re-authenticate every time
 
 The OAuth token is persisted to an owner-only (`0600`) file in your OS config

--- a/src/auth/browser-oauth.ts
+++ b/src/auth/browser-oauth.ts
@@ -5,6 +5,7 @@ import { release } from 'node:os';
 import open from 'open';
 import { DEFAULT_CALLBACK_PORT, getOAuthUrls } from '../constants';
 import { type Logger, silentLogger } from '../utils/logger';
+import { requestedScope } from './oauth-scopes';
 
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -22,13 +23,17 @@ interface BrowserOAuthConfig {
   subdomain: string;
   oauthClientId: string;
   callbackPort?: number | undefined;
+  // Required, not optional: the "forgot to thread it through" default would
+  // otherwise be requesting `write`, which is the dangerous direction.
+  readOnly: boolean;
 }
 
 interface TokenResult {
   access_token: string;
   refresh_token?: string;
   token_type: string;
-  scope: string;
+  // Omitted when identical to what was requested (RFC 6749 5.1).
+  scope?: string;
   // Present only when the Zendesk OAuth client has token expiration enabled.
   // Seconds until the access/refresh token expires.
   expires_in?: number;
@@ -123,7 +128,7 @@ export const startBrowserAuth = (
   config: BrowserOAuthConfig,
   logger: Logger = silentLogger,
 ): Promise<StartedBrowserAuth> => {
-  const { subdomain, oauthClientId } = config;
+  const { subdomain, oauthClientId, readOnly } = config;
   const { authorizeUrl: authorizeBase, tokenUrl } = getOAuthUrls(subdomain);
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = generateCodeChallenge(codeVerifier);
@@ -271,7 +276,7 @@ export const startBrowserAuth = (
         response_type: 'code',
         client_id: oauthClientId,
         redirect_uri: redirectUri,
-        scope: 'read write',
+        scope: requestedScope(readOnly),
         code_challenge: codeChallenge,
         code_challenge_method: 'S256',
       });

--- a/src/auth/oauth-scopes.ts
+++ b/src/auth/oauth-scopes.ts
@@ -33,6 +33,9 @@ export const requestedScope = (readOnly: boolean): string =>
 export const supportedScopes = (readOnly: boolean): string[] => requestedScope(readOnly).split(' ');
 
 // Hoisted: the predicate below runs on every token read.
+// Stryker disable next-line Regex: the empty-token filter below makes `/\s/`
+// and `/\s+/` produce identical output, so the quantifier is clarity, not
+// behaviour, and no test can tell the two apart.
 const WHITESPACE = /\s+/;
 
 const scopeTokens = (scope: string): string[] =>

--- a/src/auth/oauth-scopes.ts
+++ b/src/auth/oauth-scopes.ts
@@ -43,27 +43,10 @@ export const supportedScopes = (readOnly: boolean): string[] =>
   scopeTokens(requestedScope(readOnly));
 
 /**
- * Whether a token granted `granted` may still be used to serve a request for
- * `requested` — a flat "every requested token is present" subset test.
- *
- * Coverage rather than equality, because one token file is shared by every
- * server on this subdomain: a write-mode server re-authenticates once and
- * upgrades the record, after which a read-only sibling accepts it. An equality
- * check would make the two re-authenticate in turn, forever.
- *
- * A `granted` that is not a string means the record predates scope tracking.
- * That is not a guess: `read write` is the only scope this server has ever
- * requested, so any record written by any released version carries that grant —
- * hence `true`, and nobody is pushed through a sign-in on upgrade. The
- * `typeof` (rather than an `undefined` check) also absorbs a hand-edited
- * `"scope": null`, which `loadToken` would otherwise pass through unvalidated.
- *
- * What this deliberately does NOT model is Zendesk's scope hierarchy: a
- * granular grant such as `tickets:read` is judged not to cover a `read`
- * request, and vice versa. Both misjudgements only ever cost one extra
- * interactive sign-in, and neither is reachable while `read` and `read write`
- * are the only scopes requested. Granular scopes (#284) must replace this
- * predicate rather than extend it.
+ * Whether a grant still covers what this process needs: a flat subset test.
+ * Coverage, not equality, so a broader token stays usable and two servers
+ * sharing a token file converge. A non-string `granted` is a pre-#283 record,
+ * i.e. `read write`. No scope hierarchy: granular scopes (#284) replace this.
  */
 export const grantCovers = (granted: string | undefined, requested: string): boolean => {
   if (typeof granted !== 'string') return true;

--- a/src/auth/oauth-scopes.ts
+++ b/src/auth/oauth-scopes.ts
@@ -1,0 +1,68 @@
+/**
+ * The OAuth scope the server asks Zendesk for, and the one predicate that
+ * decides whether a cached token's grant is still good enough.
+ *
+ * Both scope strings live here rather than in `constants.ts` on purpose: they
+ * are behavioural strings whose mutants must be killed by assertions
+ * (`docs/decisions/mutation-testing.md`, "OAuth parameters and scopes"), and
+ * `src/auth/**` is inside the mutation scope while `constants.ts` is not.
+ * Keeping them next to the predicate that consumes them keeps both under the
+ * same gate.
+ */
+
+// Zendesk's two global scopes: `read` covers every GET endpoint (sideloads
+// included), `write` adds POST/PUT/DELETE.
+const READ_SCOPE = 'read';
+const READ_WRITE_SCOPE = 'read write';
+
+/**
+ * The scope to request for a given tool surface. `--read-only` already filters
+ * every write tool out of the surface, so asking Zendesk for `write` on top of
+ * that would be requesting an authority the server cannot even exercise — and
+ * an OAuth client whose allowed scopes stop at `read` rejects the whole
+ * authorize request with `invalid_scope`, minting no token at all (#283).
+ */
+export const requestedScope = (readOnly: boolean): string =>
+  readOnly ? READ_SCOPE : READ_WRITE_SCOPE;
+
+/**
+ * The same decision as a list, for the RFC 9728 / RFC 8414 `scopes_supported`
+ * metadata. Derived from `requestedScope` so what the HTTP transport advertises
+ * provably cannot drift from what the stdio flow requests.
+ */
+export const supportedScopes = (readOnly: boolean): string[] => requestedScope(readOnly).split(' ');
+
+// Hoisted: the predicate below runs on every token read.
+const WHITESPACE = /\s+/;
+
+const scopeTokens = (scope: string): string[] =>
+  scope.split(WHITESPACE).filter((s) => s.length > 0);
+
+/**
+ * Whether a token granted `granted` may still be used to serve a request for
+ * `requested` — a flat "every requested token is present" subset test.
+ *
+ * Coverage rather than equality, because one token file is shared by every
+ * server on this subdomain: a write-mode server re-authenticates once and
+ * upgrades the record, after which a read-only sibling accepts it. An equality
+ * check would make the two re-authenticate in turn, forever.
+ *
+ * A `granted` that is not a string means the record predates scope tracking.
+ * That is not a guess: `read write` is the only scope this server has ever
+ * requested, so any record written by any released version carries that grant —
+ * hence `true`, and nobody is pushed through a sign-in on upgrade. The
+ * `typeof` (rather than an `undefined` check) also absorbs a hand-edited
+ * `"scope": null`, which `loadToken` would otherwise pass through unvalidated.
+ *
+ * What this deliberately does NOT model is Zendesk's scope hierarchy: a
+ * granular grant such as `tickets:read` is judged not to cover a `read`
+ * request, and vice versa. Both misjudgements only ever cost one extra
+ * interactive sign-in, and neither is reachable while `read` and `read write`
+ * are the only scopes requested. Granular scopes (#284) must replace this
+ * predicate rather than extend it.
+ */
+export const grantCovers = (granted: string | undefined, requested: string): boolean => {
+  if (typeof granted !== 'string') return true;
+  const held = new Set(scopeTokens(granted));
+  return scopeTokens(requested).every((token) => held.has(token));
+};

--- a/src/auth/oauth-scopes.ts
+++ b/src/auth/oauth-scopes.ts
@@ -15,6 +15,15 @@
 const READ_SCOPE = 'read';
 const READ_WRITE_SCOPE = 'read write';
 
+// Hoisted: the predicate below runs on every token read.
+// Stryker disable next-line Regex: the empty-token filter below makes `/\s/`
+// and `/\s+/` produce identical output, so the quantifier is clarity, not
+// behaviour, and no test can tell the two apart.
+const WHITESPACE = /\s+/;
+
+const scopeTokens = (scope: string): string[] =>
+  scope.split(WHITESPACE).filter((s) => s.length > 0);
+
 /**
  * The scope to request for a given tool surface. `--read-only` already filters
  * every write tool out of the surface, so asking Zendesk for `write` on top of
@@ -30,16 +39,8 @@ export const requestedScope = (readOnly: boolean): string =>
  * metadata. Derived from `requestedScope` so what the HTTP transport advertises
  * provably cannot drift from what the stdio flow requests.
  */
-export const supportedScopes = (readOnly: boolean): string[] => requestedScope(readOnly).split(' ');
-
-// Hoisted: the predicate below runs on every token read.
-// Stryker disable next-line Regex: the empty-token filter below makes `/\s/`
-// and `/\s+/` produce identical output, so the quantifier is clarity, not
-// behaviour, and no test can tell the two apart.
-const WHITESPACE = /\s+/;
-
-const scopeTokens = (scope: string): string[] =>
-  scope.split(WHITESPACE).filter((s) => s.length > 0);
+export const supportedScopes = (readOnly: boolean): string[] =>
+  scopeTokens(requestedScope(readOnly));
 
 /**
  * Whether a token granted `granted` may still be used to serve a request for

--- a/src/auth/token-persistence.ts
+++ b/src/auth/token-persistence.ts
@@ -13,6 +13,10 @@ export interface PersistedToken {
   accessToken: string;
   refreshToken?: string | undefined;
   expiresAt?: number | undefined;
+  // The scope Zendesk *granted*, as reported by the token response. Absent on a
+  // record written before the server tracked grants -- which means `read write`,
+  // the only scope it ever requested back then (see grantCovers).
+  scope?: string | undefined;
 }
 
 const isWindows = process.platform === 'win32';

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -63,27 +63,29 @@ export const createTokenStore = (
   // Seed the in-memory cache from disk so a restart (notably the Cowork-on-Windows
   // process churn) reuses the existing token instead of re-prompting.
   let token: StoredToken | undefined = loadToken(tokenPath);
-  if (token && !grantCovers(token.scope, requested)) {
-    // The disk record was minted for a narrower surface (typically: this server
-    // dropped `--read-only` since). A refresh cannot widen a grant, so the only
-    // way out is a fresh authorization -- which the empty cache below triggers
-    // on the first tool call.
-    //
-    // Checked here and nowhere else, on purpose. A freshly minted token is the
-    // best this client can obtain: refusing it would open a browser window on
-    // every single tool call, forever, where the pre-#283 behaviour merely got
-    // a 403 on writes. A refreshed one cannot have widened either, and dropping
-    // it would rotate Zendesk's single-use refresh token for nothing. Both are
-    // served, and the next start re-decides from the record on disk.
-    //
-    // The drop is memory-only, never `clearPersistedToken`: one token file
-    // serves every process on this subdomain, so a record this server refuses
-    // may be exactly right for a read-only sibling -- and a successful sign-in
-    // overwrites the file regardless.
-    logger.warn('oauth_token_scope_insufficient', { requested, granted: token.scope });
-    token = undefined;
-  } else if (token) {
-    logger.debug('oauth_token_loaded_from_disk');
+  if (token) {
+    if (grantCovers(token.scope, requested)) {
+      logger.debug('oauth_token_loaded_from_disk');
+    } else {
+      // The disk record was minted for a narrower surface (typically: this server
+      // dropped `--read-only` since). A refresh cannot widen a grant, so the only
+      // way out is a fresh authorization -- which the empty cache below triggers
+      // on the first tool call.
+      //
+      // Checked here and nowhere else, on purpose. A freshly minted token is the
+      // best this client can obtain: refusing it would open a browser window on
+      // every single tool call, forever, where the pre-#283 behaviour merely got
+      // a 403 on writes. A refreshed one cannot have widened either, and dropping
+      // it would rotate Zendesk's single-use refresh token for nothing. Both are
+      // served, and the next start re-decides from the record on disk.
+      //
+      // The drop is memory-only, never `clearPersistedToken`: one token file
+      // serves every process on this subdomain, so a record this server refuses
+      // may be exactly right for a read-only sibling -- and a successful sign-in
+      // overwrites the file regardless.
+      logger.warn('oauth_token_scope_insufficient', { requested, granted: token.scope });
+      token = undefined;
+    }
   }
 
   // The authorize URL of the in-flight flow (set once the callback server is

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -67,22 +67,10 @@ export const createTokenStore = (
     if (grantCovers(token.scope, requested)) {
       logger.debug('oauth_token_loaded_from_disk');
     } else {
-      // The disk record was minted for a narrower surface (typically: this server
-      // dropped `--read-only` since). A refresh cannot widen a grant, so the only
-      // way out is a fresh authorization -- which the empty cache below triggers
-      // on the first tool call.
-      //
-      // Checked here and nowhere else, on purpose. A freshly minted token is the
-      // best this client can obtain: refusing it would open a browser window on
-      // every single tool call, forever, where the pre-#283 behaviour merely got
-      // a 403 on writes. A refreshed one cannot have widened either, and dropping
-      // it would rotate Zendesk's single-use refresh token for nothing. Both are
-      // served, and the next start re-decides from the record on disk.
-      //
-      // The drop is memory-only, never `clearPersistedToken`: one token file
-      // serves every process on this subdomain, so a record this server refuses
-      // may be exactly right for a read-only sibling -- and a successful sign-in
-      // overwrites the file regardless.
+      // Minted for a narrower surface (this server dropped `--read-only`
+      // since), and a refresh cannot widen a grant, so the empty cache sends
+      // the first call through a sign-in. Checked here only: a minted token is
+      // the best we can get. Memory-only -- a sibling may still need the record.
       logger.warn('oauth_token_scope_insufficient', { requested, granted: token.scope });
       token = undefined;
     }

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -114,6 +114,19 @@ export const createTokenStore = (
       ? Date.now() >= t.expiresAt - EXPIRY_SKEW_MS
       : t.refreshToken !== undefined && !probedUnknownExpiry;
 
+  // Records a grant on its way into the cache, warning when it falls short of
+  // what this process asked for. The token is still served: a new authorization
+  // would return the same narrow grant, so refusing it would re-prompt forever.
+  // Zendesk rejects an out-of-allowance scope outright (`invalid_scope`, no
+  // token), so this is a guard against an RFC-legal downgrade we have not seen,
+  // whose only other symptom would be unexplained 403s on writes.
+  const noteGrant = (granted: string | undefined): string | undefined => {
+    if (!grantCovers(granted, requested)) {
+      logger.warn('oauth_token_grant_narrowed', { requested, granted });
+    }
+    return granted;
+  };
+
   // Try to silently mint a fresh access token from the stored refresh token.
   // Resolves to the new access token, or `undefined` if there's nothing to
   // refresh / the refresh failed. On failure the on-demand path drops the dead
@@ -144,7 +157,7 @@ export const createTokenStore = (
         // Same rule as the refresh token above: an omitted `scope` means the
         // grant is unchanged, not unknown. `||`, not `??`: an empty string is
         // "not reported" too, and must not be recorded as a grant of nothing.
-        scope: result.scope || current.scope,
+        scope: noteGrant(result.scope || current.scope),
       };
       // Freshly refreshed: if expiry is still unknown, don't re-probe every call.
       probedUnknownExpiry = true;
@@ -185,7 +198,7 @@ export const createTokenStore = (
               accessToken: result.access_token,
               refreshToken: result.refresh_token,
               expiresAt: expiryFrom(result.expires_in),
-              scope: result.scope || requested,
+              scope: noteGrant(result.scope || requested),
             };
             // Freshly minted: trust it without an immediate probe-refresh.
             probedUnknownExpiry = true;

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -63,7 +63,28 @@ export const createTokenStore = (
   // Seed the in-memory cache from disk so a restart (notably the Cowork-on-Windows
   // process churn) reuses the existing token instead of re-prompting.
   let token: StoredToken | undefined = loadToken(tokenPath);
-  if (token) logger.debug('oauth_token_loaded_from_disk');
+  if (token && !grantCovers(token.scope, requested)) {
+    // The disk record was minted for a narrower surface (typically: this server
+    // dropped `--read-only` since). A refresh cannot widen a grant, so the only
+    // way out is a fresh authorization -- which the empty cache below triggers
+    // on the first tool call.
+    //
+    // Checked here and nowhere else, on purpose. A freshly minted token is the
+    // best this client can obtain: refusing it would open a browser window on
+    // every single tool call, forever, where the pre-#283 behaviour merely got
+    // a 403 on writes. A refreshed one cannot have widened either, and dropping
+    // it would rotate Zendesk's single-use refresh token for nothing. Both are
+    // served, and the next start re-decides from the record on disk.
+    //
+    // The drop is memory-only, never `clearPersistedToken`: one token file
+    // serves every process on this subdomain, so a record this server refuses
+    // may be exactly right for a read-only sibling -- and a successful sign-in
+    // overwrites the file regardless.
+    logger.warn('oauth_token_scope_insufficient', { requested, granted: token.scope });
+    token = undefined;
+  } else if (token) {
+    logger.debug('oauth_token_loaded_from_disk');
+  }
 
   // The authorize URL of the in-flight flow (set once the callback server is
   // listening); `undefined` means no flow is currently pending.
@@ -82,7 +103,10 @@ export const createTokenStore = (
   const persist = (t: StoredToken): void => saveToken(tokenPath, t, logger);
 
   const setToken = (accessToken: string, refreshToken?: string | undefined) => {
-    token = { accessToken, refreshToken };
+    // Recorded like any other installation path: an absent scope means "the
+    // read write grant this server used to be the only one to request", which
+    // is not what a token installed under `--read-only` holds.
+    token = { accessToken, refreshToken, scope: requested };
     // A token installed this way has no known expiry and unknown age, like the
     // disk-loaded one: let it be probe-refreshed once rather than inheriting a
     // previous token's "already probed" state (the flag is store-wide).
@@ -99,26 +123,6 @@ export const createTokenStore = (
     typeof t.expiresAt === 'number'
       ? Date.now() >= t.expiresAt - EXPIRY_SKEW_MS
       : t.refreshToken !== undefined && !probedUnknownExpiry;
-
-  // Whether the cached token may be served, dropping it from memory when its
-  // grant falls short of what this process needs.
-  //
-  // Deliberately NOT folded into `needsRefresh`: a refresh cannot widen a grant
-  // (and our refresh request sends no scope at all), so routing a shortfall
-  // through the refresh path would mint an equally narrow token, serve it, and
-  // burn Zendesk's single-use refresh token again on the next call. The only
-  // way out of a shortfall is a fresh authorization.
-  //
-  // The drop is memory-only, never `clearPersistedToken`: one token file serves
-  // every process on this subdomain, so a record this server refuses may be
-  // exactly right for a read-only sibling -- and a successful sign-in overwrites
-  // the file regardless.
-  const mayServeCachedGrant = (): boolean => {
-    if (!token || grantCovers(token.scope, requested)) return true;
-    logger.warn('oauth_token_scope_insufficient', { requested, granted: token.scope });
-    token = undefined;
-    return false;
-  };
 
   // Try to silently mint a fresh access token from the stored refresh token.
   // Resolves to the new access token, or `undefined` if there's nothing to
@@ -148,8 +152,9 @@ export const createTokenStore = (
         refreshToken: result.refresh_token ?? current.refreshToken,
         expiresAt: expiryFrom(result.expires_in),
         // Same rule as the refresh token above: an omitted `scope` means the
-        // grant is unchanged, not unknown.
-        scope: result.scope ?? current.scope,
+        // grant is unchanged, not unknown. `||`, not `??`: an empty string is
+        // "not reported" too, and must not be recorded as a grant of nothing.
+        scope: result.scope || current.scope,
       };
       // Freshly refreshed: if expiry is still unknown, don't re-probe every call.
       probedUnknownExpiry = true;
@@ -190,7 +195,7 @@ export const createTokenStore = (
               accessToken: result.access_token,
               refreshToken: result.refresh_token,
               expiresAt: expiryFrom(result.expires_in),
-              scope: result.scope ?? requested,
+              scope: result.scope || requested,
             };
             // Freshly minted: trust it without an immediate probe-refresh.
             probedUnknownExpiry = true;
@@ -244,10 +249,6 @@ export const createTokenStore = (
     // resolved value were being tested.
     if (refreshing !== undefined) await refreshing;
 
-    // Before the cache-hit gate: a token whose grant is too narrow is never
-    // served, however fresh it is.
-    mayServeCachedGrant();
-
     if (token && !needsRefresh(token)) {
       logger.debug('oauth_token_cache_hit');
       return token.accessToken;
@@ -256,9 +257,7 @@ export const createTokenStore = (
     // Expired, near-expiry, or unknown-expiry but refreshable → refresh silently
     // before falling back to a browser prompt.
     const refreshed = await refreshIfPossible();
-    // Checked again: a refresh response may declare a narrower grant than the
-    // record it replaced, and that token must not be handed out either.
-    if (refreshed && mayServeCachedGrant()) return refreshed;
+    if (refreshed) return refreshed;
 
     if (starting === undefined) {
       starting = beginAuth();

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,5 +1,6 @@
 import { type Logger, silentLogger } from '../utils/logger';
 import { refreshAccessToken, startBrowserAuth } from './browser-oauth';
+import { grantCovers, requestedScope } from './oauth-scopes';
 import {
   clearToken as clearPersistedToken,
   loadToken,
@@ -48,10 +49,17 @@ const expiryFrom = (expiresIn: number | undefined): number | undefined =>
   typeof expiresIn === 'number' ? Date.now() + expiresIn * 1000 : undefined;
 
 export const createTokenStore = (
-  config: { subdomain: string; oauthClientId: string; callbackPort?: number | undefined },
+  config: {
+    subdomain: string;
+    oauthClientId: string;
+    callbackPort?: number | undefined;
+    readOnly: boolean;
+  },
   logger: Logger = silentLogger,
 ) => {
   const tokenPath = resolveTokenPath(config.subdomain);
+  // Fixed for the life of the process: the tool surface cannot change under us.
+  const requested = requestedScope(config.readOnly);
   // Seed the in-memory cache from disk so a restart (notably the Cowork-on-Windows
   // process churn) reuses the existing token instead of re-prompting.
   let token: StoredToken | undefined = loadToken(tokenPath);
@@ -92,6 +100,26 @@ export const createTokenStore = (
       ? Date.now() >= t.expiresAt - EXPIRY_SKEW_MS
       : t.refreshToken !== undefined && !probedUnknownExpiry;
 
+  // Whether the cached token may be served, dropping it from memory when its
+  // grant falls short of what this process needs.
+  //
+  // Deliberately NOT folded into `needsRefresh`: a refresh cannot widen a grant
+  // (and our refresh request sends no scope at all), so routing a shortfall
+  // through the refresh path would mint an equally narrow token, serve it, and
+  // burn Zendesk's single-use refresh token again on the next call. The only
+  // way out of a shortfall is a fresh authorization.
+  //
+  // The drop is memory-only, never `clearPersistedToken`: one token file serves
+  // every process on this subdomain, so a record this server refuses may be
+  // exactly right for a read-only sibling -- and a successful sign-in overwrites
+  // the file regardless.
+  const mayServeCachedGrant = (): boolean => {
+    if (!token || grantCovers(token.scope, requested)) return true;
+    logger.warn('oauth_token_scope_insufficient', { requested, granted: token.scope });
+    token = undefined;
+    return false;
+  };
+
   // Try to silently mint a fresh access token from the stored refresh token.
   // Resolves to the new access token, or `undefined` if there's nothing to
   // refresh / the refresh failed. On failure the on-demand path drops the dead
@@ -119,6 +147,9 @@ export const createTokenStore = (
         accessToken: result.access_token,
         refreshToken: result.refresh_token ?? current.refreshToken,
         expiresAt: expiryFrom(result.expires_in),
+        // Same rule as the refresh token above: an omitted `scope` means the
+        // grant is unchanged, not unknown.
+        scope: result.scope ?? current.scope,
       };
       // Freshly refreshed: if expiry is still unknown, don't re-probe every call.
       probedUnknownExpiry = true;
@@ -147,6 +178,7 @@ export const createTokenStore = (
         subdomain: config.subdomain,
         oauthClientId: config.oauthClientId,
         callbackPort: config.callbackPort,
+        readOnly: config.readOnly,
       },
       logger,
     )
@@ -158,6 +190,7 @@ export const createTokenStore = (
               accessToken: result.access_token,
               refreshToken: result.refresh_token,
               expiresAt: expiryFrom(result.expires_in),
+              scope: result.scope ?? requested,
             };
             // Freshly minted: trust it without an immediate probe-refresh.
             probedUnknownExpiry = true;
@@ -211,6 +244,10 @@ export const createTokenStore = (
     // resolved value were being tested.
     if (refreshing !== undefined) await refreshing;
 
+    // Before the cache-hit gate: a token whose grant is too narrow is never
+    // served, however fresh it is.
+    mayServeCachedGrant();
+
     if (token && !needsRefresh(token)) {
       logger.debug('oauth_token_cache_hit');
       return token.accessToken;
@@ -219,7 +256,9 @@ export const createTokenStore = (
     // Expired, near-expiry, or unknown-expiry but refreshable → refresh silently
     // before falling back to a browser prompt.
     const refreshed = await refreshIfPossible();
-    if (refreshed) return refreshed;
+    // Checked again: a refresh response may declare a narrower grant than the
+    // record it replaced, and that token must not be handed out either.
+    if (refreshed && mayServeCachedGrant()) return refreshed;
 
     if (starting === undefined) {
       starting = beginAuth();
@@ -240,7 +279,12 @@ export const createTokenStore = (
   // when there's no refresh token do we wipe the record entirely.
   const invalidate = (): void => {
     if (token?.refreshToken) {
-      token = { accessToken: token.accessToken, refreshToken: token.refreshToken, expiresAt: 0 };
+      token = {
+        accessToken: token.accessToken,
+        refreshToken: token.refreshToken,
+        expiresAt: 0,
+        scope: token.scope,
+      };
       persist(token);
     } else {
       token = undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ const buildStdioTokenStore = (config: Config, logger: Logger) =>
       subdomain: config.subdomain,
       oauthClientId: config.oauthClientId,
       callbackPort: config.callbackPort,
+      readOnly: config.readOnly,
     },
     logger,
   );

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { supportedScopes } from '../auth/oauth-scopes';
 import type { Config } from '../config';
 import { getOAuthUrls } from '../constants';
 import { createMcpServer } from '../server';
@@ -188,12 +189,15 @@ export const buildOAuthMetadata = (
   const { authorizeUrl, tokenUrl } = getOAuthUrls(config.subdomain);
   const issuer = `https://${config.subdomain}.zendesk.com`;
   const resource = resolveResourceUrl(config, logger);
+  // One value for both documents, derived from what the stdio flow requests, so
+  // a client reading either one is told the same thing.
+  const scopes = supportedScopes(config.readOnly);
   return {
     protectedResource: {
       authorization_servers: [issuer],
       resource,
       bearer_methods_supported: ['header'],
-      scopes_supported: ['read', 'write'],
+      scopes_supported: scopes,
     },
     authorizationServer: {
       issuer,
@@ -203,7 +207,7 @@ export const buildOAuthMetadata = (
       grant_types_supported: ['authorization_code', 'refresh_token'],
       code_challenge_methods_supported: ['S256'],
       token_endpoint_auth_methods_supported: ['none'],
-      scopes_supported: ['read', 'write'],
+      scopes_supported: scopes,
     },
   };
 };

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -189,10 +189,6 @@ export const buildOAuthMetadata = (
   const { authorizeUrl, tokenUrl } = getOAuthUrls(config.subdomain);
   const issuer = `https://${config.subdomain}.zendesk.com`;
   const resource = resolveResourceUrl(config, logger);
-  // Derived from what the stdio flow requests, so a client reading either
-  // document is told the same thing. Built twice rather than shared: the two
-  // documents are separately owned, and a future scope that belongs to only
-  // one of them must not leak into the other through a shared array.
   const scopes = () => supportedScopes(config.readOnly);
   return {
     protectedResource: {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -189,15 +189,17 @@ export const buildOAuthMetadata = (
   const { authorizeUrl, tokenUrl } = getOAuthUrls(config.subdomain);
   const issuer = `https://${config.subdomain}.zendesk.com`;
   const resource = resolveResourceUrl(config, logger);
-  // One value for both documents, derived from what the stdio flow requests, so
-  // a client reading either one is told the same thing.
-  const scopes = supportedScopes(config.readOnly);
+  // Derived from what the stdio flow requests, so a client reading either
+  // document is told the same thing. Built twice rather than shared: the two
+  // documents are separately owned, and a future scope that belongs to only
+  // one of them must not leak into the other through a shared array.
+  const scopes = () => supportedScopes(config.readOnly);
   return {
     protectedResource: {
       authorization_servers: [issuer],
       resource,
       bearer_methods_supported: ['header'],
-      scopes_supported: scopes,
+      scopes_supported: scopes(),
     },
     authorizationServer: {
       issuer,
@@ -207,7 +209,7 @@ export const buildOAuthMetadata = (
       grant_types_supported: ['authorization_code', 'refresh_token'],
       code_challenge_methods_supported: ['S256'],
       token_endpoint_auth_methods_supported: ['none'],
-      scopes_supported: scopes,
+      scopes_supported: scopes(),
     },
   };
 };

--- a/tests/unit/auth/browser-oauth.test.ts
+++ b/tests/unit/auth/browser-oauth.test.ts
@@ -115,6 +115,7 @@ describe('authenticateViaBrowser', () => {
     const result = await authenticateViaBrowser({
       subdomain: SUB,
       oauthClientId: CLIENT_ID,
+      readOnly: false,
       callbackPort: 0,
     });
 
@@ -152,7 +153,12 @@ describe('authenticateViaBrowser', () => {
       return {};
     });
 
-    await authenticateViaBrowser({ subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 });
+    await authenticateViaBrowser({
+      subdomain: SUB,
+      oauthClientId: CLIENT_ID,
+      callbackPort: 0,
+      readOnly: false,
+    });
 
     const body = await bodyPromise;
     expect(body).toContain('Authentication successful!');
@@ -178,7 +184,12 @@ describe('authenticateViaBrowser', () => {
     });
 
     await expect(
-      authenticateViaBrowser({ subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 }),
+      authenticateViaBrowser({
+        subdomain: SUB,
+        oauthClientId: CLIENT_ID,
+        callbackPort: 0,
+        readOnly: false,
+      }),
     ).rejects.toThrow(/OAuth error/);
 
     const body = await bodyPromise;
@@ -213,7 +224,12 @@ describe('authenticateViaBrowser', () => {
     });
 
     await expect(
-      authenticateViaBrowser({ subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 }),
+      authenticateViaBrowser({
+        subdomain: SUB,
+        oauthClientId: CLIENT_ID,
+        callbackPort: 0,
+        readOnly: false,
+      }),
     ).rejects.toThrow(/Token exchange failed/);
 
     const body = await bodyPromise;
@@ -247,7 +263,7 @@ describe('authenticateViaBrowser', () => {
     });
 
     const result = await authenticateViaBrowser(
-      { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 },
+      { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0, readOnly: false },
       logger,
     );
 
@@ -268,6 +284,35 @@ describe('startBrowserAuth', () => {
     callbackServers.length = 0;
   });
 
+  // The requested scope follows the tool surface: a read-only server asking for
+  // `write` would request an authority it cannot exercise, and an OAuth client
+  // whose allowed scopes stop at `read` rejects such a request outright (#283).
+  it('requests the read scope only in read-only mode', async () => {
+    openMock.mockResolvedValue({});
+
+    const started = await startBrowserAuth({
+      subdomain: SUB,
+      oauthClientId: CLIENT_ID,
+      callbackPort: 0,
+      readOnly: true,
+    });
+
+    expect(new URL(started.authorizeUrl).searchParams.get('scope')).toBe('read');
+  });
+
+  it('requests read and write when write tools are exposed', async () => {
+    openMock.mockResolvedValue({});
+
+    const started = await startBrowserAuth({
+      subdomain: SUB,
+      oauthClientId: CLIENT_ID,
+      callbackPort: 0,
+      readOnly: false,
+    });
+
+    expect(new URL(started.authorizeUrl).searchParams.get('scope')).toBe('read write');
+  });
+
   it('stops the callback server and cancels the timeout once the flow completes', async () => {
     mswServer.use(oauthTokenHandler);
     const logger = makeLogger();
@@ -284,7 +329,7 @@ describe('startBrowserAuth', () => {
       });
 
       const started = await startBrowserAuth(
-        { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 },
+        { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0, readOnly: false },
         logger,
       );
       await started.tokenPromise;
@@ -311,6 +356,7 @@ describe('startBrowserAuth', () => {
     const started = await startBrowserAuth({
       subdomain: SUB,
       oauthClientId: CLIENT_ID,
+      readOnly: false,
       callbackPort: 0,
     });
     const redirectUri = new URL(started.authorizeUrl).searchParams.get('redirect_uri') ?? '';
@@ -338,7 +384,7 @@ describe('startBrowserAuth', () => {
       openMock.mockResolvedValue({});
 
       const started = await startBrowserAuth(
-        { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 },
+        { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0, readOnly: false },
         logger,
       );
       const server = lastCallbackServer();
@@ -401,7 +447,7 @@ describe('startBrowserAuth', () => {
         attachServer: vi.fn(),
       };
       const started = await startBrowserAuth(
-        { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0 },
+        { subdomain: SUB, oauthClientId: CLIENT_ID, callbackPort: 0, readOnly: false },
         logger,
       );
       const rejection = expect(started.tokenPromise).rejects.toThrow('timed out');

--- a/tests/unit/auth/oauth-scopes.test.ts
+++ b/tests/unit/auth/oauth-scopes.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { grantCovers, requestedScope, supportedScopes } from '../../../src/auth/oauth-scopes';
+
+describe('requestedScope', () => {
+  it('asks for read only in read-only mode', () => {
+    expect(requestedScope(true)).toBe('read');
+  });
+
+  it('asks for read and write otherwise', () => {
+    expect(requestedScope(false)).toBe('read write');
+  });
+});
+
+describe('supportedScopes', () => {
+  // Derived from requestedScope, so the OAuth discovery metadata cannot drift
+  // from what the authorize request actually asks for.
+  it('advertises read only in read-only mode', () => {
+    expect(supportedScopes(true)).toEqual(['read']);
+  });
+
+  it('advertises read and write otherwise', () => {
+    expect(supportedScopes(false)).toEqual(['read', 'write']);
+  });
+});
+
+describe('grantCovers', () => {
+  it.each([
+    // A record written before the server tracked grants: the only scope it ever
+    // requested was `read write`, so an absent scope IS that grant.
+    { granted: undefined, requested: 'read', covered: true, why: 'legacy record covers read' },
+    {
+      granted: undefined,
+      requested: 'read write',
+      covered: true,
+      why: 'legacy record covers read write',
+    },
+    // The one case that forces a re-authentication: OAuth cannot widen a grant.
+    { granted: 'read', requested: 'read write', covered: false, why: 'read cannot cover write' },
+    { granted: 'read write', requested: 'read', covered: true, why: 'a broader grant is fine' },
+    { granted: 'read write', requested: 'read write', covered: true, why: 'exact match' },
+    { granted: 'read', requested: 'read', covered: true, why: 'exact match, narrow' },
+    { granted: 'write read', requested: 'read write', covered: true, why: 'order is irrelevant' },
+    { granted: 'read  write', requested: 'read write', covered: true, why: 'extra whitespace' },
+    { granted: '', requested: 'read', covered: false, why: 'an empty grant covers nothing' },
+  ])('$why', ({ granted, requested, covered }) => {
+    expect(grantCovers(granted, requested)).toBe(covered);
+  });
+
+  it('treats a hand-edited non-string scope like an untracked grant', () => {
+    // loadToken casts the on-disk JSON without validating this field, so a
+    // hand-written `"scope": null` must not throw inside the token store.
+    expect(grantCovers(null as unknown as string, 'read write')).toBe(true);
+  });
+});

--- a/tests/unit/auth/oauth-scopes.test.ts
+++ b/tests/unit/auth/oauth-scopes.test.ts
@@ -42,6 +42,9 @@ describe('grantCovers', () => {
     { granted: 'write read', requested: 'read write', covered: true, why: 'order is irrelevant' },
     { granted: 'read  write', requested: 'read write', covered: true, why: 'extra whitespace' },
     { granted: '', requested: 'read', covered: false, why: 'an empty grant covers nothing' },
+    // Padding must not become a token of its own: an unfiltered split would
+    // look for an empty scope the grant cannot contain.
+    { granted: 'read write', requested: ' read ', covered: true, why: 'padded request' },
   ])('$why', ({ granted, requested, covered }) => {
     expect(grantCovers(granted, requested)).toBe(covered);
   });

--- a/tests/unit/auth/token-persistence.test.ts
+++ b/tests/unit/auth/token-persistence.test.ts
@@ -101,9 +101,14 @@ describe('token-persistence', () => {
     const path = '/cfg/acme.json';
     const { saveToken, loadToken } = await importFresh();
 
-    saveToken(path, { accessToken: 'a', refreshToken: 'r', expiresAt: 123 });
+    saveToken(path, { accessToken: 'a', refreshToken: 'r', expiresAt: 123, scope: 'read' });
 
-    expect(loadToken(path)).toEqual({ accessToken: 'a', refreshToken: 'r', expiresAt: 123 });
+    expect(loadToken(path)).toEqual({
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: 123,
+      scope: 'read',
+    });
     // Written to a temp file (chmod 0600) then renamed onto the final path.
     expect(chmodCalls.some((c) => c.path.endsWith('.tmp') && c.mode === 0o600)).toBe(true);
   });

--- a/tests/unit/auth/token-store.test.ts
+++ b/tests/unit/auth/token-store.test.ts
@@ -335,6 +335,38 @@ describe('createTokenStore', () => {
     expect(startBrowserAuthMock).toHaveBeenCalledTimes(1);
   });
 
+  it('warns when a minted grant falls short of what was requested', async () => {
+    const { started, resolveToken } = deferredStarted();
+    startBrowserAuthMock.mockResolvedValue(started);
+    const logger = makeLogger();
+    const store = createTokenStore(CONFIG, logger);
+
+    await expect(store.getToken()).rejects.toThrow('authentication required');
+    resolveToken({ access_token: 'narrow', refresh_token: 'r1', scope: 'read' });
+    await flush();
+
+    // Served anyway -- the warning is the only thing standing between the
+    // operator and unexplained 403s on every write.
+    expect(logger.warn).toHaveBeenCalledWith('oauth_token_grant_narrowed', {
+      requested: 'read write',
+      granted: 'read',
+    });
+    await expect(store.getToken()).resolves.toBe('narrow');
+  });
+
+  it('stays quiet when the granted scope covers the request', async () => {
+    const { started, resolveToken } = deferredStarted();
+    startBrowserAuthMock.mockResolvedValue(started);
+    const logger = makeLogger();
+    const store = createTokenStore(RO_CONFIG, logger);
+
+    await expect(store.getToken()).rejects.toThrow('authentication required');
+    resolveToken({ access_token: 'wide', refresh_token: 'r1', scope: 'read write' });
+    await flush();
+
+    expect(logger.warn).not.toHaveBeenCalledWith('oauth_token_grant_narrowed', expect.anything());
+  });
+
   it('serves a refreshed token rather than rotating for a grant that cannot widen', async () => {
     loadTokenMock.mockReturnValue({
       accessToken: 'old',

--- a/tests/unit/auth/token-store.test.ts
+++ b/tests/unit/auth/token-store.test.ts
@@ -183,10 +183,15 @@ describe('createTokenStore', () => {
 
   it('reuses a token loaded from disk without starting a browser flow', async () => {
     loadTokenMock.mockReturnValue({ accessToken: 'disk-token' });
-    const store = createTokenStore(CONFIG);
+    const logger = makeLogger();
+    const store = createTokenStore(CONFIG, logger);
 
     await expect(store.getToken()).resolves.toBe('disk-token');
     expect(startBrowserAuthMock).not.toHaveBeenCalled();
+    // The counterpart of oauth_token_scope_insufficient: a record that was
+    // accepted has to be visible in the logs too, or a start that skipped
+    // sign-in is indistinguishable from one that had no record at all.
+    expect(logger.debug).toHaveBeenCalledWith('oauth_token_loaded_from_disk');
   });
 
   it('forwards the configured callback port to the browser flow', async () => {

--- a/tests/unit/auth/token-store.test.ts
+++ b/tests/unit/auth/token-store.test.ts
@@ -69,6 +69,14 @@ const deferredStarted = () => {
   return { started: { authorizeUrl: AUTH_URL, tokenPromise }, resolveToken, rejectToken };
 };
 
+const makeLogger = () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  attachServer: vi.fn(),
+});
+
 // Flush the microtask + immediate queue so the store's token-promise handlers run.
 const flush = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -216,10 +224,17 @@ describe('createTokenStore', () => {
       expiresAt: FUTURE(),
     });
     startBrowserAuthMock.mockResolvedValue(deferredStarted().started);
-    const store = createTokenStore(CONFIG);
+    const logger = makeLogger();
+    const store = createTokenStore(CONFIG, logger);
 
     await expect(store.getToken()).rejects.toThrow('authentication required');
     expect(startBrowserAuthMock).toHaveBeenCalledTimes(1);
+    // Why the sign-in happened has to be visible in the logs, or a narrowed
+    // OAuth client looks like a random re-prompt.
+    expect(logger.warn).toHaveBeenCalledWith('oauth_token_scope_insufficient', {
+      requested: 'read write',
+      granted: 'read',
+    });
     // Refreshing would mint an equally narrow token and burn the single-use
     // refresh token on every call.
     expect(refreshAccessTokenMock).not.toHaveBeenCalled();

--- a/tests/unit/auth/token-store.test.ts
+++ b/tests/unit/auth/token-store.test.ts
@@ -4,11 +4,13 @@ interface TokenResult {
   access_token: string;
   refresh_token?: string;
   expires_in?: number;
+  // The granted scope, which a refresh response may omit (RFC 6749 5.1).
+  scope?: string;
 }
 
 const startBrowserAuthMock =
   vi.fn<
-    (config: { subdomain: string; oauthClientId: string }) => Promise<{
+    (config: { subdomain: string; oauthClientId: string; readOnly: boolean }) => Promise<{
       authorizeUrl: string;
       tokenPromise: Promise<TokenResult>;
     }>
@@ -24,7 +26,7 @@ const refreshAccessTokenMock =
   >();
 
 vi.mock('../../../src/auth/browser-oauth', () => ({
-  startBrowserAuth: (config: { subdomain: string; oauthClientId: string }) =>
+  startBrowserAuth: (config: { subdomain: string; oauthClientId: string; readOnly: boolean }) =>
     startBrowserAuthMock(config),
   refreshAccessToken: (config: {
     subdomain: string;
@@ -49,7 +51,11 @@ vi.mock('../../../src/auth/token-persistence', () => ({
 // Imported after vi.mock so the mocked deps are bound.
 const { createTokenStore, isAuthRequiredError } = await import('../../../src/auth/token-store');
 
-const CONFIG = { subdomain: 'testsubdomain', oauthClientId: 'test_client' };
+const CONFIG = { subdomain: 'testsubdomain', oauthClientId: 'test_client', readOnly: false };
+// Same tenant, read-only surface: the store must then ask for the `read` scope
+// and accept a broader token it finds on disk.
+const RO_CONFIG = { ...CONFIG, readOnly: true };
+const FUTURE = () => Date.now() + 60 * 60 * 1000;
 const AUTH_URL = 'https://testsubdomain.zendesk.com/oauth/authorizations/new?client_id=test_client';
 
 // A started-auth result whose token promise the test controls.
@@ -182,6 +188,147 @@ describe('createTokenStore', () => {
     await store.getToken().catch(() => {});
     expect(startBrowserAuthMock).toHaveBeenCalledWith(
       expect.objectContaining({ callbackPort: 51000 }),
+    );
+  });
+
+  it('forwards the read-only lever to the browser flow', async () => {
+    startBrowserAuthMock.mockResolvedValue(deferredStarted().started);
+
+    await createTokenStore(RO_CONFIG)
+      .getToken()
+      .catch(() => {});
+    expect(startBrowserAuthMock).toHaveBeenCalledWith(expect.objectContaining({ readOnly: true }));
+
+    startBrowserAuthMock.mockClear();
+    await createTokenStore(CONFIG)
+      .getToken()
+      .catch(() => {});
+    expect(startBrowserAuthMock).toHaveBeenCalledWith(expect.objectContaining({ readOnly: false }));
+  });
+
+  it('re-authenticates when the cached grant does not cover the requested scope', async () => {
+    // A `read` token cannot be widened: OAuth forbids a refresh from granting
+    // more than it was given, so the only way out is a new authorization.
+    loadTokenMock.mockReturnValue({
+      accessToken: 'ro',
+      refreshToken: 'r1',
+      scope: 'read',
+      expiresAt: FUTURE(),
+    });
+    startBrowserAuthMock.mockResolvedValue(deferredStarted().started);
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).rejects.toThrow('authentication required');
+    expect(startBrowserAuthMock).toHaveBeenCalledTimes(1);
+    // Refreshing would mint an equally narrow token and burn the single-use
+    // refresh token on every call.
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled();
+    // The record may still be exactly right for a read-only sibling process, and
+    // a successful sign-in overwrites the file anyway.
+    expect(clearTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps a broader cached token when running read-only', async () => {
+    loadTokenMock.mockReturnValue({
+      accessToken: 'rw',
+      refreshToken: 'r1',
+      scope: 'read write',
+      expiresAt: FUTURE(),
+    });
+    const store = createTokenStore(RO_CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('rw');
+    expect(startBrowserAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('treats a record with no scope as the read write grant it was minted under', async () => {
+    loadTokenMock.mockReturnValue({ accessToken: 'legacy', expiresAt: FUTURE() });
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('legacy');
+    expect(startBrowserAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('records the granted scope reported by the browser flow', async () => {
+    const { started, resolveToken } = deferredStarted();
+    startBrowserAuthMock.mockResolvedValue(started);
+    const store = createTokenStore(RO_CONFIG);
+
+    await expect(store.getToken()).rejects.toThrow('authentication required');
+    resolveToken({ access_token: 'fresh', refresh_token: 'r1', scope: 'read' });
+    await flush();
+
+    expect(saveTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ accessToken: 'fresh', scope: 'read' }),
+      expect.anything(),
+    );
+  });
+
+  it('falls back to the requested scope when the flow reports none', async () => {
+    const { started, resolveToken } = deferredStarted();
+    startBrowserAuthMock.mockResolvedValue(started);
+    const store = createTokenStore(RO_CONFIG);
+
+    await expect(store.getToken()).rejects.toThrow('authentication required');
+    resolveToken({ access_token: 'fresh', refresh_token: 'r1' });
+    await flush();
+
+    expect(saveTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ scope: 'read' }),
+      expect.anything(),
+    );
+  });
+
+  it('keeps the previous grant when the refresh response omits the scope', async () => {
+    loadTokenMock.mockReturnValue({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      scope: 'read',
+      expiresAt: Date.now() - 1000,
+    });
+    refreshAccessTokenMock.mockResolvedValue({ access_token: 'new', refresh_token: 'r2' });
+    const store = createTokenStore(RO_CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('new');
+    expect(saveTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ accessToken: 'new', scope: 'read' }),
+      expect.anything(),
+    );
+  });
+
+  it('re-authenticates when a refresh comes back with a narrower grant', async () => {
+    loadTokenMock.mockReturnValue({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      scope: 'read write',
+      expiresAt: Date.now() - 1000,
+    });
+    refreshAccessTokenMock.mockResolvedValue({ access_token: 'narrowed', scope: 'read' });
+    startBrowserAuthMock.mockResolvedValue(deferredStarted().started);
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).rejects.toThrow('authentication required');
+    expect(startBrowserAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the recorded grant when invalidating an access token', async () => {
+    loadTokenMock.mockReturnValue({
+      accessToken: 'rw',
+      refreshToken: 'r1',
+      scope: 'read write',
+      expiresAt: FUTURE(),
+    });
+    const store = createTokenStore(CONFIG);
+
+    store.invalidate();
+
+    expect(saveTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ scope: 'read write', expiresAt: 0 }),
+      expect.anything(),
     );
   });
 

--- a/tests/unit/auth/token-store.test.ts
+++ b/tests/unit/auth/token-store.test.ts
@@ -314,7 +314,23 @@ describe('createTokenStore', () => {
     );
   });
 
-  it('re-authenticates when a refresh comes back with a narrower grant', async () => {
+  it('serves a freshly minted token even when Zendesk granted less than asked', async () => {
+    // The alternative is a browser window on every single tool call: a new
+    // authorization would grant exactly the same narrow scope. Writes then fail
+    // with 403 from Zendesk, which is the pre-#283 behaviour.
+    const { started, resolveToken } = deferredStarted();
+    startBrowserAuthMock.mockResolvedValue(started);
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).rejects.toThrow('authentication required');
+    resolveToken({ access_token: 'narrow', refresh_token: 'r1', scope: 'read' });
+    await flush();
+
+    await expect(store.getToken()).resolves.toBe('narrow');
+    expect(startBrowserAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a refreshed token rather than rotating for a grant that cannot widen', async () => {
     loadTokenMock.mockReturnValue({
       accessToken: 'old',
       refreshToken: 'r1',
@@ -325,8 +341,37 @@ describe('createTokenStore', () => {
     startBrowserAuthMock.mockResolvedValue(deferredStarted().started);
     const store = createTokenStore(CONFIG);
 
-    await expect(store.getToken()).rejects.toThrow('authentication required');
-    expect(startBrowserAuthMock).toHaveBeenCalledTimes(1);
+    await expect(store.getToken()).resolves.toBe('narrowed');
+    expect(startBrowserAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('records an empty reported scope as unchanged rather than as a grant of nothing', async () => {
+    loadTokenMock.mockReturnValue({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      scope: 'read write',
+      expiresAt: Date.now() - 1000,
+    });
+    refreshAccessTokenMock.mockResolvedValue({ access_token: 'new', scope: '' });
+    const store = createTokenStore(CONFIG);
+
+    await expect(store.getToken()).resolves.toBe('new');
+    expect(saveTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ scope: 'read write' }),
+      expect.anything(),
+    );
+  });
+
+  it('records the requested scope for a token installed through setToken', async () => {
+    const store = createTokenStore(RO_CONFIG);
+    store.setToken('preset');
+
+    expect(saveTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ accessToken: 'preset', scope: 'read' }),
+      expect.anything(),
+    );
   });
 
   it('preserves the recorded grant when invalidating an access token', async () => {

--- a/tests/unit/transports/http.test.ts
+++ b/tests/unit/transports/http.test.ts
@@ -137,6 +137,20 @@ describe('buildOAuthMetadata', () => {
     expect(meta.authorizationServer.code_challenge_methods_supported).toEqual(['S256']);
     expect(meta.authorizationServer.token_endpoint_auth_methods_supported).toEqual(['none']);
   });
+
+  // Both documents are built separately, so both are asserted: a client that
+  // reads only one of them must not be told a different story.
+  it('advertises read and write by default', () => {
+    const meta = buildOAuthMetadata(baseConfig);
+    expect(meta.protectedResource.scopes_supported).toEqual(['read', 'write']);
+    expect(meta.authorizationServer.scopes_supported).toEqual(['read', 'write']);
+  });
+
+  it('advertises the read scope only under --read-only', () => {
+    const meta = buildOAuthMetadata({ ...baseConfig, readOnly: true });
+    expect(meta.protectedResource.scopes_supported).toEqual(['read']);
+    expect(meta.authorizationServer.scopes_supported).toEqual(['read']);
+  });
 });
 
 describe('startHttpTransport (HTTP roundtrip)', () => {
@@ -157,6 +171,13 @@ describe('startHttpTransport (HTTP roundtrip)', () => {
     };
     expect(body.authorization_servers).toContain('https://testsubdomain.zendesk.com');
     expect(body.resource).toBe('https://mcp.example.com');
+  });
+
+  it('serves the narrowed scopes_supported of a read-only server', async () => {
+    handle = await startHttpTransport({ ...baseConfig, readOnly: true });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/.well-known/oauth-protected-resource`);
+    const body = (await res.json()) as { scopes_supported: string[] };
+    expect(body.scopes_supported).toEqual(['read']);
   });
 
   it('serves /.well-known/oauth-authorization-server (RFC 8414) with PKCE S256', async () => {


### PR DESCRIPTION
## Summary

`--read-only` narrowed the tool surface but never the token: the authorize URL hardcoded `scope: 'read write'`, so an operator who refuses to hand an agent a write-capable credential had no way in — and a Zendesk OAuth client whose allowed scopes stop at `read` rejects that request with `invalid_scope`, minting no token at all. One lever, no new flag: `--read-only` now requests `read`, everything else still requests `read write`, and the HTTP discovery metadata is derived from the same resolver. The token store records the granted scope and, at startup, refuses a cached record whose grant no longer covers what the process needs.

## Linked issue

Closes #283

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no external behavior change)
- [ ] Documentation
- [ ] Tooling / CI

## Author checklist
- [x] I checked no open or merged PR already addresses the linked issue, and the issue is not already closed as completed / `released`
- [x] If this PR resolves an issue, its description above links it with a closing keyword (`Closes #<n>`) so it auto-closes on merge to `main`
- [x] `pnpm test` passes locally
- [x] `pnpm test:coverage` meets the thresholds
- [x] `pnpm check` is clean (lint + format)
- [x] `pnpm typecheck` passes
- [x] I have read the diff myself, line by line
- [x] I ran a Claude Code review on the diff and addressed its findings
- [x] Documentation is updated where needed
- [ ] If this PR adds an MCP tool: it is documented in `docs/mcp-tools-reference.md` — n/a, no tool change
- [x] If the change has **MCP-runtime-observable** behaviour: this PR carries a `## Functional validation plan` below

`pnpm test:mutation:diff origin/main HEAD` reports 39/39 mutants killed in the changed lines.

## Notes for the reviewer (human or AI)

Three design choices worth a look:

- **The lever travels as a boolean, resolved to a scope string once**, in the new `src/auth/oauth-scopes.ts`. Putting the ternary in `src/index.ts` would have parked the only interesting branch in the one file excluded from both coverage and mutation; a `scope: string` seam would have widened the contract past the agreed lever, and Zendesk mints a token for an unrecognised scope string and only 403s at use time. The field is **required** on both config types because the "forgot to thread it" default would otherwise be requesting `write`.
- **The grant is checked at the disk seed and nowhere else.** The first version of this branch checked in `getToken`, on every read, including on a freshly minted token — a re-authentication loop: when Zendesk grants less than was asked for, a new authorization returns the same narrow scope, so every tool call would have opened another browser window, forever, where the behaviour before this branch was merely a 403 on writes. Checking a refreshed token was no better: a refresh cannot widen a grant either, so the rotation spends Zendesk's single-use refresh token for nothing and leaves the shared record narrower than it found it. The disk seed is the one moment a grant can actually be stale (the server dropped `--read-only` since), so that is where it is decided; the rest of `getToken` is untouched.
- **Coverage, not equality, and the drop is memory-only.** One token file serves every process on a subdomain: with coverage, a write-mode server re-authenticates once and upgrades the shared record, after which a read-only sibling accepts it — an equality check would make the two re-authenticate in turn forever. Clearing the file would destroy a record that may still be right for that sibling, and a successful sign-in overwrites it anyway.

Consequence stated plainly in the docs, because #283 asks a security question: a `--read-only` server that finds a read+write token on disk **will use it**. The flag narrows what is *requested*; it is not "this process can never hold a write token". A record with no `scope` counts as `read write` — not a guess, that is the only scope any released version ever requested, and treating it as unknown would push every existing user through a sign-in on upgrade for nothing.

Granular per-resource scopes (`tickets:read`) are deliberately out: they need a tool→scope map to keep the surface coherent, and `get_ticket_history` already 403s under `tickets:read` because Ticket Audits requires the global `read`. Tracked in #284.

Known limit, not addressed here: an `invalid_scope` rejection at the authorize endpoint still reaches the agent as the generic "authentication required" text, with the cause only in a `warn` log. `docs/troubleshooting.md` now names the symptom and the fix; carrying the authorize error into the error text is a separate change.

## Functional validation plan

### Context

The change is in the **authorization flow and the discovery metadata**, both of which run *before* any tool call. A server that is already running and authenticated cannot exercise them through `mcp__zendesk__*` calls — so unlike most plans here, scenarios V3-V7 need short-lived local processes. Each one is read-only, points `ZENDESK_TOKEN_FILE` at a throwaway path, and never touches the real token cache.

What the running server *does* validate is the most important regression: V1.

Not touched by this change, do not test: tool behaviour, HC resources, prompts, retry policy.

### Setup & prerequisites

- Report the commit you tested: `git rev-parse HEAD` (expected `2cc5232` or later).
- Substitute your tenant for `<sub>` below, and run from the repo root.
- `pnpm build` output is needed by V3-V6 (`dist/index.js`); if `dist/` is stale, `pnpm build` first.
- **Never paste token material into the report.** V2 asks only for JSON *keys* and the value of `scope`.

### Scenarios

| id | Validates | Manipulation | Expected observable |
| --- | --- | --- | --- |
| **V1** | A cached token written by an earlier version still serves; nobody is re-prompted on upgrade | none — use the running, authenticated server | `mcp__zendesk__get_current_user` returns your user. No `Zendesk authentication required` error, no browser prompt |
| **V2** | The record shape on disk | `jq 'keys, .scope' "${ZENDESK_TOKEN_FILE:-$HOME/.config/fruggr/zendesk-mcp-server/<sub>.json}"` | Either no `scope` key (legacy record — consistent with V1), or `scope` present with the value `"read write"`. Report the key list and the scope value only |
| **V3** | `--read-only` asks Zendesk for `read` alone (the #283 ask) | `printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"p","version":"0"}}}' '{"jsonrpc":"2.0","method":"notifications/initialized"}' '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_current_user","arguments":{}}}' \| ZENDESK_TOKEN_FILE=/tmp/probe-ro.json timeout 30 node dist/index.js <sub> --read-only --mode all 2>&1 \| grep -o 'scope=[^&]*'` | `scope=read` — and nothing else. (The browser cannot open in a headless session; that is expected and irrelevant, the URL is printed either way) |
| **V4** | The default is unchanged | same command without `--read-only`, `ZENDESK_TOKEN_FILE=/tmp/probe-rw.json` | `scope=read+write` (the `+` is URL encoding of the space) |
| **V5** | A stale cached grant forces a fresh authorization at startup, and says why | `echo '{"accessToken":"fake","refreshToken":"fake","scope":"read","expiresAt":99999999999999}' > /tmp/probe-narrow.json`, then the V4 command with `ZENDESK_TOKEN_FILE=/tmp/probe-narrow.json` and `LOG_LEVEL=warn`, reading the whole stderr rather than grepping | The tool call fails with `Zendesk authentication required`; stderr carries `oauth_token_scope_insufficient` with `requested: read write` / `granted: read`; the authorize URL asks for `scope=read+write`. The fake token is never sent to Zendesk |
| **V6** | A grant that *does* cover is served, even a narrow one | same file as V5, but run **with** `--read-only` | Different failure: `Authentication failed. Your Zendesk token may be expired or invalid` (a real 401 from Zendesk, proving the token was served rather than refused), and **no** `oauth_token_scope_insufficient`, **no** authorize URL |
| **V7** | HTTP discovery metadata follows the same lever | `node dist/index.js <sub> --transport http --port 3999 --read-only &` then `curl -s localhost:3999/.well-known/oauth-protected-resource` and `.../oauth-authorization-server`; repeat on port 4000 without `--read-only`; kill both | Read-only server: `"scopes_supported":["read"]` in **both** documents. Default server: `["read","write"]` in both. No auth needed, these endpoints are public |

### Long-running behaviours

None added. The 5-minute authorize timeout and the 4-hour keepalive are untouched and already covered by fake-timer unit tests in `tests/unit/auth/`. Do not wait anything out; V5's `expiresAt` is far in the future by design so no refresh path is entered.

### Priorities

1. **V1** — the upgrade-regression risk that affects every existing user.
2. **V3 / V4** — the actual subject of #283.
3. **V5 / V6** — the cached-grant semantics, the subtlest part of the change.
4. **V7** — HTTP metadata.
5. **V2** — informational.

### Reporting instructions

Post one PR comment: the SHA you tested, then one line per id with `OK` / `FAIL` / `BLOCKED` and the observed evidence (the grep output, the log line, the JSON fragment — no token material). Close with a green/failing summary. A credential or egress failure is `BLOCKED`, not something to work around.

https://claude.ai/code/session_013rZoaABLQpymNKjiU5P7YS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only mode requests and advertises only the `read` OAuth scope.
  * Standard mode continues to request and advertise `read` and `write`.
  * OAuth token grants are tracked to prevent incompatible cached tokens from being used.

* **Bug Fixes**
  * Improved handling of missing or incomplete OAuth scope responses.
  * Read-only access correctly blocks write operations.

* **Documentation**
  * Added setup, deployment, configuration, and troubleshooting guidance for OAuth scopes and reauthentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->